### PR TITLE
test: wait for k3d cluster to 'be up' before returning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:unit": "npm run gen-data-json && jest src --coverage",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",
     "test:journey-wasm": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run-wasm",
-    "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0'",
+    "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0' --wait && kubectl rollout status deployment -n kube-system",
     "test:journey:build": "npm run build && npm pack",
     "test:journey:image": "docker buildx build --tag pepr:dev . && k3d image import pepr:dev -c pepr-dev",
     "test:journey:run": "jest --detectOpenHandles journey/entrypoint.test.ts",


### PR DESCRIPTION
## Description
I've been running lots of capability tests recently -- and wipe-and-recreate-ing lots of clusters -- and have gotten tired of having to watch k9s to determine when the new cluster was "up" enough to use.

I suspect I'm not the only person who's grown tired of doing this manually so this PR adds the same "wait for cluster to be usable" stuff that I've been using locally.

## Related Issue
n/a

Relates to #
n/a

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
