### PR TITLE
Breaking Change: Automatic base64 encoding/decoding for secrets

### DIFF
--- a/hack/e2e.test.mjs
+++ b/hack/e2e.test.mjs
@@ -111,8 +111,9 @@ test.serial("E2E: `pepr deploy`", async t => {
     const cm4 = await waitForConfigMap("pepr-demo", "example-4");
     const cm4a = await waitForConfigMap("pepr-demo-2", "example-4a");
     const cm5 = await waitForConfigMap("pepr-demo", "example-5");
+    const s1 = await waitForSecret("pepr-demo", "secret-1");
 
-    t.log("ConfigMaps created");
+    t.log("ConfigMaps and secret created");
 
     // Validate the example-1 CM
     t.is(cm1.metadata.annotations["static-test.pepr.dev/hello-pepr"], "succeeded");
@@ -150,6 +151,12 @@ test.serial("E2E: `pepr deploy`", async t => {
     t.is(cm5.metadata.annotations["static-test.pepr.dev/hello-pepr"], "succeeded");
     t.truthy(cm5.data["chuck-says"]);
     t.log("Validated example-5 ConfigMap data");
+
+    // Validate the secret-1 Secret
+    t.is(s1.metadata.annotations["static-test.pepr.dev/hello-pepr"], "succeeded");
+    t.is(s1.data["example"], "dW5pY29ybiBtYWdpYyAtIG1vZGlmaWVkIGJ5IFBlcHI=");
+    t.is(s1.data["magic"], "Y2hhbmdlLXdpdGhvdXQtZW5jb2Rpbmc=");
+    t.log("Validated secret-1 Secret data");
 
     // Remove the sample yaml for the HelloPepr capability
     execSync("kubectl delete -f hello-pepr.samples.yaml", {
@@ -244,6 +251,16 @@ async function waitForConfigMap(namespace, name) {
   } catch (error) {
     await delay2Secs();
     return waitForConfigMap(namespace, name);
+  }
+}
+
+async function waitForSecret(namespace, name) {
+  try {
+    const resp = await k8sCoreApi.readNamespacedSecret(name, namespace);
+    return resp.body;
+  } catch (error) {
+    await delay2Secs();
+    return waitForSecret(namespace, name);
   }
 }
 

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -48,7 +48,8 @@ export default function (program: RootCmd) {
       await fs.writeFile("insecure-tls.key", webhook.tls.pem.key);
 
       try {
-        await webhook.deploy();
+        // Deploy the webhook with a 30 second timeout for debugging
+        await webhook.deploy(undefined, 30);
         Log.info(`Module deployed successfully`);
 
         let program: ChildProcess;

--- a/src/cli/init/templates/capabilities/hello-pepr.samples.json
+++ b/src/cli/init/templates/capabilities/hello-pepr.samples.json
@@ -19,6 +19,17 @@
   },
   {
     "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+      "name": "secret-1",
+      "namespace": "pepr-demo"
+    },
+    "data": {
+      "example": "dW5pY29ybiBtYWdpYw=="
+    }
+  },
+  {
+    "apiVersion": "v1",
     "kind": "ConfigMap",
     "metadata": {
       "name": "example-1",

--- a/src/cli/init/templates/capabilities/hello-pepr.ts
+++ b/src/cli/init/templates/capabilities/hello-pepr.ts
@@ -213,6 +213,28 @@ When(a.ConfigMap)
 
 /**
  * ---------------------------------------------------------------------------------------------------
+ *                                   CAPABILITY ACTION (Secret Base64 Handling)                      *
+ * ---------------------------------------------------------------------------------------------------
+ *
+ * The K8s JS client provides incomplete support for base64 encoding/decoding handling for secrets,
+ * unlike the GO client. To make this less painful, Pepr automatically handles base64 encoding/decoding
+ * secret data before and after the Capability Action is executed.
+ */
+When(a.Secret)
+  .IsCreated()
+  .WithName("secret-1")
+  .Then(request => {
+    const secret = request.Raw;
+
+    // This will be encoded at the end of all processing back to base64: "Y2hhbmdlLXdpdGhvdXQtZW5jb2Rpbmc="
+    secret.data.magic = "change-without-encoding";
+
+    // You can modify the data directly, and it will be encoded at the end of all processing
+    secret.data.example += " - modified by Pepr";
+  });
+
+/**
+ * ---------------------------------------------------------------------------------------------------
  *                                   CAPABILITY ACTION (Untyped Custom Resource)                     *
  * ---------------------------------------------------------------------------------------------------
  *

--- a/src/lib/k8s/webhook.ts
+++ b/src/lib/k8s/webhook.ts
@@ -132,7 +132,7 @@ export class Webhook {
     };
   }
 
-  mutatingWebhook(): V1MutatingWebhookConfiguration {
+  mutatingWebhook(timeoutSeconds = 10): V1MutatingWebhookConfiguration {
     const { name } = this;
     const ignore = [peprIgnore];
 
@@ -172,7 +172,7 @@ export class Webhook {
           clientConfig,
           failurePolicy: "Ignore",
           matchPolicy: "Equivalent",
-          timeoutSeconds: 15,
+          timeoutSeconds,
           namespaceSelector: {
             matchExpressions: ignore,
           },
@@ -411,7 +411,7 @@ export class Webhook {
     return resources.map(r => dumpYaml(r, { noRefs: true })).join("---\n");
   }
 
-  async deploy(code?: Buffer) {
+  async deploy(code?: Buffer, webhookTimeout?: number) {
     Log.info("Establishing connection to Kubernetes");
 
     const namespace = "pepr-system";
@@ -436,7 +436,7 @@ export class Webhook {
       await coreV1Api.createNamespace(ns);
     }
 
-    const wh = this.mutatingWebhook();
+    const wh = this.mutatingWebhook(webhookTimeout);
     try {
       Log.info("Creating mutating webhook");
       await admissionApi.createMutatingWebhookConfiguration(wh);

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -5,6 +5,7 @@
     "declarationMap": false,
     "emitDeclarationOnly": false,
     "outDir": "dist/test",
+    "sourceMap": true
   },
   "include": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
This PR closes #95 by transparently handling Base64 encoding for the `data` field of Secrets. This behavior mirrors the Go K8s client behavior and eliminates the need for users to understand/worry about dealing with the encoding. 

Other options explored included extending new classes for ConfigMaps and Secrets, and using getters/setters, but these failed due to the nature of JS getter/setter support for modifying object properties.