### PR TITLE
feat!: update `pepr build --entry-point` flag to allow output of deployable module

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,9 @@ Create a [zarf.yaml](https://zarf.dev) and K8s manifest for the current module. 
 
 **Options:**
 
-- `-r, --registry-info [<registry>/<username>]` - Registry Info: Image registry and username. Note: You must be signed into the registry
-- `--rbac-mode [admin|scoped]` - Rbac Mode: admin, scoped (default: admin)
 - `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
+- `-e, --entry-point [file]` - Specify the entry point file to build with. (default: "pepr.ts")
+- `-n, --no-embed` - Disables embedding of deployment files into output module. Useful when creating library modules intended solely for reuse/distribution via NPM
+- `-r, --registry-info [<registry>/<username>]` - Registry Info: Image registry and username. Note: You must be signed into the registry
+- `-o, --output-dir [output directory]` - Define where to place build output
+- `--rbac-mode [admin|scoped]` - Rbac Mode: admin, scoped (default: admin) (choices: "admin", "scoped", default: "admin")

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -24,7 +24,7 @@ export default function (program: RootCmd) {
     .option("-e, --entry-point [file]", "Specify the entry point file to build with.", peprTS)
     .option(
       "-n, --no-embed",
-      "Disables embedding of deployable files into output module.  Useful when creating library modules intended solely for reuse/distribution via NPM.",
+      "Disables embedding of deployment files into output module.  Useful when creating library modules intended solely for reuse/distribution via NPM.",
     )
     .option(
       "-r, --registry-info [<registry>/<username>]",

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -22,7 +22,7 @@ export default function (program: RootCmd) {
     .command("build")
     .description("Build a Pepr Module for deployment")
     .option("-e, --entry-point [file]", "Specify the entry point file to build with.", peprTS)
-    .option("-n, --no-embed", "Disables embedding of NPM packages into output module.")
+    .option("-n, --no-embed", "Disables embedding of deployable files into output module.  Useful when creating library modules intended solely for reuse/distribution via NPM.")
     .option(
       "-r, --registry-info [<registry>/<username>]",
       "Registry Info: Image registry and username. Note: You must be signed into the registry",
@@ -65,7 +65,7 @@ export default function (program: RootCmd) {
         }
       }
 
-      // If building without embedding NPM packages, exit after building
+      // If building without embedding, exit after building
       if (!opts.embed) {
         console.info(`✅ Module built successfully at ${path}`);
         return;
@@ -206,7 +206,7 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
       ctxCfg.minify = false;
     }
 
-    // If not embedding NPM modules
+    // If not embedding (i.e. making a library module to be distro'd via NPM)
     if (!embed) {
       // Don't minify
       ctxCfg.minify = false;

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { BuildOptions, BuildResult, analyzeMetafile, context } from "esbuild";
 import { promises as fs } from "fs";
 import { basename, dirname, extname, resolve } from "path";
@@ -168,7 +168,8 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
     }
 
     // Run `tsc` to validate the module's types & output sourcemaps
-    execSync(`./node_modules/.bin/tsc --project ${modulePath}/tsconfig.json --outdir ${outputDir}`);
+    const args = ["--project", `${modulePath}/tsconfig.json`, "--outdir", outputDir];
+    execFileSync("./node_modules/.bin/tsc", args);
 
     // Common build options for all builds
     const ctxCfg: BuildOptions = {

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -22,7 +22,10 @@ export default function (program: RootCmd) {
     .command("build")
     .description("Build a Pepr Module for deployment")
     .option("-e, --entry-point [file]", "Specify the entry point file to build with.", peprTS)
-    .option("-n, --no-embed", "Disables embedding of deployable files into output module.  Useful when creating library modules intended solely for reuse/distribution via NPM.")
+    .option(
+      "-n, --no-embed",
+      "Disables embedding of deployable files into output module.  Useful when creating library modules intended solely for reuse/distribution via NPM.",
+    )
     .option(
       "-r, --registry-info [<registry>/<username>]",
       "Registry Info: Image registry and username. Note: You must be signed into the registry",

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -4,7 +4,7 @@
 import { execSync } from "child_process";
 import { BuildOptions, BuildResult, analyzeMetafile, context } from "esbuild";
 import { promises as fs } from "fs";
-import { basename, extname, resolve } from "path";
+import { basename, dirname, extname, resolve } from "path";
 import { createDockerfile } from "../lib/included-files";
 import { Assets } from "../lib/assets";
 import { dependencies, version } from "./init/templates";
@@ -21,11 +21,8 @@ export default function (program: RootCmd) {
   program
     .command("build")
     .description("Build a Pepr Module for deployment")
-    .option(
-      "-e, --entry-point [file]",
-      "Specify the entry point file to build with. Note that changing this disables embedding of NPM packages.",
-      peprTS,
-    )
+    .option("-e, --entry-point [file]", "Specify the entry point file to build with.", peprTS)
+    .option("-n, --no-embed", "Disables embedding of NPM packages into output module.")
     .option(
       "-r, --registry-info [<registry>/<username>]",
       "Registry Info: Image registry and username. Note: You must be signed into the registry",
@@ -47,7 +44,7 @@ export default function (program: RootCmd) {
       }
 
       // Build the module
-      const { cfg, path, uuid } = await buildModule(undefined, opts.entryPoint);
+      const { cfg, path, uuid } = await buildModule(undefined, opts.entryPoint, opts.embed);
 
       // Files to include in controller image for WASM support
       const { includedFiles } = cfg.pepr;
@@ -68,8 +65,8 @@ export default function (program: RootCmd) {
         }
       }
 
-      // If building with a custom entry point, exit after building
-      if (opts.entryPoint !== peprTS) {
+      // If building without embedding NPM packages, exit after building
+      if (!opts.embed) {
         console.info(`✅ Module built successfully at ${path}`);
         return;
       }
@@ -114,17 +111,18 @@ externalLibs.push("pepr");
 externalLibs.push("@kubernetes/client-node");
 
 export async function loadModule(entryPoint = peprTS) {
-  // Resolve the path to the module's package.json file
-  const cfgPath = resolve(".", "package.json");
-  const input = resolve(".", entryPoint);
+  // Resolve path to the module / files
+  const entryPointPath = resolve(".", entryPoint);
+  const modulePath = dirname(entryPointPath);
+  const cfgPath = resolve(modulePath, "package.json");
 
   // Ensure the module's package.json and entrypoint files exist
   try {
     await fs.access(cfgPath);
-    await fs.access(input);
+    await fs.access(entryPointPath);
   } catch (e) {
     console.error(
-      `Could not find ${cfgPath} or ${input} in the current directory. Please run this command from the root of your module's directory.`,
+      `Could not find ${cfgPath} or ${entryPointPath} in the current directory. Please run this command from the root of your module's directory.`,
     );
     process.exit(1);
   }
@@ -145,16 +143,17 @@ export async function loadModule(entryPoint = peprTS) {
 
   return {
     cfg,
-    input,
+    entryPointPath,
+    modulePath,
     name,
     path: resolve(outputDir, name),
     uuid,
   };
 }
 
-export async function buildModule(reloader?: Reloader, entryPoint = peprTS) {
+export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embed = true) {
   try {
-    const { cfg, path, uuid } = await loadModule(entryPoint);
+    const { cfg, modulePath, path, uuid } = await loadModule(entryPoint);
 
     const validFormat = await peprFormat(true);
 
@@ -165,8 +164,8 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS) {
       );
     }
 
-    // Run `tsc` to validate the module's types
-    execSync("./node_modules/.bin/tsc", { stdio: "pipe" });
+    // Run `tsc` to validate the module's types & output sourcemaps
+    execSync(`./node_modules/.bin/tsc --project ${modulePath}/tsconfig.json --outdir ${outputDir}`);
 
     // Common build options for all builds
     const ctxCfg: BuildOptions = {
@@ -207,18 +206,18 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS) {
       ctxCfg.minify = false;
     }
 
-    // Handle custom entry points
-    if (entryPoint !== peprTS) {
-      // Don't minify if we're using a custom entry point
+    // If not embedding NPM modules
+    if (!embed) {
+      // Don't minify
       ctxCfg.minify = false;
 
-      // Preserve the original file name if we're using a custom entry point
+      // Preserve the original file name
       ctxCfg.outfile = resolve(outputDir, basename(entryPoint, extname(entryPoint))) + ".js";
 
-      // Only bundle the NPM packages if we're not using a custom entry point
+      // Don't bundle
       ctxCfg.packages = "external";
 
-      // Don't tree shake if we're using a custom entry point
+      // Don't tree shake
       ctxCfg.treeShaking = false;
     }
 

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -26,7 +26,8 @@ describe("Storage", () => {
     storage.registerSender(mockSender);
     jest.useFakeTimers();
 
-    storage.setItemAndWait("key1", "value1");
+    // asserting on sender invocation rather than Promise so no need to wait
+    void storage.setItemAndWait("key1", "value1");
 
     expect(mockSender).toHaveBeenCalledWith("add", ["key1"], "value1");
     jest.useRealTimers();

--- a/website/content/en/docs/cli.md
+++ b/website/content/en/docs/cli.md
@@ -59,6 +59,9 @@ Create a [zarf.yaml](https://zarf.dev) and K8s manifest for the current module. 
 
 **Options:**
 
-- `-r, --registry-info [<registry>/<username>]` - Registry Info: Image registry and username. Note: You must be signed into the registry
-- `--rbac-mode [admin|scoped]` - Rbac Mode: admin, scoped (default: admin)
 - `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
+- `-e, --entry-point [file]` - Specify the entry point file to build with. (default: "pepr.ts")
+- `-n, --no-embed` - Disables embedding of deployment files into output module. Useful when creating library modules intended solely for reuse/distribution via NPM
+- `-r, --registry-info [<registry>/<username>]` - Registry Info: Image registry and username. Note: You must be signed into the registry
+- `-o, --output-dir [output directory]` - Define where to place build output
+- `--rbac-mode [admin|scoped]` - Rbac Mode: admin, scoped (default: admin) (choices: "admin", "scoped", default: "admin")


### PR DESCRIPTION
## Description
As part of trying to establish a nice e2e test pattern for individual Pepr Capabilities within a Module project, I want to be able to specify both the target output directory (`--output-dir`) and the desired entrypoint .ts file (`--entry-point`) **while also** outputting a fully-packed & deployable Module.

While calling `pepr build` with this combination of the flags is already possible, and while the (current) `--entry-point` flag implementation allows specification of the entrypoint file to use _it also_ changes the way the module gets built such that the output module is no longer independently deployable.

This PR changes the way the `--entry-point` flag works to make it output fully a deployable module and instead adds a new flag: `--no-embed` to cover the pre-existing behavior.  This allows use of the flags `--output-dir` and `--entry-point` together to fully specify what-gets-built-and-where while still allowing callers to opt-in to the previous behavior with the new flag (`--no-embed`).

## Related Issue

Fixes #392 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)
- [x] Breaking-change-as-part-of-adding-new-feature

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
