### PR TITLE
fix: add binding to OnSchedule

### DIFF
--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -51,7 +51,7 @@ export class Capability implements CapabilityExport {
 
     // creates isWatch binding so it runs in the watch controller
     this.#bindings.push(generateScheduleBinding(name));
-
+    this.hasSchedule = true;
     // Create a new schedule
     const newSchedule: Schedule = {
       name,

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -8,7 +8,7 @@ import { pickBy } from "ramda";
 import Log from "./logger";
 import { isBuildMode, isDevMode, isWatchMode } from "./module";
 import { PeprStore, Storage } from "./storage";
-import { OnSchedule, Schedule } from "./schedule";
+import { OnSchedule, Schedule, generateScheduleBinding } from "./schedule";
 import {
   Binding,
   BindingFilter,
@@ -49,24 +49,22 @@ export class Capability implements CapabilityExport {
   OnSchedule: (schedule: Schedule) => void = (schedule: Schedule) => {
     const { name, every, unit, run, startTime, completions } = schedule;
 
-    if (process.env.PEPR_WATCH_MODE === "true") {
-      // Only create/watch schedule store if necessary
-      this.hasSchedule = true;
+    // creates isWatch binding so it runs in the watch controller
+    this.#bindings.push(generateScheduleBinding(name));
 
-      // Create a new schedule
-      const newSchedule: Schedule = {
-        name,
-        every,
-        unit,
-        run,
-        startTime,
-        completions,
-      };
+    // Create a new schedule
+    const newSchedule: Schedule = {
+      name,
+      every,
+      unit,
+      run,
+      startTime,
+      completions,
+    };
 
-      this.#scheduleStore.onReady(() => {
-        new OnSchedule(newSchedule).setStore(this.#scheduleStore);
-      });
-    }
+    this.#scheduleStore.onReady(() => {
+      new OnSchedule(newSchedule).setStore(this.#scheduleStore);
+    });
   };
 
   /**

--- a/src/lib/schedule.test.ts
+++ b/src/lib/schedule.test.ts
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { beforeEach, describe, expect, it, jest, afterEach } from "@jest/globals";
-import { OnSchedule, Schedule } from "./schedule";
+import { OnSchedule, Schedule, generateScheduleBinding } from "./schedule";
 import { Unsubscribe } from "./storage";
+import { Binding } from "./types";
+import { GroupVersionKind } from "kubernetes-fluent-client";
 
 export class MockStorage {
   private storage: Record<string, string> = {};
@@ -47,6 +49,30 @@ export class MockStorage {
     return;
   }
 }
+
+describe("generateScheduleBinding", () => {
+  it("generates a Binding for OnSchedule", () => {
+    const testName = "testOnSchedule";
+    const expectedGVK: GroupVersionKind = {
+      kind: "OnSchedule",
+      group: "pepr.dev",
+      version: "v1alpha1",
+    };
+
+    const binding: Binding = generateScheduleBinding(testName);
+
+    expect(binding.event).toBeDefined();
+    expect(binding.isWatch).toBe(true);
+    expect(binding.model).toBeDefined();
+    expect(binding.kind).toEqual(expectedGVK);
+    expect(binding.filters).toEqual({
+      name: testName,
+      namespaces: [],
+      labels: { schedule: testName },
+      annotations: { schedule: testName },
+    });
+  });
+});
 
 describe("OnSchedule", () => {
   const mockSchedule: Schedule = {

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -2,9 +2,32 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { PeprStore } from "./storage";
+import { Binding, Event } from "./types";
+import { GroupVersionKind } from "kubernetes-fluent-client";
 
 type Unit = "seconds" | "second" | "minute" | "minutes" | "hours" | "hour";
 
+abstract class GenericSchedule {}
+
+// Example GroupVersionKind
+const scheduleGVK: GroupVersionKind = {
+  kind: "OnSchedule",
+  group: "pepr.dev",
+  version: "v1alpha1",
+};
+
+export const generateScheduleBinding = (name: string): Binding => ({
+  event: Event.Any,
+  isWatch: true,
+  model: GenericSchedule,
+  kind: scheduleGVK,
+  filters: {
+    name: name,
+    namespaces: [],
+    labels: { schedule: name },
+    annotations: { schedule: name },
+  },
+});
 export interface Schedule {
   /**
    * * The name of the store

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -28,12 +28,12 @@ describe("WatchProcessor", () => {
     const capabilities = [
       {
         bindings: [
-          { isWatch: true, model: "someModel", filters: { name: "bleh" }, event: "Create" },
-          { isWatch: false, model: "someModel", filters: {}, event: "Create" },
+          { isWatch: true, model: "someModel", filters: { name: "bleh" }, event: "Create", kind: { kind: "someKind" } },
+          { isWatch: false, model: "someModel", filters: {}, event: "Create", kind: { kind: "someKind" } },
         ],
       },
       {
-        bindings: [{ isWatch: true, model: "someModel", filters: {}, event: "Create" }],
+        bindings: [{ isWatch: true, model: "someModel", filters: {}, event: "Create", kind: { kind: "someKind" } }],
       },
     ] as unknown as Capability[];
 
@@ -73,9 +73,30 @@ describe("WatchProcessor", () => {
     const capabilities = [
       {
         bindings: [
-          { isWatch: true, model: "someModel", filters: {}, event: "Create", watchCallback: watchCallbackCreate },
-          { isWatch: true, model: "someModel", filters: {}, event: "Update", watchCallback: watchCallbackUpdate },
-          { isWatch: true, model: "someModel", filters: {}, event: "Delete", watchCallback: watchCallbackDelete },
+          {
+            kind: { kind: "someKind" },
+            isWatch: true,
+            model: "someModel",
+            filters: {},
+            event: "Create",
+            watchCallback: watchCallbackCreate,
+          },
+          {
+            kind: { kind: "someKind" },
+            isWatch: true,
+            model: "someModel",
+            filters: {},
+            event: "Update",
+            watchCallback: watchCallbackUpdate,
+          },
+          {
+            kind: { kind: "someKind" },
+            isWatch: true,
+            model: "someModel",
+            filters: {},
+            event: "Delete",
+            watchCallback: watchCallbackDelete,
+          },
           // Add more events here
         ],
       },

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -12,7 +12,7 @@ import { Binding, Event } from "./types";
 export function setupWatch(capabilities: Capability[]) {
   capabilities
     .flatMap(c => c.bindings)
-    .filter(binding => binding.isWatch)
+    .filter(binding => binding.isWatch && binding.kind.kind !== "OnSchedule")
     .forEach(runBinding);
 }
 


### PR DESCRIPTION
## Description

The `OnSchedule` implementation needed a binding with `isWatch` in order to be deployed onto the Watch controller

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
