### PR TITLE
feat: add labels to kube artifacts

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,3 +67,43 @@ GET /metrics
   pepr_Validate_sum 402.4275380000472
   pepr_Validate_count 2
 ```
+
+## Prometheus Operator
+
+If using the Prometheus Operator, the following `ServiceMonitor` example manifests can be used to scrape the `/metrics` endpoint for the `admission` and `watcher` controllers.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: admission
+spec:
+  selector:
+    matchLabels:
+      pepr.dev/controller: admission
+  namespaceSelector:
+    matchNames:
+    - pepr-system
+  endpoints:
+  - targetPort: 3000
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: watcher
+spec:
+  selector:
+    matchLabels:
+      pepr.dev/controller: watcher
+  namespaceSelector:
+    matchNames:
+    - pepr-system 
+  endpoints:
+  - targetPort: 3000
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+```

--- a/src/lib/assets/networking.ts
+++ b/src/lib/assets/networking.ts
@@ -43,10 +43,14 @@ export function service(name: string): kind.Service {
     metadata: {
       name,
       namespace: "pepr-system",
+      labels: {
+        "pepr.dev/controller": "admission",
+      },
     },
     spec: {
       selector: {
         app: name,
+        "pepr.dev/controller": "admission",
       },
       ports: [
         {
@@ -65,10 +69,14 @@ export function watcherService(name: string): kind.Service {
     metadata: {
       name: `${name}-watcher`,
       namespace: "pepr-system",
+      labels: {
+        "pepr.dev/controller": "watcher",
+      },
     },
     spec: {
       selector: {
         app: `${name}-watcher`,
+        "pepr.dev/controller": "watcher",
       },
       ports: [
         {

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -45,6 +45,7 @@ export function watcher(assets: Assets, hash: string) {
       namespace: "pepr-system",
       labels: {
         app,
+        "pepr.dev/controller": "watcher",
       },
     },
     spec: {
@@ -55,12 +56,14 @@ export function watcher(assets: Assets, hash: string) {
       selector: {
         matchLabels: {
           app,
+          "pepr.dev/controller": "watcher",
         },
       },
       template: {
         metadata: {
           labels: {
             app,
+            "pepr.dev/controller": "watcher",
           },
         },
         spec: {
@@ -151,6 +154,7 @@ export function deployment(assets: Assets, hash: string): kind.Deployment {
       namespace: "pepr-system",
       labels: {
         app,
+        "pepr.dev/controller": "admission",
       },
     },
     spec: {
@@ -158,12 +162,14 @@ export function deployment(assets: Assets, hash: string): kind.Deployment {
       selector: {
         matchLabels: {
           app,
+          "pepr.dev/controller": "admission",
         },
       },
       template: {
         metadata: {
           labels: {
             app,
+            "pepr.dev/controller": "admission",
           },
         },
         spec: {

--- a/website/content/en/docs/metrics.md
+++ b/website/content/en/docs/metrics.md
@@ -72,3 +72,42 @@ GET /metrics
   pepr_Validate_sum 402.4275380000472
   pepr_Validate_count 2
 ```
+## Prometheus Operator
+
+If using the Prometheus Operator, the following `ServiceMonitor` example manifests can be used to scrape the `/metrics` endpoint for the `admission` and `watcher` controllers.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: admission
+spec:
+  selector:
+    matchLabels:
+      pepr.dev/controller: admission
+  namespaceSelector:
+    matchNames:
+    - pepr-system
+  endpoints:
+  - targetPort: 3000
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: watcher
+spec:
+  selector:
+    matchLabels:
+      pepr.dev/controller: watcher
+  namespaceSelector:
+    matchNames:
+    - pepr-system 
+  endpoints:
+  - targetPort: 3000
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+```


### PR DESCRIPTION
## Description

This PR is a draft and discussion around adding labels to kube artifacts to distinguish what is what. For instance, I may want to get logs from only the watcher or admission pods without looking up the pod/deployment or uuid names. It also creates a method for scraping services using a `ServiceMonitor`'s `MatchLabel`. This PR was created while writing documentation around scraping the Pepr services with Prometheus.

It also provides documentation how to scrape the Pepr services. Use this [gist](https://gist.github.com/cmwylie19/f9503ddebe848616a4e8891bfaeafb3e) as a guide if needed

End Result:

```bash
┌─[cmwylie19@Cases-MacBook-Pro] - [~/pepr] - [2023-12-07 04:21:28]
└─[0] <git:(426 324b16f) > k get svc,po,deploy -n pepr-system  --show-labels     
NAME                               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE     LABELS
service/pepr-static-test           ClusterIP   10.43.9.3      <none>        443/TCP   5m24s   pepr.dev/controller=admission
service/pepr-static-test-watcher   ClusterIP   10.43.75.252   <none>        443/TCP   5m24s   pepr.dev/controller=watcher

NAME                                            READY   STATUS    RESTARTS   AGE     LABELS
pod/pepr-static-test-b7f858d7-fsx5z             1/1     Running   0          5m24s   app=pepr-static-test,pepr.dev/controller=admission,pod-template-hash=b7f858d7
pod/pepr-static-test-b7f858d7-vr89k             1/1     Running   0          5m24s   app=pepr-static-test,pepr.dev/controller=admission,pod-template-hash=b7f858d7
pod/pepr-static-test-watcher-78647f6bbd-8jckv   1/1     Running   0          5m24s   app=pepr-static-test-watcher,pepr.dev/controller=watcher,pod-template-hash=78647f6bbd

NAME                                       READY   UP-TO-DATE   AVAILABLE   AGE     LABELS
deployment.apps/pepr-static-test           2/2     2            2           5m24s   app=pepr-static-test,pepr.dev/controller=admission
deployment.apps/pepr-static-test-watcher   1/1     1            1           5m24s   app=pepr-static-test-watcher,pepr.dev/controller=watcher
```

## Related Issue

Fixes #426 
<!-- or -->
Relates to #412

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
