### PR TITLE
chore: add diagnostic flag to journey tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0'",
     "test:journey:build": "npm run build && npm pack",
     "test:journey:image": "docker buildx build --tag pepr:dev . && k3d image import pepr:dev -c pepr-dev",
-    "test:journey:run": "jest journey/entrypoint.test.ts",
-    "test:journey:run-wasm": "jest journey/entrypoint-wasm.test.ts",
+    "test:journey:run": "jest --detectOpenHandles journey/entrypoint.test.ts",
+    "test:journey:run-wasm": "jest --detectOpenHandles journey/entrypoint-wasm.test.ts",
     "format:check": "eslint src && prettier src --check",
     "format:fix": "eslint src --fix && prettier src --write"
   },


### PR DESCRIPTION
## Description
Just want to get some diagnostics about what may be causing the Journey's to hang.

Flag docs:  https://jestjs.io/docs/cli#--detectopenhandles
Example failing run:  https://github.com/defenseunicorns/pepr/actions/runs/6561877127

## Related Issue
n/a

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
