### PR TITLE
Fix capability namespace list being ignored

### DIFF
--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -24,7 +24,7 @@ test("should reject when name does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should reject when kind does not match", () => {
@@ -41,7 +41,7 @@ test("should reject when kind does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should reject when group does not match", () => {
@@ -58,7 +58,7 @@ test("should reject when group does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should reject when version does not match", () => {
@@ -79,7 +79,7 @@ test("should reject when version does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when group, version, and kind match", () => {
@@ -96,7 +96,7 @@ test("should allow when group, version, and kind match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should allow when kind match and others are empty", () => {
@@ -117,7 +117,24 @@ test("should allow when kind match and others are empty", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
+});
+
+test("should reject when teh capability namespace does not match", () => {
+  const binding = {
+    event: Event.Any,
+    kind: gvkMap.V1Pod,
+    filters: {
+      name: "",
+      namespaces: [],
+      labels: {},
+      annotations: {},
+    },
+    callback,
+  };
+  const pod = CreatePod();
+
+  expect(shouldSkipRequest(binding, pod, ["bleh", "bleh2"])).toBe(true);
 });
 
 test("should reject when namespace does not match", () => {
@@ -134,7 +151,7 @@ test("should reject when namespace does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when namespace is match", () => {
@@ -151,7 +168,7 @@ test("should allow when namespace is match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should reject when label does not match", () => {
@@ -170,7 +187,7 @@ test("should reject when label does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when label is match", () => {
@@ -198,7 +215,7 @@ test("should allow when label is match", () => {
     test2: "test2",
   };
 
-  expect(shouldSkipRequest(binding, pod)).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should reject when annotation does not match", () => {
@@ -217,7 +234,7 @@ test("should reject when annotation does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when annotation is match", () => {
@@ -244,7 +261,7 @@ test("should allow when annotation is match", () => {
     test2: "test2",
   };
 
-  expect(shouldSkipRequest(binding, pod)).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should use `oldObject` when the operation is `DELETE`", () => {
@@ -266,5 +283,5 @@ test("should use `oldObject` when the operation is `DELETE`", () => {
 
   const pod = DeletePod();
 
-  expect(shouldSkipRequest(binding, pod)).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -12,13 +12,14 @@ import { Binding, Event } from "./types";
  * @param req the incoming request
  * @returns
  */
-export function shouldSkipRequest(binding: Binding, req: Request) {
+export function shouldSkipRequest(binding: Binding, req: Request, capabilityNamespaces: string[]) {
   const { group, kind, version } = binding.kind || {};
   const { namespaces, labels, annotations, name } = binding.filters || {};
   const operation = req.operation.toUpperCase();
   // Use the old object if the request is a DELETE operation
   const srcObject = operation === Operation.DELETE ? req.oldObject : req.object;
   const { metadata } = srcObject || {};
+  const combinedNamespaces = [...namespaces, ...capabilityNamespaces];
 
   // Test for matching operation
   if (!binding.event.includes(operation) && !binding.event.includes(Event.Any)) {
@@ -46,7 +47,7 @@ export function shouldSkipRequest(binding: Binding, req: Request) {
   }
 
   // Test for matching namespaces
-  if (namespaces.length && !namespaces.includes(req.namespace || "")) {
+  if (combinedNamespaces.length && !combinedNamespaces.includes(req.namespace || "")) {
     logger.debug("Namespace does not match");
     return true;
   }

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -40,7 +40,7 @@ export async function mutateProcessor(
 
   Log.info(reqMetadata, `Processing request`);
 
-  for (const { name, bindings } of capabilities) {
+  for (const { name, bindings, namespaces } of capabilities) {
     const actionMetadata = { ...reqMetadata, name };
 
     for (const action of bindings) {
@@ -50,7 +50,7 @@ export async function mutateProcessor(
       }
 
       // Continue to the next action without doing anything if this one should be skipped
-      if (shouldSkipRequest(action, req)) {
+      if (shouldSkipRequest(action, req, namespaces)) {
         continue;
       }
 

--- a/src/lib/validate-processor.ts
+++ b/src/lib/validate-processor.ts
@@ -28,7 +28,7 @@ export async function validateProcessor(
 
   Log.info(reqMetadata, `Processing validation request`);
 
-  for (const { name, bindings } of capabilities) {
+  for (const { name, bindings, namespaces } of capabilities) {
     const actionMetadata = { ...reqMetadata, name };
 
     for (const action of bindings) {
@@ -38,7 +38,7 @@ export async function validateProcessor(
       }
 
       // Continue to the next action without doing anything if this one should be skipped
-      if (shouldSkipRequest(action, req)) {
+      if (shouldSkipRequest(action, req, namespaces)) {
         continue;
       }
 


### PR DESCRIPTION
Fixes #243.

This PR correctly handles namespace filters provided when a Capability is created, such as in HelloPepr.