### PR TITLE
docs: npm version

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -18,7 +18,7 @@ The store is backed by ETCD in a `PeprStore` resource, and updates happen at 5-s
 
 ## Watch
 
-Pepr facilitates efficient change notifications on resources through `Watch`. It is recommended to use `Watch` instead of `Mutate` or `Validate` when longer running operations are needed, as there is no [timeout limitation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts). An instance where `Watch` is beneficial is when API calls need to be chained together. `Watch` operations can be sequentially executed after `Mutate` and `Validate`.
+Pepr streamlines the process of receiving timely change notifications on resources by employing the `Watch` mechanism. It is advisable to opt for `Watch` over `Mutate` or `Validate` when dealing with more extended operations, as `Watch` does not face any [timeout limitations](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts). Additionally, `Watch` proves particularly advantageous for monitoring previously existing resources within a cluster. One compelling scenario for leveraging `Watch` is when there is a need to chain API calls together, allowing `Watch` operations to be sequentially executed following `Mutate` and `Validate` actions.
 
 ```typescript
 When(a.Pod)

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ When(a.ConfigMap)
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/en/) v18.0.0+ (even-numbered releases only).
-  - To ensure compatability and optimal performance, it is recommended to use even-numbered releases of Node.js as they are stable releases and receive long-term support for three years. Odd-numbered releases are experimental and may not be supported by certain libraries utilized in Pepr.
+- [Node.js](https://nodejs.org/en/) v18.0.0+ (even-numbered releases only)
+  - To ensure compatability and optimal performance, it is recommended to use even-numbered releases of Node.js as they are stable releases and receive long-term support for three years. Odd-numbered releases are experimental and may not be supported by certain libraries utilized in Pepr.  
+
+- [npm](https://www.npmjs.com/) v10.1.0+  
 
 - Recommended (optional) tools:
   - [Visual Studio Code](https://code.visualstudio.com/) for inline debugging and [Pepr Capabilities](#capability) creation.

--- a/src/lib/schedule.test.ts
+++ b/src/lib/schedule.test.ts
@@ -7,6 +7,10 @@ import { Unsubscribe } from "./storage";
 
 export class MockStorage {
   private storage: Record<string, string> = {};
+  subscription: string;
+  constructor() {
+    this.subscription = "";
+  }
 
   getItem(key: string): string | null {
     return this.storage[key] || null;
@@ -32,10 +36,14 @@ export class MockStorage {
   }
 
   subscribe(): Unsubscribe {
+    // Expected 'this' to be used by class method 'subscribe'
+    this.subscription = "";
     return true as unknown as Unsubscribe;
   }
 
   onReady(): void {
+    // Expected 'this' to be used by class method 'onReady'
+    this.subscription = "";
     return;
   }
 }

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -25,9 +25,14 @@ describe("Storage", () => {
     const mockSender = jest.fn();
     storage.registerSender(mockSender);
     jest.useFakeTimers();
-
-    storage.setItemAndWait("key1", "value1");
-
+    // needed for lint
+    (async () => {
+      try {
+        await storage.setItemAndWait("key1", "value1");
+      } catch (err) {
+        console.log(err);
+      }
+    })();
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
     jest.useRealTimers();
   });

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -25,14 +25,9 @@ describe("Storage", () => {
     const mockSender = jest.fn();
     storage.registerSender(mockSender);
     jest.useFakeTimers();
-    // needed for lint
-    (async () => {
-      try {
-        await storage.setItemAndWait("key1", "value1");
-      } catch (err) {
-        console.log(err);
-      }
-    })();
+
+    storage.setItemAndWait("key1", "value1");
+
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
     jest.useRealTimers();
   });


### PR DESCRIPTION
## Description
While preparing to write release notes for `pepr` and looking back over the `npx pepr build` it became painfully obvious that the Pepr cli was not working on my machine. I tried on my VM and it also didn't work. The problem was the npm version `9.x.x`.

After upgrading `npm` pepr worked as expected. This PR adds to the `npm` version of 10.x to the `README.md` under prereqs.

- Additionally adds more around best practice for `Watch`
- Small linting fixes


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
