### PR TITLE
visible errors

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -177,14 +177,14 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS) {
 
     return { ctx, path, cfg, uuid };
   } catch (e) {
-    Log.debug(e.message);
+    Log.error(e.message);
 
     if (e.stdout) {
       const out = e.stdout.toString() as string;
       const err = e.stderr.toString();
 
-      Log.debug(out);
-      Log.debug(err);
+      Log.error(out);
+      Log.error(err);
 
       // Check for version conflicts
       if (out.includes("Types have separate declarations of a private property '_name'.")) {


### PR DESCRIPTION
if you have a syntax error in your module, `npx pepr build` will now tell you without added `-l debug`
errors will not be logged as Error, so in the event any build function fails there's a visible message