### PR TITLE
Add GenericKind and RegisterKind() 

### DIFF
--- a/hack/build-template-data.js
+++ b/hack/build-template-data.js
@@ -10,7 +10,7 @@ const baseDir = path.join(__dirname, "..", "src", "cli", "init", "templates");
 const gitignore = fs.readFileSync(path.join(baseDir, "gitignore"), "utf8");
 const readme = fs.readFileSync(path.join(baseDir, "README.md"), "utf8");
 const peprTS = fs.readFileSync(path.join(baseDir, "pepr.ts"), "utf8");
-const helloPeprTS = fs.readFileSync(path.join(baseDir, "hello-pepr.ts"), "utf8");
+const helloPeprTS = fs.readFileSync(path.join(baseDir, "capabilities", "hello-pepr.ts"), "utf8");
 
 fs.writeFileSync(
   path.join(baseDir, "data.json"),

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import k8s from "@kubernetes/client-node";
 import utils from "ramda";
 import { Capability } from "./src/lib/capability";
 import { fetch, fetchRaw } from "./src/lib/fetch";
-import { a } from "./src/lib/k8s";
+import { RegisterKind, a } from "./src/lib/k8s";
 import Log from "./src/lib/logger";
 import { PeprModule } from "./src/lib/module";
 import { PeprRequest } from "./src/lib/request";
@@ -16,6 +16,7 @@ export {
   /** PeprModule is used to setup a complete Pepr Module: `new PeprModule(cfg, {...capabilities})` */
   PeprModule,
   PeprRequest,
+  RegisterKind,
   Capability,
   Log,
   utils,

--- a/src/cli/init/templates/package.json
+++ b/src/cli/init/templates/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pepr-dev-module",
+  "description": "static test package.json for local pepr core development",
+  "pepr": {
+    "name": "Development Module",
+    "uuid": "20e17cf6-a2e4-46b2-b626-75d88d96c88b",
+    "description": "Development module for pepr",
+    "version": "dev",
+    "onError": "ignore",
+    "alwaysIgnore": {
+      "namespaces": [],
+      "labels": []
+    }
+  }
+}

--- a/src/cli/init/templates/samples.json
+++ b/src/cli/init/templates/samples.json
@@ -67,5 +67,46 @@
       "name": "example-5",
       "namespace": "pepr-demo"
     }
+  },
+  {
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+      "name": "unicorns.pepr.dev"
+    },
+    "spec": {
+      "group": "pepr.dev",
+      "versions": [
+        {
+          "name": "v1",
+          "served": true,
+          "storage": true,
+          "schema": {
+            "openAPIV3Schema": {
+              "type": "object",
+              "properties": {
+                "spec": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "counter": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "scope": "Namespaced",
+      "names": {
+        "plural": "unicorns",
+        "singular": "unicorn",
+        "kind": "Unicorn"
+      }
+    }
   }
 ]

--- a/src/cli/init/templates/tsconfig.json
+++ b/src/cli/init/templates/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.module.json",
+  "compilerOptions": {
+    "paths": {
+      "pepr": ["../../../../index"]
+    },
+    "rootDir": "../../../../"
+  }
+}

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { modelToGroupVersionKind } from "./k8s";
+import { GroupVersionKind, modelToGroupVersionKind } from "./k8s";
 import logger from "./logger";
 import {
   BindToAction,
@@ -63,13 +63,21 @@ export class Capability implements CapabilityCfg {
    * processed by Pepr. The action will be executed if the resource matches the specified kind and any
    * filters that are applied.
    *
-   * @param model if using a custom KubernetesObject not available in `a.*`, specify the GroupVersionKind
+   * @param model the KubernetesObject model to match
+   * @param kind if using a custom KubernetesObject not available in `a.*`, specify the GroupVersionKind
    * @returns
    */
-  When = <T extends GenericClass>(model: T): WhenSelector<T> => {
+  When = <T extends GenericClass>(model: T, kind?: GroupVersionKind): WhenSelector<T> => {
+    const matchedKind = modelToGroupVersionKind(model.name);
+
+    // If the kind is not specified and the model is not a KubernetesObject, throw an error
+    if (!matchedKind && !kind) {
+      throw new Error(`Kind not specified for ${model.name}`);
+    }
+
     const binding: Binding = {
-      // If the kind is not specified, use the default KubernetesObject
-      kind: modelToGroupVersionKind(model.name),
+      // If the kind is not specified, use the matched kind from the model
+      kind: kind || matchedKind,
       filters: {
         name: "",
         namespaces: [],

--- a/src/lib/k8s/index.ts
+++ b/src/lib/k8s/index.ts
@@ -6,6 +6,6 @@ import * as kind from "./upstream";
 /** a is a colleciton of K8s types to be used within a CapabilityAction: `When(a.Configmap)` */
 export { kind as a };
 
-export { modelToGroupVersionKind, gvkMap } from "./kinds";
+export { modelToGroupVersionKind, gvkMap, RegisterKind } from "./kinds";
 
 export * from "./types";

--- a/src/lib/k8s/kinds.ts
+++ b/src/lib/k8s/kinds.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
+import { GenericClass } from "../types";
 import { GroupVersionKind } from "./types";
 
 export const gvkMap: Record<string, GroupVersionKind> = {
@@ -468,3 +469,21 @@ export const gvkMap: Record<string, GroupVersionKind> = {
 export function modelToGroupVersionKind(key: string): GroupVersionKind {
   return gvkMap[key];
 }
+
+/**
+ * Registers a new model and GroupVersionKind with Pepr for use with `When(a.<Kind>)`
+ *
+ * @param model Used to match the GroupVersionKind and define the type-data for the request
+ * @param groupVersionKind Contains the match paramaters to determine the request should be handled
+ */
+export const RegisterKind = (model: GenericClass, groupVersionKind: GroupVersionKind) => {
+  const name = model.name;
+
+  // Do not allow overwriting existing GVKs
+  if (gvkMap[name]) {
+    throw new Error(`GVK ${name} already registered`);
+  }
+
+  // Set the GVK
+  gvkMap[name] = groupVersionKind;
+};

--- a/src/lib/k8s/types.ts
+++ b/src/lib/k8s/types.ts
@@ -23,6 +23,19 @@ export interface KubernetesListObject<T extends KubernetesObject> {
 }
 
 /**
+ * GenericKind is a generic Kubernetes object that can be used to represent any Kubernetes object
+ * that is not explicitly supported by Pepr. This can be used on its own or as a base class for
+ * other types. See the examples in `HelloPepr.ts` for more information.
+ */
+export class GenericKind {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+/**
  *  GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion
  * to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
  **/

--- a/src/lib/k8s/upstream.ts
+++ b/src/lib/k8s/upstream.ts
@@ -45,3 +45,5 @@ export {
   V1ValidatingWebhookConfiguration as ValidatingWebhookConfiguration,
   V1VolumeAttachment as VolumeAttachment,
 } from "@kubernetes/client-node/dist";
+
+export { GenericKind } from "./types";


### PR DESCRIPTION
Adds support and examples for binding CapabilityActions to K8s GroupVersionKinds not currently in Pepr core.