### PR TITLE
Make debugging easier when multiple capabilities are in play

### DIFF
--- a/src/lib/assets/helpers.test.ts
+++ b/src/lib/assets/helpers.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+// helpers.test.ts
+
+import test from "ava";
+import { extractLabelsFromCapabilities } from "./helpers";
+import { ModuleCapabilities } from "./loader";
+import { Binding } from "../types";
+
+test("extractLabelsFromAssets", t => {
+  const hash = "1234567890";
+  const blankBinding: Binding[] = [];
+  const testCases: Array<[ModuleCapabilities[], { [key: string]: string }]> = [
+    [
+      [
+        {
+          _name: "hello-pepr",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "goodbye-pepr",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "hello-world",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "goodbye-world",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+      ],
+      {
+        "hello-pepr": hash,
+        "goodbye-pepr": hash,
+        "hello-world": hash,
+        "goodbye-world": hash,
+      },
+    ],
+    [
+      [
+        {
+          _name: "hello-leapfrog",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "goodbye-leapfrog",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "hello-uds",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "goodbye-uds",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+      ],
+      {
+        "hello-leapfrog": hash,
+        "goodbye-leapfrog": hash,
+        "hello-uds": hash,
+        "goodbye-uds": hash,
+      },
+    ],
+    [
+      [
+        {
+          _name: "hello-zarf",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "goodbye-zarf",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "hello-earth",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+        {
+          _name: "goodbye-earth",
+          _description: "",
+          _namespaces: ["", ""],
+          _bindings: blankBinding,
+        },
+      ],
+      {
+        "hello-zarf": hash,
+        "goodbye-zarf": hash,
+        "hello-earth": hash,
+        "goodbye-earth": hash,
+      },
+    ],
+  ];
+
+  for (const [input, expected] of testCases) {
+    const labels = extractLabelsFromCapabilities(input, hash);
+    t.is(labels, expected);
+  }
+});

--- a/src/lib/assets/helpers.test.ts
+++ b/src/lib/assets/helpers.test.ts
@@ -8,7 +8,7 @@ import { ModuleCapabilities } from "./loader";
 import { Binding } from "../types";
 
 test("extractLabelsFromAssets", t => {
-  const hash = "1234567890";
+  const hash = "12345";
   const blankBinding: Binding[] = [];
   const testCases: Array<[ModuleCapabilities[], { [key: string]: string }]> = [
     [
@@ -117,6 +117,6 @@ test("extractLabelsFromAssets", t => {
 
   for (const [input, expected] of testCases) {
     const labels = extractLabelsFromCapabilities(input, hash);
-    t.is(labels, expected);
+    t.deepEqual(labels, expected);
   }
 });

--- a/src/lib/assets/helpers.ts
+++ b/src/lib/assets/helpers.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { ModuleCapabilities } from "./loader";
+/**
+ * Extract labels from a capabilities
+ *
+ * @param assets The webhook application
+ * @param hash Generated hash
+ * @returns { key:[string]: string } which represents the labels
+ */
+export function extractLabelsFromCapabilities(
+  capabilities: ModuleCapabilities[],
+  hash: string,
+): {
+  [key: string]: string;
+} {
+  const labels: { [key: string]: string } = {};
+
+  capabilities.map(capability => (labels[capability._name] = hash.substring(0, 5)));
+  return labels;
+}

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -5,6 +5,7 @@ import { gzipSync } from "zlib";
 
 import { Assets } from ".";
 import { Deployment, Namespace, Secret } from "../k8s/upstream";
+import { extractLabelsFromCapabilities } from "./helpers";
 
 /** Generate the pepr-system namespace */
 export const namespace: Namespace = {
@@ -14,7 +15,7 @@ export const namespace: Namespace = {
 };
 
 export function deployment(assets: Assets, hash: string): Deployment {
-  const { name, image } = assets;
+  const { name, image, capabilities } = assets;
   const app = name;
 
   return {
@@ -25,6 +26,7 @@ export function deployment(assets: Assets, hash: string): Deployment {
       namespace: "pepr-system",
       labels: {
         app,
+        ...extractLabelsFromCapabilities(capabilities, hash),
       },
     },
     spec: {
@@ -38,6 +40,7 @@ export function deployment(assets: Assets, hash: string): Deployment {
         metadata: {
           labels: {
             app,
+            ...extractLabelsFromCapabilities(capabilities, hash),
           },
         },
         spec: {


### PR DESCRIPTION
Closes #224 

This feature adds the capability names to the labels in the deployment and the deployment's podSpec.

This PR is necessary because at times you have multiple controllers and it is difficult to know which controller is responsible for a given capability. Now you can easily debug by a given capability.

I'm using a substring of the hash of the first 5 characters. If I had included the whole hash the character limit would be hit. The value of the label is not relevant.

If you know you have a capability, like `cpu-chopper` for instance, you can debug by following logs easily:

```bash
k logs -n pepr-system -l cpu-chopper -f
```

actual example with `hello-pepr`
```bash
└─[130] <git:(main✈) > k get deploy -n pepr-system --show-labels
NAME               READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
pepr-static-test   0/2     2            0           26s   app=pepr-static-test,hello-pepr=2f099
┌─[cmwylie19@Cases-MacBook-Pro] - [~/pepr/pepr-test-module] - [2023-09-01 09:59:00]
└─[0] <git:(main✈) > k get po -n pepr-system -l hello-pepr
NAME                                READY   STATUS             RESTARTS   AGE
pepr-static-test-7769b97ffb-z6jbm   0/1     ErrImagePull       0          42s
pepr-static-test-7769b97ffb-25m82   0/1     ImagePullBackOff   0          42s
┌─[cmwylie19@Cases-MacBook-Pro] - [~/pepr/pepr-test-module] - [2023-09-01 09:59:16]
└─[0] <git:(main✈) > k logs -n pepr-system -f -l hello-pepr
Error from server (BadRequest): container "server" in pod "pepr-static-test-7769b97ffb-25m82" is waiting to start: trying and failing to pull image
```
