### PR TITLE
.gitignore and function return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 
+# pepr-test-module should be ignored
+pepr-test-module/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -20,7 +20,7 @@ const peprIgnoreLabel: V1LabelSelectorRequirement = {
 
 const peprIgnoreNamespaces: string[] = ["kube-system", "pepr-system"];
 
-export async function generateWebhookRules(assets: Assets, isMutateWebhook: boolean) {
+export async function generateWebhookRules(assets: Assets, isMutateWebhook: boolean): Promise<V1RuleWithOperations[]> {
   const { config, capabilities } = assets;
   const rules: V1RuleWithOperations[] = [];
 


### PR DESCRIPTION
Update .gitignore to include `pepr-test-module` and add a return type for `generateWebhookRules` function

Closes #256 