### PR TITLE
Change default `pepr dev` host to `host.k3d.internal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ pepr init
 npm run k3d-setup
 
 # Start playing with Pepr now
+# If using another local K8s distro instead of k3d, run `pepr dev --host host.docker.internal`
 pepr dev
 kubectl apply -f capabilities/hello-pepr.samples.yaml
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,7 @@ Initialize a new Pepr Module.
 - `--skip-post-init` - Skip npm install, git init and VSCode launch
 
 ---
+
 ## `pepr update`
 
 Update the current Pepr Module to the latest SDK version and update the global Pepr CLI to the same version.
@@ -23,12 +24,15 @@ Update the current Pepr Module to the latest SDK version and update the global P
 
 ## `pepr dev`
 
-Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module.
+Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module. Note
+the `pepr dev` assumes a K3d cluster is running by default. If you are working with Kind or another docker-based
+K8s distro, you will need to pass the `--host host.docker.internal` option to `pepr dev`. If working with a remote
+cluster you will have to give Pepr a host path to your machine that is reachable from the K8s cluster.
 
 **Options:**
 
 - `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
-- `-h, --host [host]` - Host to listen on (default: "host.docker.internal")
+- `-h, --host [host]` - Host to listen on (default: "host.k3d.internal")
 - `--confirm` - Skip confirmation prompt
 
 ---

--- a/docs/module.md
+++ b/docs/module.md
@@ -23,6 +23,7 @@ Each Pepr Module is it's own Typescript project, produced by [`pepr init`](./cli
    npm run k3d-setup
 
    # Launch pepr dev mode (npm start or pepr dev)
+   # If using another local K8s distro instead of k3d, use `pepr dev --host host.docker.internal`
    pepr dev
 
    # From another terminal, apply the sample yaml

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -15,7 +15,7 @@ export default function (program: RootCmd) {
   program
     .command("dev")
     .description("Setup a local webhook development environment")
-    .option("-h, --host [host]", "Host to listen on", "host.docker.internal")
+    .option("-h, --host [host]", "Host to listen on", "host.k3d.internal")
     .option("--confirm", "Skip confirmation prompt")
     .action(async opts => {
       // Prompt the user to confirm if they didn't pass the --confirm flag


### PR DESCRIPTION
Due to limitations on some host operating systems, this PR changes the default `pepr dev` host from `host.docker.internal` => `host.k3d.internal`. This change will ensure the provided K3d setup script does not break on affected systems while also adding an additional flag requirement for users of KinD or other local K8s distros.  Docs were updated to reflect this change as well.