### PR TITLE
chore: kubernetes slack channel for pepr and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [actions](./docs/actions.md) for more details.
 
 ## Community
 
-Become a part of our community by connecting with developers on the [#Pepr](https://pepr.dev/slack) channel, hosted on the K8s Slack platform. Our growing group of developers, users, and contributors is always ready to help with queries, exchange examples, and explore innovative uses of Pepr together!
+Become a part of our community by connecting with developers in the `#pepr` channel on Kubernetes Slack. Our growing group of developers, users, and contributors is always ready to help with queries, exchange examples, and explore innovative uses of Pepr together!
 
 To join our channel go to [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community) and join the `#pepr` channel.
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ See [actions](./docs/actions.md) for more details.
 
 ## Community
 
-Become a part of our vibrant community by connecting with developers on the [#Pepr](https://pepr.dev/slack) channel, hosted on the K8s Slack platform. Our dynamic group of developers, users, and contributors is always ready to help with queries, exchange examples, and explore innovative uses of Pepr together!
+Become a part of our community by connecting with developers on the [#Pepr](https://pepr.dev/slack) channel, hosted on the K8s Slack platform. Our growing group of developers, users, and contributors is always ready to help with queries, exchange examples, and explore innovative uses of Pepr together!
 
-We deeply appreciate the contributions of our Pepr community, from fixing bugs to collaborating on the development of new features.
+To join our channel go to [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community) and join the `#pepr` channel.
 
 <a href="https://github.com/defenseunicorns/pepr/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=defenseunicorns/pepr" />

--- a/README.md
+++ b/README.md
@@ -139,3 +139,15 @@ See [actions](./docs/actions.md) for more details.
 ## TypeScript
 
 [TypeScript](https://www.typescriptlang.org/) is a strongly typed, object-oriented programming language built on top of JavaScript. It provides optional static typing and a rich type system, allowing developers to write more robust code. TypeScript is transpiled to JavaScript, enabling it to run in any environment that supports JavaScript. Pepr allows you to use JavaScript or TypeScript to write capabilities, but TypeScript is recommended for its type safety and rich type system. You can learn more about TypeScript [here](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html).
+
+## Community
+
+Become a part of our vibrant community by connecting with developers on the [#Pepr](https://pepr.dev/slack) channel, hosted on the K8s Slack platform. Our dynamic group of developers, users, and contributors is always ready to help with queries, exchange examples, and explore innovative uses of Pepr together!
+
+We deeply appreciate the contributions of our Pepr community, from fixing bugs to collaborating on the development of new features.
+
+<a href="https://github.com/defenseunicorns/pepr/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=defenseunicorns/pepr" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ See [actions](./docs/actions.md) for more details.
 
 ## Community
 
-Become a part of our community by connecting with developers in the `#pepr` channel on Kubernetes Slack. Our growing group of developers, users, and contributors is always ready to help with queries, exchange examples, and explore innovative uses of Pepr together!
-
 To join our channel go to [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community) and join the `#pepr` channel.
 
 <a href="https://github.com/defenseunicorns/pepr/graphs/contributors">


### PR DESCRIPTION
## Description

TODO
- [x] Update website to have `https://pepr.dev/slack` [Issue](https://github.com/defenseunicorns/pepr-website/issues/40)
- [x] Officially have the slack channel open [Link to PR](https://github.com/kubernetes/community/pull/7672)


## Related Issue

Fixes #462 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
