### PR TITLE
Check if value is undefined to avoid error on base64Decode and assign…

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,16 +30,20 @@ export function convertFromBase64Map(obj: { data?: Record<string, string> }) {
 
   obj.data = obj.data ?? {};
   for (const key in obj.data) {
-    const decoded = base64Decode(obj.data[key]);
-    if (isAscii.test(decoded)) {
-      // Only decode ascii values
-      obj.data[key] = decoded;
+    if (obj.data[key] == undefined) {
+      obj.data[key] = ""
     } else {
-      skip.push(key);
+      const decoded = base64Decode(obj.data[key]);
+      if (isAscii.test(decoded)) {
+        // Only decode ascii values
+        obj.data[key] = decoded;
+      } else {
+        skip.push(key);
+      }
     }
-  }
 
-  Log.debug(`Non-ascii data detected in keys: ${skip}, skipping automatic base64 decoding`);
+    Log.debug(`Non-ascii data detected in keys: ${skip}, skipping automatic base64 decoding`);
+  }
 
   return skip;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,10 +41,8 @@ export function convertFromBase64Map(obj: { data?: Record<string, string> }) {
         skip.push(key);
       }
     }
-
-    Log.debug(`Non-ascii data detected in keys: ${skip}, skipping automatic base64 decoding`);
   }
-
+  Log.debug(`Non-ascii data detected in keys: ${skip}, skipping automatic base64 decoding`);
   return skip;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,7 +31,7 @@ export function convertFromBase64Map(obj: { data?: Record<string, string> }) {
   obj.data = obj.data ?? {};
   for (const key in obj.data) {
     if (obj.data[key] == undefined) {
-      obj.data[key] = ""
+      obj.data[key] = "";
     } else {
       const decoded = base64Decode(obj.data[key]);
       if (isAscii.test(decoded)) {


### PR DESCRIPTION
When the value of object.data's keys is undefined, you will get an error on the decode. This PR handles this by assigning the null value an empty string which represents the value it should be decoded to. 

Closes #199 

```javascript
export function convertFromBase64Map(obj: { data?: Record<string, string> }) {
  const skip: string[] = [];

  obj.data = obj.data ?? {};
  for (const key in obj.data) {
    if (obj.data[key] == undefined) {
      obj.data[key] = ""
    } else {
      const decoded = base64Decode(obj.data[key]);
      if (isAscii.test(decoded)) {
        // Only decode ascii values
        obj.data[key] = decoded;
      } else {
        skip.push(key);
      }
    }

    Log.debug(`Non-ascii data detected in keys: ${skip}, skipping automatic base64 decoding`);
  }

  return skip;
}
```