### PR TITLE
metrics endpoint in pepr

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,56 @@
+# `/metrics` Endpoint Documentation
+
+The `/metrics` endpoint provides metrics for the application that are collected via the `MetricsCollector` class. It uses the `prom-client` library and performance hooks from Node.js to gather and expose the metrics data in a format that can be scraped by Prometheus.
+
+## Metrics Exposed
+
+The `MetricsCollector` exposes the following metrics:
+
+- `pepr_errors`: A counter that increments when an error event occurs in the application.
+- `pepr_alerts`: A counter that increments when an alert event is triggered in the application.
+- `pepr_summary`: A summary that provides the observed durations of events in the application.
+
+## API Details
+
+**Method:** GET
+
+**URL:** `/metrics`
+
+**Response Type:** text/plain
+
+**Status Codes:**
+- 200 OK: On success, returns the current metrics from the application.
+
+**Response Body:**
+The response body is a plain text representation of the metrics data, according to the Prometheus exposition formats. It includes the metrics mentioned above.
+
+## Examples
+
+### Request
+
+```plaintext
+GET /metrics
+```
+
+### Response
+```plaintext
+# HELP pepr_errors error counter
+# TYPE pepr_errors counter
+pepr_errors 5
+
+# HELP pepr_alerts alerts counter
+# TYPE pepr_alerts counter
+pepr_alerts 10
+
+# HELP pepr_summary summary
+# TYPE pepr_summary summary
+pepr_summary{quantile="0.01"} 200
+pepr_summary{quantile="0.05"} 220
+pepr_summary{quantile="0.5"} 250
+pepr_summary{quantile="0.9"} 280
+pepr_summary{quantile="0.95"} 300
+pepr_summary{quantile="0.99"} 350
+pepr_summary{quantile="0.999"} 400
+pepr_summary_sum 123456789
+pepr_summary_count 500
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "fast-json-patch": "3.1.1",
         "http-status-codes": "2.2.0",
         "node-fetch": "2.6.11",
+        "prom-client": "^14.2.0",
         "ramda": "0.29.0"
       },
       "bin": {
@@ -45,358 +46,6 @@
         "prompts": "2.4.2",
         "typescript": "5.0.4",
         "uuid": "9.0.0"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -456,9 +105,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -610,6 +259,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
+      "dev": true
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
@@ -627,9 +282,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+      "version": "18.16.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+      "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.4",
@@ -728,11 +383,12 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
       "dev": true,
       "dependencies": {
+        "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
       }
@@ -749,9 +405,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -957,9 +613,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1189,9 +845,9 @@
       }
     },
     "node_modules/ava/node_modules/globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
+      "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
       "dev": true,
       "dependencies": {
         "dir-glob": "^3.0.1",
@@ -1253,6 +909,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
@@ -3772,6 +3433,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prom-client": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -4418,6 +4090,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -4504,9 +4184,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "fast-json-patch": "3.1.1",
     "http-status-codes": "2.2.0",
     "node-fetch": "2.6.11",
+    "prom-client": "^14.2.0",
     "ramda": "0.29.0"
   },
   "devDependencies": {

--- a/src/lib/controller.ts
+++ b/src/lib/controller.ts
@@ -10,7 +10,6 @@ import { Request, Response } from "./k8s/types";
 import Log from "./logger";
 import { processor } from "./processor";
 import { ModuleConfig } from "./types";
-import { performance } from "perf_hooks";
 import { MetricsCollector } from "./metrics";
 
 export class Controller {
@@ -137,7 +136,7 @@ export class Controller {
   };
 
   private mutate = async (req: express.Request, res: express.Response) => {
-    const startTime = performance.now();
+    const startTime = this.metricsCollector.observeStart();
 
     try {
       // Validate the token
@@ -177,7 +176,7 @@ export class Controller {
         kind: "AdmissionReview",
         response,
       });
-      this.metricsCollector.observe(startTime);
+      this.metricsCollector.observeEnd(startTime);
     } catch (err) {
       console.error(err);
       res.status(500).send("Internal Server Error");

--- a/src/lib/controller.ts
+++ b/src/lib/controller.ts
@@ -10,10 +10,13 @@ import { Request, Response } from "./k8s/types";
 import Log from "./logger";
 import { processor } from "./processor";
 import { ModuleConfig } from "./types";
+import { performance } from "perf_hooks";
+import { MetricsCollector } from "./metrics";
 
 export class Controller {
   private readonly app = express();
   private running = false;
+  private metricsCollector = new MetricsCollector("pepr");
 
   // The token used to authenticate requests
   private token = "";
@@ -32,6 +35,9 @@ export class Controller {
 
     // Health check endpoint
     this.app.get("/healthz", this.healthz);
+
+    // Metrics endpoint
+    this.app.get("/metrics", this.metrics);
 
     // Mutate endpoint
     this.app.post("/mutate/:token", this.mutate);
@@ -121,7 +127,18 @@ export class Controller {
     }
   };
 
+  private metrics = async (req: express.Request, res: express.Response) => {
+    try {
+      res.send(await this.metricsCollector.getMetrics());
+    } catch (err) {
+      console.error(err);
+      res.status(500).send("Internal Server Error");
+    }
+  };
+
   private mutate = async (req: express.Request, res: express.Response) => {
+    const startTime = performance.now();
+
     try {
       // Validate the token
       const { token } = req.params;
@@ -129,6 +146,7 @@ export class Controller {
         const err = `Unauthorized: invalid token '${token.replace(/[^\w]/g, "_")}'`;
         console.warn(err);
         res.status(401).send(err);
+        this.metricsCollector.alert();
         return;
       }
 
@@ -159,9 +177,11 @@ export class Controller {
         kind: "AdmissionReview",
         response,
       });
+      this.metricsCollector.observe(startTime);
     } catch (err) {
       console.error(err);
       res.status(500).send("Internal Server Error");
+      this.metricsCollector.error();
     }
   };
 }

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import test from "ava";
+import { performance } from "perf_hooks";
+import { MetricsCollector } from "./metrics";
+
+test("constructor initializes counters correctly", t => {
+  const collector = new MetricsCollector("testPrefix");
+
+  t.truthy(collector);
+});
+
+test("error method increments error counter", async t => {
+  const collector = new MetricsCollector("testPrefix");
+
+  collector.error();
+
+  const metrics = await collector.getMetrics();
+  t.regex(metrics, /testPrefix_errors 1/);
+});
+
+test("alert method increments alerts counter", async t => {
+  const collector = new MetricsCollector("testPrefix");
+
+  collector.alert();
+
+  const metrics = await collector.getMetrics();
+  t.regex(metrics, /testPrefix_alerts 1/);
+});
+
+test("observeStart returns current timestamp", t => {
+  const collector = new MetricsCollector("testPrefix");
+
+  const timeBefore = performance.now();
+  const startTime = collector.observeStart();
+  const timeAfter = performance.now();
+
+  t.true(timeBefore <= startTime);
+  t.true(timeAfter >= startTime);
+});
+
+test("observeEnd updates summary", async t => {
+  const collector = new MetricsCollector("testPrefix");
+
+  const startTime = collector.observeStart();
+  await new Promise(resolve => setTimeout(resolve, 100)); // Delay to simulate operation
+  collector.observeEnd(startTime);
+
+  const metrics = await collector.getMetrics();
+  t.regex(metrics, /testPrefix_summary_count 1/);
+  t.regex(metrics, /testPrefix_summary_sum \d+\.\d+/);
+});

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -4,47 +4,76 @@
 import promClient from "prom-client";
 import { performance } from "perf_hooks";
 
+/**
+ * MetricsCollector class handles metrics collection using prom-client and performance hooks.
+ */
 export class MetricsCollector {
-  private registery: promClient.Registry;
-  private errors: promClient.Counter<string>;
-  private alerts: promClient.Counter<string>;
-  private summary: promClient.Summary<string>;
+  private _registry: promClient.Registry;
+  private _errors: promClient.Counter<string>;
+  private _alerts: promClient.Counter<string>;
+  private _summary: promClient.Summary<string>;
 
+  /**
+   * Creates a MetricsCollector instance with prefixed metrics.
+   * @param {string} [prefix='pepr'] - The prefix for the metric names.
+   */
   constructor(prefix = "pepr") {
-    this.registery = new promClient.Registry();
+    this._registry = new promClient.Registry();
 
-    this.errors = new promClient.Counter({
+    this._errors = new promClient.Counter({
       name: `${prefix}_errors`,
       help: "error counter",
-      registers: [this.registery],
+      registers: [this._registry],
     });
 
-    this.alerts = new promClient.Counter({
+    this._alerts = new promClient.Counter({
       name: `${prefix}_alerts`,
       help: "alerts counter",
-      registers: [this.registery],
+      registers: [this._registry],
     });
 
-    this.summary = new promClient.Summary({
+    this._summary = new promClient.Summary({
       name: `${prefix}_summary`,
       help: "summary",
-      registers: [this.registery],
+      registers: [this._registry],
     });
   }
 
-  error(): void {
-    this.errors.inc();
+  /**
+   * Increments the error counter.
+   */
+  error() {
+    this._errors.inc();
   }
 
-  alert(): void {
-    this.alerts.inc();
+  /**
+   * Increments the alerts counter.
+   */
+  alert() {
+    this._alerts.inc();
   }
 
-  observe(startTime: number): void {
-    this.summary.observe(performance.now() - startTime);
+  /**
+   * Returns the current timestamp from performance.now() method. Useful for start timing an operation.
+   * @returns {number} The timestamp.
+   */
+  observeStart() {
+    return performance.now();
   }
 
-  async getMetrics(): Promise<string> {
-    return this.registery.metrics();
+  /**
+   * Observes the duration since the provided start time and updates the summary.
+   * @param {number} startTime - The start time.
+   */
+  observeEnd(startTime: number) {
+    this._summary.observe(performance.now() - startTime);
+  }
+
+  /**
+   * Fetches the current metrics from the registry.
+   * @returns {Promise<string>} The metrics.
+   */
+  async getMetrics() {
+    return this._registry.metrics();
   }
 }

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import promClient from "prom-client";
+import { performance } from "perf_hooks";
+
+export class MetricsCollector {
+  private registery: promClient.Registry;
+  private errors: promClient.Counter<string>;
+  private alerts: promClient.Counter<string>;
+  private summary: promClient.Summary<string>;
+
+  constructor(prefix = "pepr") {
+    this.registery = new promClient.Registry();
+
+    this.errors = new promClient.Counter({
+      name: `${prefix}_errors`,
+      help: "error counter",
+      registers: [this.registery],
+    });
+
+    this.alerts = new promClient.Counter({
+      name: `${prefix}_alerts`,
+      help: "alerts counter",
+      registers: [this.registery],
+    });
+
+    this.summary = new promClient.Summary({
+      name: `${prefix}_summary`,
+      help: "summary",
+      registers: [this.registery],
+    });
+  }
+
+  error(): void {
+    this.errors.inc();
+  }
+
+  alert(): void {
+    this.alerts.inc();
+  }
+
+  observe(startTime: number): void {
+    this.summary.observe(performance.now() - startTime);
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registery.metrics();
+  }
+}


### PR DESCRIPTION
added a simple metrics route to pepr, not exposed via servicemonitor a WIP for now.

for now, I've only added 3 counters that live in the /mutate endpoint:
alert: if you use the wrong `API KEY`
summary: it uses a full summary for OK requests. 
error: a counter if there are issues. 

I've not yet figured out the best way to allow extended metrics into each of the capabilities, but for now, the simplicity of this should help us drive that.

https://github.com/defenseunicorns/pepr/issues/24