### PR TITLE
feat: add controller env variables from package.json Pepr config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pepr is on a mission to save Kubernetes from the tyranny of YAML, intimidating g
 - Entire NPM ecosystem available for advanced operations
 - Realtime K8s debugging system for testing/reacting to cluster changes
 - Controller network isolation and tamper-resistent module execution
-- Automatic least-privilege RBAC generation [soon](https://github.com/defenseunicorns/pepr/issues/31)
+- Least-privilege [RBAC](https://github.com/defenseunicorns/pepr/blob/main/docs/rbac.md) generation
 - AMD64 and ARM64 support
 
 ## Example Pepr Action

--- a/journey/pepr-build.ts
+++ b/journey/pepr-build.ts
@@ -66,4 +66,6 @@ async function validateZarfYaml() {
 
   // Check the generated k8s yaml
   expect(k8sYaml).toMatch(`image: ${expectedImage}`);
+  expect(k8sYaml).toMatch(`name: MY_CUSTOM_VAR`);
+  expect(k8sYaml).toMatch(`value: example-value`);
 }

--- a/journey/pepr-build.ts
+++ b/journey/pepr-build.ts
@@ -68,4 +68,6 @@ async function validateZarfYaml() {
   expect(k8sYaml).toMatch(`image: ${expectedImage}`);
   expect(k8sYaml).toMatch(`name: MY_CUSTOM_VAR`);
   expect(k8sYaml).toMatch(`value: example-value`);
+  expect(k8sYaml).toMatch(`name: ZARF_VAR`);
+  expect(k8sYaml).toMatch(`value: '###ZARF_VAR_THING###'`);
 }

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -42,6 +42,9 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string) {
         labels: [],
       },
       includedFiles: [],
+      env: {
+        MY_CUSTOM_VAR: "example-value",
+      },
     },
     scripts: {
       "k3d-setup": scripts["test:journey:k3d"],

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -25,6 +25,11 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string) {
   // Make typescript a dev dependency
   const { typescript } = peerDependencies;
 
+  const testEnv = {
+    MY_CUSTOM_VAR: "example-value",
+    ZARF_VAR: "###ZARF_VAR_THING###",
+  };
+
   const data = {
     name,
     version: "0.0.1",
@@ -42,9 +47,7 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string) {
         labels: [],
       },
       includedFiles: [],
-      env: {
-        MY_CUSTOM_VAR: "example-value",
-      },
+      env: pgkVerOverride ? testEnv : {},
     },
     scripts: {
       "k3d-setup": scripts["test:journey:k3d"],

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -28,6 +28,8 @@ export type ModuleConfig = {
   alwaysIgnore: WebhookIgnore;
   /** Define the log level for the in-cluster controllers */
   logLevel?: string;
+  /** Propagate env variables to in-cluster controllers */
+  env?: Record<string, string>;
 };
 
 export type PackageJSON = {


### PR DESCRIPTION
## Description

This allows user to specify custom env variables in the `package.json` Pepr Config that will be injected into the controller env variables. The immediate use for [UDS Core](https://github.com/defenseunicorns/uds-core) will be in combination with Zarf variables to allow for a sort of simple global config without needing to watch or get another K8s resource and deal with race conditions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
