### PR TITLE
feat: add timestamp to podSpec annotations force rollout on deployments

### DIFF
--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -63,6 +63,9 @@ export function watcher(assets: Assets, hash: string) {
       },
       template: {
         metadata: {
+          annotations: {
+            buildTimestamp: `${Date.now()}`,
+          },
           labels: {
             app,
             "pepr.dev/controller": "watcher",
@@ -180,6 +183,9 @@ export function deployment(assets: Assets, hash: string): kind.Deployment {
       },
       template: {
         metadata: {
+          annotations: {
+            buildTimestamp: `${Date.now()}`,
+          },
           labels: {
             app,
             "pepr.dev/controller": "admission",


### PR DESCRIPTION
## Description

Consecutive builds of `npx pepr build` or upgrading versions and rebuilding rotates tls credentials and the module code (secrets) but does not guarantee that the deployment has any updates that will force rollout.

This PR adds an timestamp annotation to the Deployment's podSpec to force a new rollout on each apply in the cluster after a build. Thanks @mjnagel 


## Related Issue

Fixes #477 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
