### PR TITLE
fix: update to use kubernetes-fluent-client v1.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/ramda": "0.29.9",
         "express": "4.18.2",
         "fast-json-patch": "3.1.1",
-        "kubernetes-fluent-client": "1.8.2",
+        "kubernetes-fluent-client": "1.8.3",
         "pino": "8.16.2",
         "pino-pretty": "10.2.3",
         "prom-client": "15.0.0",
@@ -5669,9 +5669,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-1.8.2.tgz",
-      "integrity": "sha512-dbYWdhSlRziA65r+HClhdWvhbFiUItOSKlYvSGLSSPYZrheNGgq73VDfoU4Kp2To2VIZJVs73xS+HBnDGQz77Q==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-1.8.3.tgz",
+      "integrity": "sha512-U/UFWt++hyBIORelnyp/DKTj2n/q9ubhRYaXJ84NoR4fhN98ur2JN8BH7NLw/Bqda99+yEo38JebM7Xct0uTPQ==",
       "dependencies": {
         "@kubernetes/client-node": "1.0.0-rc3",
         "byline": "5.0.0",
@@ -5679,7 +5679,7 @@
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
         "quicktype-core": "github:defenseunicorns/temp-quicktype-fork#main",
-        "type-fest": "4.5.0",
+        "type-fest": "4.7.1",
         "yargs": "17.7.2"
       },
       "bin": {
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client/node_modules/type-fest": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.5.0.tgz",
-      "integrity": "sha512-diLQivFzddJl4ylL3jxSkEc39Tpw7o1QeEHIPxVwryDK2lpB7Nqhzhuo6v5/Ls08Z0yPSAhsyAWlv1/H0ciNmw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/ramda": "0.29.9",
     "express": "4.18.2",
     "fast-json-patch": "3.1.1",
-    "kubernetes-fluent-client": "1.8.2",
+    "kubernetes-fluent-client": "1.8.3",
     "pino": "8.16.2",
     "pino-pretty": "10.2.3",
     "prom-client": "15.0.0",


### PR DESCRIPTION
## Description

including fix from KFC that contains fix for Core V1 Event (old) --> kind.CoreEvent,  and EventsV1Event --> kind.Event
old: `kubectl get event`
new: `kubectl get events.events.k8s.io`


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ x] Test, docs, adr added or updated as needed
- [ x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
