### PR TITLE
feat: force option on npx pepr deploy

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -16,10 +16,6 @@ export default function (program: RootCmd) {
     .option("--confirm", "Skip confirmation prompt")
     .option("--force", "Force deploy the module, override manager field")
     .action(async opts => {
-      let force = false;
-      if (opts.force) {
-        force = true;
-      }
       if (!opts.confirm) {
         // Prompt the user to confirm
         const confirm = await prompt({
@@ -51,7 +47,7 @@ export default function (program: RootCmd) {
       }
 
       try {
-        await webhook.deploy(force);
+        await webhook.deploy(opts.force);
         // Wait for the pepr-system resources to be fully up
         await namespaceDeploymentsReady();
         console.info(`✅ Module deployed successfully`);

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -16,6 +16,10 @@ export default function (program: RootCmd) {
     .option("--confirm", "Skip confirmation prompt")
     .option("--force", "Force deploy the module, override manager field")
     .action(async opts => {
+      let force = false;
+      if (opts.force) {
+        force = true;
+      }
       if (!opts.confirm) {
         // Prompt the user to confirm
         const confirm = await prompt({
@@ -47,7 +51,7 @@ export default function (program: RootCmd) {
       }
 
       try {
-        await webhook.deploy(opts.force);
+        await webhook.deploy(force);
         // Wait for the pepr-system resources to be fully up
         await namespaceDeploymentsReady();
         console.info(`✅ Module deployed successfully`);

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -14,6 +14,7 @@ export default function (program: RootCmd) {
     .description("Deploy a Pepr Module")
     .option("-i, --image [image]", "Override the image tag")
     .option("--confirm", "Skip confirmation prompt")
+    .option("--force", "Force deploy the module, override manager field")
     .action(async opts => {
       if (!opts.confirm) {
         // Prompt the user to confirm
@@ -46,7 +47,7 @@ export default function (program: RootCmd) {
       }
 
       try {
-        await webhook.deploy();
+        await webhook.deploy(opts.force);
         // Wait for the pepr-system resources to be fully up
         await namespaceDeploymentsReady();
         console.info(`✅ Module deployed successfully`);

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -54,8 +54,8 @@ export default function (program: RootCmd) {
         const runFork = async () => {
           console.info(`Running module ${path}`);
 
-          // Deploy the webhook with a 30 second timeout for debugging
-          await webhook.deploy(30);
+          // Deploy the webhook with a 30 second timeout for debugging, don't force
+          await webhook.deploy(false, 30);
 
           program = fork(path, {
             env: {

--- a/src/lib/assets/deploy.ts
+++ b/src/lib/assets/deploy.ts
@@ -14,7 +14,7 @@ import { peprStoreCRD } from "./store";
 import { webhookConfig } from "./webhooks";
 import { CapabilityExport } from "../types";
 
-export async function deploy(assets: Assets, force: boolean = false, webhookTimeout?: number) {
+export async function deploy(assets: Assets, force: boolean, webhookTimeout?: number) {
   Log.info("Establishing connection to Kubernetes");
 
   const { name, host, path } = assets;
@@ -62,7 +62,7 @@ export async function deploy(assets: Assets, force: boolean = false, webhookTime
   await setupWatcher(assets, hash, force);
 }
 
-async function setupRBAC(name: string, capabilities: CapabilityExport[], force: boolean = false) {
+async function setupRBAC(name: string, capabilities: CapabilityExport[], force: boolean) {
   Log.info("Applying cluster role binding");
   const crb = clusterRoleBinding(name);
   await K8s(kind.ClusterRoleBinding).Apply(crb, { force });
@@ -84,7 +84,7 @@ async function setupRBAC(name: string, capabilities: CapabilityExport[], force: 
   await K8s(kind.RoleBinding).Apply(roleBinding, { force });
 }
 
-async function setupController(assets: Assets, code: Buffer, hash: string, force: boolean = false) {
+async function setupController(assets: Assets, code: Buffer, hash: string, force: boolean) {
   const { name } = assets;
 
   Log.info("Applying module secret");
@@ -108,7 +108,7 @@ async function setupController(assets: Assets, code: Buffer, hash: string, force
   await K8s(kind.Deployment).Apply(dep, { force });
 }
 
-async function setupWatcher(assets: Assets, hash: string, force: boolean = false) {
+async function setupWatcher(assets: Assets, hash: string, force: boolean) {
   // If the module has a watcher, deploy it
   const watchDeployment = watcher(assets, hash);
   if (watchDeployment) {

--- a/src/lib/assets/deploy.ts
+++ b/src/lib/assets/deploy.ts
@@ -14,7 +14,7 @@ import { peprStoreCRD } from "./store";
 import { webhookConfig } from "./webhooks";
 import { CapabilityExport } from "../types";
 
-export async function deploy(assets: Assets, webhookTimeout?: number) {
+export async function deploy(assets: Assets, force: boolean = false, webhookTimeout?: number) {
   Log.info("Establishing connection to Kubernetes");
 
   const { name, host, path } = assets;
@@ -26,7 +26,7 @@ export async function deploy(assets: Assets, webhookTimeout?: number) {
   const mutateWebhook = await webhookConfig(assets, "mutate", webhookTimeout);
   if (mutateWebhook) {
     Log.info("Applying mutating webhook");
-    await K8s(kind.MutatingWebhookConfiguration).Apply(mutateWebhook);
+    await K8s(kind.MutatingWebhookConfiguration).Apply(mutateWebhook, { force });
   } else {
     Log.info("Mutating webhook not needed, removing if it exists");
     await K8s(kind.MutatingWebhookConfiguration).Delete(name);
@@ -36,14 +36,14 @@ export async function deploy(assets: Assets, webhookTimeout?: number) {
   const validateWebhook = await webhookConfig(assets, "validate", webhookTimeout);
   if (validateWebhook) {
     Log.info("Applying validating webhook");
-    await K8s(kind.ValidatingWebhookConfiguration).Apply(validateWebhook);
+    await K8s(kind.ValidatingWebhookConfiguration).Apply(validateWebhook, { force });
   } else {
     Log.info("Validating webhook not needed, removing if it exists");
     await K8s(kind.ValidatingWebhookConfiguration).Delete(name);
   }
 
   Log.info("Applying the Pepr Store CRD if it doesn't exist");
-  await K8s(kind.CustomResourceDefinition).Apply(peprStoreCRD);
+  await K8s(kind.CustomResourceDefinition).Apply(peprStoreCRD, { force });
 
   // If a host is specified, we don't need to deploy the rest of the resources
   if (host) {
@@ -57,66 +57,66 @@ export async function deploy(assets: Assets, webhookTimeout?: number) {
     throw new Error("No code provided");
   }
 
-  await setupRBAC(name, assets.capabilities);
-  await setupController(assets, code, hash);
-  await setupWatcher(assets, hash);
+  await setupRBAC(name, assets.capabilities, force);
+  await setupController(assets, code, hash, force);
+  await setupWatcher(assets, hash, force);
 }
 
-async function setupRBAC(name: string, capabilities: CapabilityExport[]) {
+async function setupRBAC(name: string, capabilities: CapabilityExport[], force: boolean = false) {
   Log.info("Applying cluster role binding");
   const crb = clusterRoleBinding(name);
-  await K8s(kind.ClusterRoleBinding).Apply(crb);
+  await K8s(kind.ClusterRoleBinding).Apply(crb, { force });
 
   Log.info("Applying cluster role");
   const cr = clusterRole(name, capabilities);
-  await K8s(kind.ClusterRole).Apply(cr);
+  await K8s(kind.ClusterRole).Apply(cr, { force });
 
   Log.info("Applying service account");
   const sa = serviceAccount(name);
-  await K8s(kind.ServiceAccount).Apply(sa);
+  await K8s(kind.ServiceAccount).Apply(sa, { force });
 
   Log.info("Applying store role");
   const role = storeRole(name);
-  await K8s(kind.Role).Apply(role);
+  await K8s(kind.Role).Apply(role, { force });
 
   Log.info("Applying store role binding");
   const roleBinding = storeRoleBinding(name);
-  await K8s(kind.RoleBinding).Apply(roleBinding);
+  await K8s(kind.RoleBinding).Apply(roleBinding, { force });
 }
 
-async function setupController(assets: Assets, code: Buffer, hash: string) {
+async function setupController(assets: Assets, code: Buffer, hash: string, force: boolean = false) {
   const { name } = assets;
 
   Log.info("Applying module secret");
   const mod = moduleSecret(name, code, hash);
-  await K8s(kind.Secret).Apply(mod);
+  await K8s(kind.Secret).Apply(mod, { force });
 
   Log.info("Applying controller service");
   const svc = service(name);
-  await K8s(kind.Service).Apply(svc);
+  await K8s(kind.Service).Apply(svc, { force });
 
   Log.info("Applying TLS secret");
   const tls = tlsSecret(name, assets.tls);
-  await K8s(kind.Secret).Apply(tls);
+  await K8s(kind.Secret).Apply(tls, { force });
 
   Log.info("Applying API token secret");
   const apiToken = apiTokenSecret(name, assets.apiToken);
-  await K8s(kind.Secret).Apply(apiToken);
+  await K8s(kind.Secret).Apply(apiToken, { force });
 
   Log.info("Applying deployment");
   const dep = deployment(assets, hash);
-  await K8s(kind.Deployment).Apply(dep);
+  await K8s(kind.Deployment).Apply(dep, { force });
 }
 
-async function setupWatcher(assets: Assets, hash: string) {
+async function setupWatcher(assets: Assets, hash: string, force: boolean = false) {
   // If the module has a watcher, deploy it
   const watchDeployment = watcher(assets, hash);
   if (watchDeployment) {
     Log.info("Applying watcher deployment");
-    await K8s(kind.Deployment).Apply(watchDeployment);
+    await K8s(kind.Deployment).Apply(watchDeployment, { force });
 
     Log.info("Applying watcher service");
     const watchSvc = watcherService(assets.name);
-    await K8s(kind.Service).Apply(watchSvc);
+    await K8s(kind.Service).Apply(watchSvc, { force });
   }
 }

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -37,7 +37,7 @@ export class Assets {
     this.apiToken = crypto.randomBytes(32).toString("hex");
   }
 
-  deploy = async (force: boolean = false, webhookTimeout?: number) => {
+  deploy = async (force: boolean, webhookTimeout?: number) => {
     this.capabilities = await loadCapabilities(this.path);
     await deploy(this, force, webhookTimeout);
   };

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -37,9 +37,9 @@ export class Assets {
     this.apiToken = crypto.randomBytes(32).toString("hex");
   }
 
-  deploy = async (webhookTimeout?: number) => {
+  deploy = async (force: boolean = false, webhookTimeout?: number) => {
     this.capabilities = await loadCapabilities(this.path);
-    await deploy(this, webhookTimeout);
+    await deploy(this, force, webhookTimeout);
   };
 
   zarfYaml = (path: string) => zarfYaml(this, path);


### PR DESCRIPTION
## Description

`npx pepr dev` uses Server Side Apply which has field managers. During an upgrade where `kubectl` or a different manager than Pepr was the initial deployer a `--force` option is necessary to allow Pepr to override the manager and deploy 

## Related Issue

Fixes #474 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
