### PR TITLE
feat: enable docs build on published release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,9 @@ on:
     paths: ["docs/**.md"]
 
 
-  # enable triggering when releases are pub'd
-  # release:
-  #   types: [published]
+  enable triggering when releases are pub'd
+  release:
+    types: [published]
 
 jobs:
   


### PR DESCRIPTION
## Description

Enables build & publish of pepr-docs on pepr release.  Automation go!

Fixes #485 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
