### PR TITLE
Refactor init templates into separate files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,5 +14,5 @@
   "rules": {
     "sort-imports": ["error", { "ignoreDeclarationSort": true }]
   },
-  "ignorePatterns": ["node_modules", "dist"]
+  "ignorePatterns": ["node_modules", "dist", "src/cli/init/templates/data.json"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ pepr
 dist/
 *.js
 *.js.amp
+# Permit this single file to be checked in
+!hack/*.js
 node_modules/
 stats.html
 .vscode

--- a/hack/build-template-data.js
+++ b/hack/build-template-data.js
@@ -1,0 +1,23 @@
+// This is a helper script to collect the contents of the template files before building the CLI
+
+/* eslint-disable */
+const fs = require("fs");
+const path = require("path");
+
+const baseDir = path.join(__dirname, "..", "src", "cli", "init", "templates");
+
+// Read the text file
+const gitignore = fs.readFileSync(path.join(baseDir, "gitignore"), "utf8");
+const readme = fs.readFileSync(path.join(baseDir, "README.md"), "utf8");
+const peprTS = fs.readFileSync(path.join(baseDir, "pepr.ts"), "utf8");
+const helloPeprTS = fs.readFileSync(path.join(baseDir, "hello-pepr.ts"), "utf8");
+
+fs.writeFileSync(
+  path.join(baseDir, "data.json"),
+  JSON.stringify({
+    gitignore,
+    readme,
+    peprTS,
+    helloPeprTS,
+  })
+);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     }
   },
   "scripts": {
-    "build": "rm -fr dist/* && tsc -p tsconfig.build.json",
+    "prebuild": "rm -fr dist/* && node src/cli/init/templates/collect.js",
+    "build": "tsc -p tsconfig.build.json",
     "test": "npm run build && ava && node dist/cli.js -V",
     "lint": "npx eslint src",
     "lint:fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "scripts": {
-    "prebuild": "rm -fr dist/* && node src/cli/init/templates/collect.js",
+    "prebuild": "rm -fr dist/* && node hack/build-template-data.js",
     "build": "tsc -p tsconfig.build.json",
     "test": "npm run build && ava && node dist/cli.js -V",
     "lint": "npx eslint src",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,12 +4,10 @@
 import { version } from "../../package.json";
 import { banner } from "./banner";
 import build from "./build";
-import capability from "./capability";
 import deploy from "./deploy";
 import dev from "./dev";
 import init from "./init";
 import { RootCmd } from "./root";
-import test from "./test";
 
 const program = new RootCmd();
 
@@ -29,7 +27,7 @@ deploy(program);
 dev(program);
 
 // @todo: finish/re-evaluate these commands
-test(program);
-capability(program);
+// test(program);
+// capability(program);
 
 program.parse();

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -4,30 +4,14 @@
 import { dumpYaml } from "@kubernetes/client-node";
 import { inspect } from "util";
 import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
-import { dependencies, version } from "../../../package.json";
+import { dependencies, scripts, version } from "../../../package.json";
+import generatedJSON from "./templates/data.json";
+import peprSnippetsJSON from "./templates/pepr.code-snippets.json";
+import prettierRCJSON from "./templates/prettierrc.json";
+import samplesJSON from "./templates/samples.json";
+import tsConfigJSON from "./templates/tsconfig.json";
 import { sanitizeName } from "./utils";
 import { InitOptions } from "./walkthrough";
-
-export function genPeprTS() {
-  return {
-    path: "pepr.ts",
-    data: `import { PeprModule } from "pepr";
-import cfg from "./package.json";
-import { HelloPepr } from "./capabilities/hello-pepr";
-
-/**
- * This is the main entrypoint for the Pepr module. It is the file that is run when the module is started.
- * This is where you register your configurations and capabilities with the module.
- */
-new PeprModule(cfg, [
-  // "HelloPepr" is a demo capability that is included with Pepr. You can remove it if you want.
-  HelloPepr,
-
-  // Your additional capabilities go here
-]);
-`,
-  };
-}
 
 export function genPkgJSON(opts: InitOptions) {
   // Generate a random UUID for the module based on the module name
@@ -53,6 +37,7 @@ export function genPkgJSON(opts: InitOptions) {
       },
     },
     scripts: {
+      "k3d-setup": scripts["e2e-dev-setup"],
       build: "pepr build",
       start: "pepr dev",
     },
@@ -71,225 +56,44 @@ export function genPkgJSON(opts: InitOptions) {
   };
 }
 
-export const tsConfig = {
-  path: "tsconfig.json",
-  data: {
-    compilerOptions: {
-      esModuleInterop: true,
-      lib: ["ES2020"],
-      moduleResolution: "node",
-      resolveJsonModule: true,
-      rootDir: ".",
-      strict: false,
-      target: "ES2020",
-    },
-    include: ["**/*.ts"],
-  },
-};
-
-export const gitIgnore = {
-  path: ".gitignore",
-  data: `# Ignore node_modules and Pepr build artifacts
-node_modules
-dist
-insecure*
-`,
-};
-
-export const prettierRC = {
-  path: ".prettierrc",
-  data: {
-    arrowParens: "avoid",
-    bracketSameLine: false,
-    bracketSpacing: true,
-    embeddedLanguageFormatting: "auto",
-    insertPragma: false,
-    printWidth: 80,
-    quoteProps: "as-needed",
-    requirePragma: false,
-    semi: true,
-    tabWidth: 2,
-    useTabs: false,
-  },
-};
+export function genPeprTS() {
+  return {
+    path: "pepr.ts",
+    data: generatedJSON.peprTS,
+  };
+}
 
 export const readme = {
   path: "README.md",
-  data: `# Pepr Module
-
-This is a Pepr module. It is a module that can be used with the [Pepr]() framework.
-
-The \`capabilities\` directory contains all the capabilities for this module. By default, 
-a capability is a single typescript file in the format of \`capability-name.ts\` that is 
-imported in the root \`pepr.ts\` file as \`import { HelloPepr } from "./capabilities/hello-pepr";\`. 
-Because this is typescript, you can organize this however you choose, e.g. creating a sub-folder 
-per-capability or common logic in shared files or folders.
-
-Example Structure:
-
-\`\`\`
-Module Root
-├── package.json
-├── pepr.ts
-└── capabilities
-    ├── example-one.ts
-    ├── example-three.ts
-    └── example-two.ts
-\`\`\`
-`,
-};
-
-export const samplesYaml = {
-  path: "hello-pepr.samples.yaml",
-  data: [
-    {
-      apiVersion: "v1",
-      kind: "Namespace",
-      metadata: {
-        name: "pepr-demo",
-      },
-    },
-    {
-      apiVersion: "v1",
-      kind: "ConfigMap",
-      metadata: {
-        name: "example-1",
-        namespace: "pepr-demo",
-      },
-      data: {
-        key: "ex-1-val",
-      },
-    },
-    {
-      apiVersion: "v1",
-      kind: "ConfigMap",
-      metadata: {
-        name: "example-2",
-        namespace: "pepr-demo",
-      },
-      data: {
-        key: "ex-2-val",
-      },
-    },
-    {
-      apiVersion: "v1",
-      kind: "ConfigMap",
-      metadata: {
-        name: "example-3",
-        namespace: "pepr-demo",
-        labels: {
-          change: "by-label",
-        },
-      },
-      data: {
-        key: "ex-3-val",
-      },
-    },
-  ]
-    .map(r => dumpYaml(r, { noRefs: true }))
-    .join("---\n"),
+  data: generatedJSON.readme,
 };
 
 export const helloPeprTS = {
   path: "hello-pepr.ts",
-  data: `import { Capability, a } from "pepr";
+  data: generatedJSON.helloPeprTS,
+};
 
-/**
- *  The HelloPepr is an example capability to demonstrate some general concepts of Pepr.
- *  To test this capability you can run \`pepr dev\` and then run the following command:
- *  \`kubectl apply -f capabilities/hello-pepr.samples.yaml\`
- */ 
-export const HelloPepr = new Capability({
-  name: "hello-pepr",
-  description: "A simple example capability to show how things work.",
-  namespaces: ["pepr-demo"],
-});
+export const gitIgnore = {
+  path: ".gitignore",
+  data: generatedJSON.gitignore,
+};
 
-// Use the 'When' function to create a new Capability Action
-const { When } = HelloPepr;
-  
-/**
- * This is a single Capability Action. They can be in the same file or put imported from other files.
- * In this exmaple, when a ConfigMap is created with the name \`example-1\`, then add a label and annotation.
- *
- * Equivelant to manually running:
- * \`kubectl label configmap example-1 pepr=was-here\`
- * \`kubectl annotate configmap example-1 pepr.dev=annotations-work-too\`
- */
-When(a.ConfigMap)
-  .IsCreated()
-  .WithName("example-1")
-  .Then(request =>
-    request
-      .SetLabel("pepr", "was-here")
-      .SetAnnotation("pepr.dev", "annotations-work-too")
-  );
-
-/**
- * This Capabiility Action does the exact same changes for example-2, except this time it uses the \`.ThenSet()\` feature.
- * You can stack multiple \`.Then()\` calls, but only a single \`.ThenSet()\`
- */
-When(a.ConfigMap)
-  .IsCreated()
-  .WithName("example-2")
-  .ThenSet({
-    metadata: {
-      labels: {
-        pepr: "was-here",
-      },
-      annotations: {
-        "pepr.dev": "annotations-work-too",
-      },
-    },
-  });
-
-/**
- * This Capability Action combines different styles. Unlike the previous actions, this one will look for any ConfigMap
- * in the \`pepr-demo\` namespace that has the label \`change=by-label\` during either CREATE or UPDATE. Note that all 
- * conditions added such as \`WithName()\`, \`WithLabel()\`, \`InNamespace()\`, are ANDs so all conditions must be true 
- * for the request to be procssed.
- */
-When(a.ConfigMap)
-  .IsCreatedOrUpdated()
-  .WithLabel("change", "by-label")
-  .Then(request => {
-    // The K8s object e are going to mutate
-    const cm = request.Raw;
-
-    // Get the username and uid of the K8s reuest
-    const { username, uid } = request.Request.userInfo;
-
-    // Store some data about the request in the configmap
-    cm.data["username"] = username;
-    cm.data["uid"] = uid;
-
-    // You can still mix other ways of making changes too
-    request.SetAnnotation("pepr.dev", "making-waves");
-  });    
-`,
+export const samplesYaml = {
+  path: "hello-pepr.samples.yaml",
+  data: samplesJSON.map(r => dumpYaml(r, { noRefs: true })).join("---\n"),
 };
 
 export const snippet = {
   path: "pepr.code-snippets",
-  data: `{
-  "Create a new Pepr capability": {
-    "prefix": "create pepr capability",
-    "body": [
-      "import { Capability, a } from 'pepr';",
-      "",
-      "export const $\{TM_FILENAME_BASE/(.*)/$\{1:/pascalcase}/} = new Capability({",
-      "\\tname: '$\{TM_FILENAME_BASE}',",
-      "\\tdescription: '$\{1:A brief description of this capability.}',",
-      "\\tnamespaces: [$\{2:}],",
-      "});",
-      "",
-      "// Use the 'When' function to create a new Capability Action",
-      "const { When } = $\{TM_FILENAME_BASE/(.*)/$\{1:/pascalcase}/};",
-      "",
-      "// When(a.<Kind>).Is<Event>().Then(change => change.<changes>",
-      "When($\{3:})"
-    ],
-    "description": "Creates a new Pepr capability with a specified description, and optional namespaces, and adds a When statement for the specified value."
-  }
-}`,
+  data: peprSnippetsJSON,
+};
+
+export const tsConfig = {
+  path: "tsconfig.json",
+  data: tsConfigJSON,
+};
+
+export const prettierRC = {
+  path: ".prettierrc",
+  data: prettierRCJSON,
 };

--- a/src/cli/init/templates/.gitignore
+++ b/src/cli/init/templates/.gitignore
@@ -1,0 +1,1 @@
+data.json

--- a/src/cli/init/templates/README.md
+++ b/src/cli/init/templates/README.md
@@ -1,0 +1,22 @@
+# Pepr Module
+
+This is a Pepr Module. [Pepr](https://github.com/defenseunicorns/pepr) is a Kubernetes tranformation system
+written in Typescript.
+
+The `capabilities` directory contains all the capabilities for this module. By default, 
+a capability is a single typescript file in the format of `capability-name.ts` that is 
+imported in the root `pepr.ts` file as `import { HelloPepr } from "./capabilities/hello-pepr";`. 
+Because this is typescript, you can organize this however you choose, e.g. creating a sub-folder 
+per-capability or common logic in shared files or folders.
+
+Example Structure:
+
+```
+Module Root
+├── package.json
+├── pepr.ts
+└── capabilities
+    ├── example-one.ts
+    ├── example-three.ts
+    └── example-two.ts
+```

--- a/src/cli/init/templates/README.md
+++ b/src/cli/init/templates/README.md
@@ -3,10 +3,10 @@
 This is a Pepr Module. [Pepr](https://github.com/defenseunicorns/pepr) is a Kubernetes tranformation system
 written in Typescript.
 
-The `capabilities` directory contains all the capabilities for this module. By default, 
-a capability is a single typescript file in the format of `capability-name.ts` that is 
-imported in the root `pepr.ts` file as `import { HelloPepr } from "./capabilities/hello-pepr";`. 
-Because this is typescript, you can organize this however you choose, e.g. creating a sub-folder 
+The `capabilities` directory contains all the capabilities for this module. By default,
+a capability is a single typescript file in the format of `capability-name.ts` that is
+imported in the root `pepr.ts` file as `import { HelloPepr } from "./capabilities/hello-pepr";`.
+Because this is typescript, you can organize this however you choose, e.g. creating a sub-folder
 per-capability or common logic in shared files or folders.
 
 Example Structure:

--- a/src/cli/init/templates/gitignore
+++ b/src/cli/init/templates/gitignore
@@ -1,0 +1,4 @@
+# Ignore node_modules and Pepr build artifacts
+node_modules
+dist
+insecure*

--- a/src/cli/init/templates/hello-pepr.ts
+++ b/src/cli/init/templates/hello-pepr.ts
@@ -1,0 +1,72 @@
+import { Capability, a } from "pepr";
+
+/**
+ *  The HelloPepr Capability is an example capability to demonstrate some general concepts of Pepr.
+ *  To test this capability you can run `pepr dev` or `npm start` and then run the following command:
+ *  `kubectl apply -f capabilities/hello-pepr.samples.yaml`
+ */
+export const HelloPepr = new Capability({
+  name: "hello-pepr",
+  description: "A simple example capability to show how things work.",
+  namespaces: ["pepr-demo"],
+});
+
+// Use the 'When' function to create a new Capability Action
+const { When } = HelloPepr;
+
+/**
+ * This is a single Capability Action. They can be in the same file or imported from other files.
+ * In this exmaple, when a ConfigMap is created with the name `example-1`, we add a label and annotation.
+ *
+ * Equivelant to manually running:
+ * `kubectl label configmap example-1 pepr=was-here`
+ * `kubectl annotate configmap example-1 pepr.dev=annotations-work-too`
+ */
+When(a.ConfigMap)
+  .IsCreated()
+  .WithName("example-1")
+  .Then(request => {
+    request.SetLabel("pepr", "was-here").SetAnnotation("pepr.dev", "annotations-work-too");
+  });
+
+/**
+ * This Capabiility Action does the exact same changes for example-2, except this time it uses the `.ThenSet()` feature.
+ * You can stack multiple `.Then()` calls, but only a single `.ThenSet()`
+ */
+When(a.ConfigMap)
+  .IsCreated()
+  .WithName("example-2")
+  .ThenSet({
+    metadata: {
+      labels: {
+        pepr: "was-here",
+      },
+      annotations: {
+        "pepr.dev": "annotations-work-too",
+      },
+    },
+  });
+
+/**
+ * This Capability Action combines different styles. Unlike the previous actions, this one will look for any ConfigMap
+ * in the `pepr-demo` namespace that has the label `change=by-label` during either CREATE or UPDATE. Note that all
+ * conditions added such as `WithName()`, `WithLabel()`, `InNamespace()`, are ANDs so all conditions must be true
+ * for the request to be procssed.
+ */
+When(a.ConfigMap)
+  .IsCreatedOrUpdated()
+  .WithLabel("change", "by-label")
+  .Then(request => {
+    // The K8s object e are going to mutate
+    const cm = request.Raw;
+
+    // Get the username and uid of the K8s reuest
+    const { username, uid } = request.Request.userInfo;
+
+    // Store some data about the request in the configmap
+    cm.data["username"] = username;
+    cm.data["uid"] = uid;
+
+    // You can still mix other ways of making changes too
+    request.SetAnnotation("pepr.dev", "making-waves");
+  });

--- a/src/cli/init/templates/pepr.code-snippets.json
+++ b/src/cli/init/templates/pepr.code-snippets.json
@@ -1,0 +1,21 @@
+{
+  "Create a new Pepr capability": {
+    "prefix": "create pepr capability",
+    "body": [
+      "import { Capability, a } from 'pepr';",
+      "",
+      "export const ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/} = new Capability({",
+      "\tname: '${TM_FILENAME_BASE}',",
+      "\tdescription: '${1:A brief description of this capability.}',",
+      "\tnamespaces: [${2:}],",
+      "});",
+      "",
+      "// Use the 'When' function to create a new Capability Action",
+      "const { When } = ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/};",
+      "",
+      "// When(a.<Kind>).Is<Event>().Then(change => change.<changes>",
+      "When(${3:})"
+    ],
+    "description": "Creates a new Pepr capability with a specified description, and optional namespaces, and adds a When statement for the specified value."
+  }
+}

--- a/src/cli/init/templates/pepr.ts
+++ b/src/cli/init/templates/pepr.ts
@@ -1,0 +1,14 @@
+import { PeprModule } from "pepr";
+import { HelloPepr } from "./capabilities/hello-pepr";
+import cfg from "./package.json";
+
+/**
+ * This is the main entrypoint for the Pepr module. It is the file that is run when the module is started.
+ * This is where you register your configurations and capabilities with the module.
+ */
+new PeprModule(cfg, [
+  // "HelloPepr" is a demo capability that is included with Pepr. You can remove it if you want.
+  HelloPepr,
+
+  // Your additional capabilities go here
+]);

--- a/src/cli/init/templates/prettierrc.json
+++ b/src/cli/init/templates/prettierrc.json
@@ -1,0 +1,13 @@
+{
+  "arrowParens": "avoid",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "insertPragma": false,
+  "printWidth": 80,
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/src/cli/init/templates/samples.json
+++ b/src/cli/init/templates/samples.json
@@ -1,0 +1,45 @@
+[
+  {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+      "name": "pepr-demo"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "example-1",
+      "namespace": "pepr-demo"
+    },
+    "data": {
+      "key": "ex-1-val"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "example-2",
+      "namespace": "pepr-demo"
+    },
+    "data": {
+      "key": "ex-2-val"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "example-3",
+      "namespace": "pepr-demo",
+      "labels": {
+        "change": "by-label"
+      }
+    },
+    "data": {
+      "key": "ex-3-val"
+    }
+  }
+]

--- a/src/cli/init/templates/tsconfig.json
+++ b/src/cli/init/templates/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
-    "declaration": true,
     "esModuleInterop": true,
     "lib": ["ES2020"],
-    "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "./dist",
     "resolveJsonModule": true,
+    "rootDir": ".",
     "strict": false,
     "target": "ES2020"
   },
-  "exclude": ["node_modules", "dist", "src/cli/init/templates"]
+  "include": ["**/*.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
-    "extends": "./tsconfig.json",
-    "exclude": ["node_modules", "dist", "fixtures", "**/*.test.ts"]
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "fixtures", "**/*.test.ts", "src/cli/init/templates"]
 }


### PR DESCRIPTION
Rather than ugly string templates, this allows us to be more sane about the init template and will make future reuse in the CLI cleaner.

FIxes #18