### PR TITLE
chore: connect failurePolicy to package.json onError

### DIFF
--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -129,7 +129,7 @@ export async function webhookConfig(
         name: `${name}.pepr.dev`,
         admissionReviewVersions: ["v1", "v1beta1"],
         clientConfig,
-        failurePolicy: "Ignore",
+        failurePolicy: config.onError === "reject" ? "Fail" : "Ignore" ,
         matchPolicy: "Equivalent",
         timeoutSeconds,
         namespaceSelector: {

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -129,7 +129,7 @@ export async function webhookConfig(
         name: `${name}.pepr.dev`,
         admissionReviewVersions: ["v1", "v1beta1"],
         clientConfig,
-        failurePolicy: config.onError === "reject" ? "Fail" : "Ignore" ,
+        failurePolicy: config.onError === "reject" ? "Fail" : "Ignore",
         matchPolicy: "Equivalent",
         timeoutSeconds,
         namespaceSelector: {


### PR DESCRIPTION
## Description

@bburky brought up a potential security thread related to the webhook configurations's `failurePolicy`. Currently, the failurePolicy is always ignore and there is no way to change it, this prove be danger to a ValidatingAdmission Webook or even a Mutating that is supposed to remove capability and securityContexts because it can cause the webhoook to _ignore the object and pass it into the cluster_.

During `npx pepr init` there is a prompt about:

```bash
? How do you want Pepr to handle errors encountered during K8s operations? › - Use arrow-keys. Return to submit.
❯   Ignore - Pepr will continue processing and generate an entry in the Pepr Controller log.
    Log an audit event
    Reject the operation
```

Based on this response, the package.json is populated with `onError` section:

```json
 "pepr": {
    "name": "pepr-test-module",
    "uuid": "static-test",
    "onError": "reject", // <----- HERE
    "alwaysIgnore": {
      "namespaces": [],
      "labels": []
    },
    "includedFiles": []
  },
```

If `reject` is present on the onError section then the failurePolicy generated during a `npx pepr build` will be `Fail`.

## Related Issue

Fixes #434 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
