### PR TITLE
feat: setItemAndWait transactional way to set an item in the store

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -36,7 +36,7 @@ const unsubscribe = Store.subscribe(data => {
 
 - `getItem(key: string)`: Retrieves a value by its key. Returns `null` if the key doesn't exist.
 - `setItem(key: string, value: string)`: Sets a value for a given key. Creates a new key-value pair if the key doesn't exist.
-- `setItemAndWait(key: string, value: string)`: Sets a value for a given key. Creates a new key-value pair if the key doesn't exist. Returns a promise when the new key and value show up in the store.
+- `setItemAndWait(key: string, value: string)`: Sets a value for a given key. Creates a new key-value pair if the key doesn't exist. Returns a promise when the new key and value show up in the store. Should only be used on a `Watch` to avoid [timeouts](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts).
 - `removeItem(key: string)`: Deletes a key-value pair by its key.
 - `clear()`: Clears all key-value pairs from the store.
 - `subscribe(listener: DataReceiver)`: Subscribes to store updates.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "build": "tsc && node build.mjs",
     "test": "npm run test:unit && npm run test:journey",
-    "test:unit": "npm run gen-data-json && jest src --coverage",
+    "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",
     "test:journey-wasm": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run-wasm",
     "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0' --wait && kubectl rollout status deployment -n kube-system",

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -50,6 +50,7 @@ export class Capability implements CapabilityExport {
     setItem: this.#store.setItem,
     subscribe: this.#store.subscribe,
     onReady: this.#store.onReady,
+    setItemAndWait: this.#store.setItemAndWait,
   };
 
   get bindings() {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -21,11 +21,11 @@ describe("Storage", () => {
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
   });
 
-  it("should set an item and wait", async () => {
+  it("should set an item and wait", () => {
     const mockSender = jest.fn();
     storage.registerSender(mockSender);
 
-    await storage.setItemAndWait("key1", "value1");
+    storage.setItemAndWait("key1", "value1");
 
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
   });

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -21,6 +21,15 @@ describe("Storage", () => {
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
   });
 
+  it("should set an item and wait", async () => {
+    const mockSender = jest.fn();
+    storage.registerSender(mockSender);
+
+    await storage.setItemAndWait("key1", "value1");
+
+    expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
+  });
+
   it("should remove an item", () => {
     const mockSender = jest.fn();
     storage.registerSender(mockSender);

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -24,10 +24,12 @@ describe("Storage", () => {
   it("should set an item and wait", () => {
     const mockSender = jest.fn();
     storage.registerSender(mockSender);
+    jest.useFakeTimers();
 
     storage.setItemAndWait("key1", "value1");
 
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
+    jest.clearAllTimers();
   });
 
   it("should remove an item", () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -88,6 +88,27 @@ export class Storage implements PeprStore {
     this.#dispatchUpdate("add", [key], value);
   };
 
+  /**
+   * Creates a promise and subscribes to the store, the promise resolves when 
+   * the key and value are seen in the store.
+   * 
+   * @param key - The key to add into the store
+   * @param value - The value of the key
+   * @returns 
+   */
+  setItemAndWait = (key: string, value: string) => {
+    Log.warn(`setItemAndWait should only be used on a Watch`);
+    this.#dispatchUpdate("add", [key], value);
+    return new Promise<void>(resolve => {
+      const unsubscribe = this.subscribe(data =>{
+        if(data[key] === value) {
+          unsubscribe();
+          resolve();
+        }
+      })
+    })
+  }
+
   subscribe = (subscriber: DataReceiver) => {
     const idx = this.#subscriberId++;
     this.#subscribers[idx] = subscriber;

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -112,7 +112,7 @@ export class Storage implements PeprStore {
           resolve();
         }
       });
-      
+
       // If promise has not resolved before MAX_WAIT_TIME reject
       setTimeout(() => {
         unsubscribe();

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -116,7 +116,7 @@ export class Storage implements PeprStore {
       // If promise has not resolved before MAX_WAIT_TIME reject
       setTimeout(() => {
         unsubscribe();
-        reject();
+        return reject();
       }, MAX_WAIT_TIME);
     });
   };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -40,6 +40,12 @@ export interface PeprStore {
    * Register a function to be called when the store is ready.
    */
   onReady(callback: DataReceiver): void;
+
+  /**
+   * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
+   * Resolves when the key/value show up in the store.
+   */
+  setItemAndWait(key: string, value: string): Promise<void>;
 }
 
 /**

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -111,12 +111,13 @@ export class Storage implements PeprStore {
           unsubscribe();
           resolve();
         }
-        // If promise has not resolved before MAX_WAIT_TIME reject
-        setTimeout(() => {
-          unsubscribe();
-          reject();
-        }, MAX_WAIT_TIME);
       });
+      
+      // If promise has not resolved before MAX_WAIT_TIME reject
+      setTimeout(() => {
+        unsubscribe();
+        reject();
+      }, MAX_WAIT_TIME);
     });
   };
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -89,25 +89,25 @@ export class Storage implements PeprStore {
   };
 
   /**
-   * Creates a promise and subscribes to the store, the promise resolves when 
+   * Creates a promise and subscribes to the store, the promise resolves when
    * the key and value are seen in the store.
-   * 
+   *
    * @param key - The key to add into the store
    * @param value - The value of the key
-   * @returns 
+   * @returns
    */
   setItemAndWait = (key: string, value: string) => {
     Log.warn(`setItemAndWait should only be used on a Watch`);
     this.#dispatchUpdate("add", [key], value);
     return new Promise<void>(resolve => {
-      const unsubscribe = this.subscribe(data =>{
-        if(data[key] === value) {
+      const unsubscribe = this.subscribe(data => {
+        if (data[key] === value) {
           unsubscribe();
           resolve();
         }
-      })
-    })
-  }
+      });
+    });
+  };
 
   subscribe = (subscriber: DataReceiver) => {
     const idx = this.#subscriberId++;

--- a/src/templates/capabilities/hello-pepr.ts
+++ b/src/templates/capabilities/hello-pepr.ts
@@ -69,10 +69,7 @@ When(a.Namespace)
     }
 
     // You can share data between actions using the Store, including between different types of actions
-    Store.setItemAndWait(
-      "watch-data",
-      "This data was stored by a Watch Action.",
-    );
+    Store.setItem("watch-data", "This data was stored by a Watch Action.");
   });
 
 /**

--- a/src/templates/capabilities/hello-pepr.ts
+++ b/src/templates/capabilities/hello-pepr.ts
@@ -69,7 +69,10 @@ When(a.Namespace)
     }
 
     // You can share data between actions using the Store, including between different types of actions
-    Store.setItem("watch-data", "This data was stored by a Watch Action.");
+    Store.setItemAndWait(
+      "watch-data",
+      "This data was stored by a Watch Action.",
+    );
   });
 
 /**

--- a/website/content/en/docs/store.md
+++ b/website/content/en/docs/store.md
@@ -41,7 +41,7 @@ const unsubscribe = Store.subscribe(data => {
 
 - `getItem(key: string)`: Retrieves a value by its key. Returns `null` if the key doesn't exist.
 - `setItem(key: string, value: string)`: Sets a value for a given key. Creates a new key-value pair if the key doesn't exist.
-- `setItemAndWait(key: string, value: string)`: Sets a value for a given key. Creates a new key-value pair if the key doesn't exist. Returns a promise when the new key and value show up in the store.
+- `setItemAndWait(key: string, value: string)`: Sets a value for a given key. Creates a new key-value pair if the key doesn't exist. Returns a promise when the new key and value show up in the store. Should only be used on a `Watch` to avoid [timeouts](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts).
 - `removeItem(key: string)`: Deletes a key-value pair by its key.
 - `clear()`: Clears all key-value pairs from the store.
 - `subscribe(listener: DataReceiver)`: Subscribes to store updates.

--- a/website/content/en/docs/store.md
+++ b/website/content/en/docs/store.md
@@ -1,3 +1,8 @@
+---
+title: Store
+linkTitle: Store
+---
+
 # Pepr Store: A Lightweight Key-Value Store for Pepr Modules
 
 The nature of admission controllers and general watch operations (the `Mutate`, `Validate` and `Watch` actions in Pepr) make some types of complex and long-running operations difficult. There are also times when you need to share data between different actions. While you could manually create your own K8s resources and manage their cleanup, this can be very hard to track and keep performant at scale. 


### PR DESCRIPTION
## Description

Provides a function to set an item in the store in a transactional way during a `Watch` action.

## Related Issue

Fixes #359 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
