### PR TITLE
feat: add flag to change directory of built artifacts

### DIFF
--- a/journey/entrypoint-wasm.test.ts
+++ b/journey/entrypoint-wasm.test.ts
@@ -15,4 +15,4 @@ export const cwd = "pepr-test-module";
 // Allow 5 minutes for the tests to run
 jest.setTimeout(1000 * 60 * 5);
 
-describe("Journey: `npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped -o dst`", peprBuild);
+describe("Journey: `npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped -o dist/pepr-test-module/child/folder`", peprBuild);

--- a/journey/entrypoint-wasm.test.ts
+++ b/journey/entrypoint-wasm.test.ts
@@ -15,4 +15,4 @@ export const cwd = "pepr-test-module";
 // Allow 5 minutes for the tests to run
 jest.setTimeout(1000 * 60 * 5);
 
-describe("Journey: `npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped`", peprBuild);
+describe("Journey: `npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped -o dst`", peprBuild);

--- a/journey/pepr-build-wasm.ts
+++ b/journey/pepr-build-wasm.ts
@@ -9,17 +9,22 @@ import { resolve } from "path";
 
 import { cwd } from "./entrypoint.test";
 
+// test npx pepr build -o dst
+const outputDir = "dst";
 export function peprBuild() {
+
+  execSync(`mkdir ${outputDir}`);
+
   it("should successfully build the Pepr project with arguments", async () => {
-    execSync("npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped", { cwd: cwd, stdio: "inherit" });
+    execSync(`npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped -o ${outputDir}`, { cwd: cwd, stdio: "inherit" });
   });
 
   it("should generate produce the K8s yaml file", async () => {
-    await fs.access(resolve(cwd, "dist", "pepr-module-static-test.yaml"));
+    await fs.access(resolve(cwd, outputDir, "pepr-module-static-test.yaml"));
   });
 
   it("should generate a custom image in zarf.yaml", async () => {
-    await fs.access(resolve(cwd, "dist", "zarf.yaml"));
+    await fs.access(resolve(cwd, outputDir, "zarf.yaml"));
     await validateZarfYaml();
   });
 
@@ -30,7 +35,7 @@ export function peprBuild() {
 
 async function validateClusterRoleYaml() {
   // Read the generated yaml files
-  const k8sYaml = await fs.readFile(resolve(cwd, "dist", "pepr-module-static-test.yaml"), "utf8");
+  const k8sYaml = await fs.readFile(resolve(cwd, outputDir, "pepr-module-static-test.yaml"), "utf8");
   const cr = await fs.readFile(resolve("journey", "resources", "clusterrole.yaml"), "utf8");
 
   expect(k8sYaml.includes(cr)).toEqual(true)
@@ -41,8 +46,8 @@ async function validateZarfYaml() {
   const peprVer = execSync("npx pepr --version", { cwd }).toString().trim();
 
   // Read the generated yaml files
-  const k8sYaml = await fs.readFile(resolve(cwd, "dist", "pepr-module-static-test.yaml"), "utf8");
-  const zarfYAML = await fs.readFile(resolve(cwd, "dist", "zarf.yaml"), "utf8");
+  const k8sYaml = await fs.readFile(resolve(cwd, outputDir, "pepr-module-static-test.yaml"), "utf8");
+  const zarfYAML = await fs.readFile(resolve(cwd, outputDir, "zarf.yaml"), "utf8");
 
   // The expected image name
   const expectedImage = `gchr.io/defenseunicorns/custom-pepr-controller:file:../pepr-${peprVer}.tgz`;

--- a/journey/pepr-build-wasm.ts
+++ b/journey/pepr-build-wasm.ts
@@ -13,7 +13,9 @@ import { cwd } from "./entrypoint.test";
 const outputDir = "dst";
 export function peprBuild() {
 
-  execSync(`mkdir ${outputDir}`,{ cwd });
+  it("should build artifacts in the dst folder", async () => {
+    execSync(`mkdir ${outputDir}`, { cwd, stdio: "inherit" });
+  });
 
   it("should successfully build the Pepr project with arguments", async () => {
     execSync(`npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped -o ${outputDir}`, { cwd: cwd, stdio: "inherit" });

--- a/journey/pepr-build-wasm.ts
+++ b/journey/pepr-build-wasm.ts
@@ -13,7 +13,7 @@ import { cwd } from "./entrypoint.test";
 const outputDir = "dst";
 export function peprBuild() {
 
-  execSync(`mkdir ${outputDir}`);
+  execSync(`mkdir ${outputDir}`,{ cwd });
 
   it("should successfully build the Pepr project with arguments", async () => {
     execSync(`npx pepr build -r gchr.io/defenseunicorns --rbac-mode scoped -o ${outputDir}`, { cwd: cwd, stdio: "inherit" });

--- a/journey/pepr-build-wasm.ts
+++ b/journey/pepr-build-wasm.ts
@@ -14,7 +14,7 @@ const outputDir = "dst";
 export function peprBuild() {
 
   it("should build artifacts in the dst folder", async () => {
-    execSync(`mkdir ${outputDir}`, { cwd, stdio: "inherit" });
+    await fs.mkdir(outputDir, { recursive: true })
   });
 
   it("should successfully build the Pepr project with arguments", async () => {

--- a/journey/pepr-build-wasm.ts
+++ b/journey/pepr-build-wasm.ts
@@ -10,7 +10,7 @@ import { resolve } from "path";
 import { cwd } from "./entrypoint.test";
 
 // test npx pepr build -o dst
-const outputDir = "dst";
+const outputDir = "dist/pepr-test-module/child/folder";
 export function peprBuild() {
 
   it("should build artifacts in the dst folder", async () => {

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -13,7 +13,7 @@ import { peprFormat } from "./format";
 import { Option } from "commander";
 
 const peprTS = "pepr.ts";
-
+let outputDir: string = "dist";
 export type Reloader = (opts: BuildResult<BuildOptions>) => void | Promise<void>;
 
 export default function (program: RootCmd) {
@@ -28,6 +28,10 @@ export default function (program: RootCmd) {
     .option(
       "-r, --registry-info [<registry>/<username>]",
       "Registry Info: Image registry and username. Note: You must be signed into the registry",
+    )
+    .option(
+      "-o, --output-dir [output directory]",
+      "Define where the contents of the dist folder go",
     )
     .addOption(
       new Option("--rbac-mode [admin|scoped]", "Rbac Mode: admin, scoped (default: admin)")
@@ -79,10 +83,13 @@ export default function (program: RootCmd) {
       }
 
       const yamlFile = `pepr-module-${uuid}.yaml`;
-      const yamlPath = resolve("dist", yamlFile);
+      if (opts.outputDir) {
+        outputDir = opts.outputDir;
+      }
+      const yamlPath = resolve(outputDir, yamlFile);
       const yaml = await assets.allYaml(opts.rbacMode);
 
-      const zarfPath = resolve("dist", "zarf.yaml");
+      const zarfPath = resolve(outputDir, "zarf.yaml");
       const zarf = assets.zarfYaml(yamlFile);
 
       await fs.writeFile(yamlPath, yaml);
@@ -135,7 +142,7 @@ export async function loadModule(entryPoint = peprTS) {
     cfg,
     input,
     name,
-    path: resolve("dist", name),
+    path: resolve(outputDir, name),
     uuid,
   };
 }
@@ -201,7 +208,7 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS) {
       ctxCfg.minify = false;
 
       // Preserve the original file name if we're using a custom entry point
-      ctxCfg.outfile = resolve("dist", basename(entryPoint, extname(entryPoint))) + ".js";
+      ctxCfg.outfile = resolve(outputDir, basename(entryPoint, extname(entryPoint))) + ".js";
 
       // Only bundle the NPM packages if we're not using a custom entry point
       ctxCfg.packages = "external";

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -32,7 +32,7 @@ export default function (program: RootCmd) {
     )
     .option(
       "-o, --output-dir [output directory]",
-      "Define where the contents of the dist folder go",
+      "Define where to place build output",
     )
     .addOption(
       new Option("--rbac-mode [admin|scoped]", "Rbac Mode: admin, scoped (default: admin)")

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -11,6 +11,7 @@ import { dependencies, version } from "./init/templates";
 import { RootCmd } from "./root";
 import { peprFormat } from "./format";
 import { Option } from "commander";
+import { createDirectoryIfNotExists } from "../lib/helpers";
 
 const peprTS = "pepr.ts";
 let outputDir: string = "dist";
@@ -39,6 +40,15 @@ export default function (program: RootCmd) {
         .default("admin"),
     )
     .action(async opts => {
+      // assign custom output directory if provided
+      if (opts.outputDir) {
+        outputDir = opts.outputDir;
+        createDirectoryIfNotExists(outputDir).catch(error => {
+          console.error("Could not create output directory. ", error, " Using dist folder.");
+          outputDir = "dist";
+        });
+      }
+
       // Build the module
       const { cfg, path, uuid } = await buildModule(undefined, opts.entryPoint);
 
@@ -83,9 +93,7 @@ export default function (program: RootCmd) {
       }
 
       const yamlFile = `pepr-module-${uuid}.yaml`;
-      if (opts.outputDir) {
-        outputDir = opts.outputDir;
-      }
+
       const yamlPath = resolve(outputDir, yamlFile);
       const yaml = await assets.allYaml(opts.rbacMode);
 

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -41,12 +41,8 @@ export default function (program: RootCmd) {
       if (opts.outputDir) {
         outputDir = opts.outputDir;
         createDirectoryIfNotExists(outputDir).catch(error => {
-          console.error(
-            "Could not create output directory. ",
-            error,
-            " Defaulting to dist folder.",
-          );
-          outputDir = "dist";
+          console.error(`Error creating output directory: ${error}`);
+          process.exit(1);
         });
       }
 

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -30,10 +30,7 @@ export default function (program: RootCmd) {
       "-r, --registry-info [<registry>/<username>]",
       "Registry Info: Image registry and username. Note: You must be signed into the registry",
     )
-    .option(
-      "-o, --output-dir [output directory]",
-      "Define where to place build output",
-    )
+    .option("-o, --output-dir [output directory]", "Define where to place build output")
     .addOption(
       new Option("--rbac-mode [admin|scoped]", "Rbac Mode: admin, scoped (default: admin)")
         .choices(["admin", "scoped"])
@@ -44,7 +41,11 @@ export default function (program: RootCmd) {
       if (opts.outputDir) {
         outputDir = opts.outputDir;
         createDirectoryIfNotExists(outputDir).catch(error => {
-          console.error("Could not create output directory. ", error, " Defaulting to dist folder.");
+          console.error(
+            "Could not create output directory. ",
+            error,
+            " Defaulting to dist folder.",
+          );
           outputDir = "dist";
         });
       }

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -44,7 +44,7 @@ export default function (program: RootCmd) {
       if (opts.outputDir) {
         outputDir = opts.outputDir;
         createDirectoryIfNotExists(outputDir).catch(error => {
-          console.error("Could not create output directory. ", error, " Using dist folder.");
+          console.error("Could not create output directory. ", error, " Defaulting to dist folder.");
           outputDir = "dist";
         });
       }

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -3,7 +3,9 @@
 
 import { CapabilityExport } from "./types";
 import { createRBACMap, addVerbIfNotExists } from "./helpers";
-import { expect, describe, test } from "@jest/globals";
+import { expect, describe, test, jest } from "@jest/globals";
+import { promises as fs } from "fs";
+import { createDirectoryIfNotExists } from "./helpers";
 
 const capabilities: CapabilityExport[] = JSON.parse(`[
     {
@@ -279,5 +281,54 @@ describe("addVerbIfNotExists", () => {
     const verbs = ["get", "list", "watch"];
     addVerbIfNotExists(verbs, "get");
     expect(verbs).toEqual(["get", "list", "watch"]); // The array remains unchanged
+  });
+});
+
+jest.mock("fs", () => {
+  return {
+    promises: {
+      access: jest.fn(),
+      mkdir: jest.fn(),
+    },
+  };
+});
+
+describe("createDirectoryIfNotExists function", () => {
+  test("should create a directory if it doesn't exist", async () => {
+    (fs.access as jest.Mock).mockRejectedValue({ code: "ENOENT" } as never);
+    (fs.mkdir as jest.Mock).mockResolvedValue(undefined as never);
+
+    const directoryPath = "/pepr/pepr-test-module/asdf";
+
+    await createDirectoryIfNotExists(directoryPath);
+
+    expect(fs.access).toHaveBeenCalledWith(directoryPath);
+    expect(fs.mkdir).toHaveBeenCalledWith(directoryPath, { recursive: true });
+  });
+
+  test("should not create a directory if it already exists", async () => {
+    jest.resetAllMocks();
+    (fs.access as jest.Mock).mockResolvedValue(undefined as never);
+
+    const directoryPath = "/pepr/pepr-test-module/asdf";
+
+    await createDirectoryIfNotExists(directoryPath);
+
+    expect(fs.access).toHaveBeenCalledWith(directoryPath);
+    expect(fs.mkdir).not.toHaveBeenCalled();
+  });
+
+  test("should throw an error for other fs.access errors", async () => {
+    jest.resetAllMocks();
+    (fs.access as jest.Mock).mockRejectedValue({ code: "ERROR" } as never);
+
+    const directoryPath = "/pepr/pepr-test-module/asdf";
+
+    // Ensure the function throws an error with the expected code
+    try {
+      await createDirectoryIfNotExists(directoryPath);
+    } catch (error) {
+      expect(error.code).toEqual("ERROR");
+    }
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -324,7 +324,6 @@ describe("createDirectoryIfNotExists function", () => {
 
     const directoryPath = "/pepr/pepr-test-module/asdf";
 
-    // Ensure the function throws an error with the expected code
     try {
       await createDirectoryIfNotExists(directoryPath);
     } catch (error) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { CapabilityExport } from "./types";
+import { promises as fs } from "fs";
 
 type RBACMap = {
   [key: string]: {
@@ -37,3 +38,15 @@ export const createRBACMap = (capabilities: CapabilityExport[]): RBACMap => {
     return acc;
   }, {});
 };
+
+export async function createDirectoryIfNotExists(path: string) {
+  try {
+    await fs.access(path);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      await fs.mkdir(path, { recursive: true });
+    } else {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Provide a flag during `npx pepr build` for output to define where the contents of the dist folder go. This request came up during consideration for module testing.

## Related Issue

Fixes #350 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
