### PR TITLE
feat: make module_uuid optional

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -1,64 +1,12 @@
-# Pepr Best Practices
+# Pepr Best Practices (WIP)
 
 ## TOC
 
-- [Deployment](#deployment)
-- [Keep Modules Small](#keep-modules-small)
-- [core development](#core-development)
-- [debugging](#debugging)
-- [OnSchedule](#onschedule)
-- [Security](#security)
-- [monitoring](#monitoring)
 - [Store](#pepr-store)
+- [OnSchedule](#onschedule)
 - [Watch](#watch)
-- [multiple-modules-or-multiple-capabilities](#multiple-modules-or-multiple-capabilities)
-
-## Deployment
-
-The recommended approach for production deployments is `declaratively` rather than `imperatively`. `npx pepr deploy` should only be used in development.
-
-## Core Development
-
-When developing new features in Pepr Core, it is recommended to to use `npx pepr 
-deploy -i pepr:dev`, which will deploy Pepr's Kubernetes manifests to the cluster with the development image. This will allow you to test your changes without having to build a new image and push it to a registry. 
 
 
-## Keep Modules Small
-
-Modules are minified and built JavaScript files that are stored in a Kubernetes Secret in the cluster. The Secret is mounted in the Pepr container and is processed by Pepr Core. Due to the nature of the module being packaged in a secret, it is recommended to keep the modules as small as possible to avoid hitting the [1MB limit](https://kubernetes.io/docs/concepts/configuration/secret/#restriction-data-size) of secrets.
-
-Recommendations for keeping models small are:
-- Don't repeat yourself 
-- Only import the part of the library modules that you need
-
-
-
-## Debugging
-
-Pepr can be broken down into two parts: admission and watches. If the focus of the debug is on a mutation or validation, then only pay attention to pods with labels `pepr.dev/controller: admission`. If you are building an operator or dealing with resources that already exist in the cluster (not through admission), then `pepr.dev/controller: watch` are the pods to pay attention to.
-
-
-## Monitoring
-
-Pepr can monitor its validations and mutations through the `npx pepr monitor <module-uuid>` command. This command will display a list of acrtions peformed by Pepr's the Admission Controller.
-
-
-## Security 
-
-Pepr is designed to be secure by default by creating securityContext limiting the scope of privilege on pods. This is done by setting the `runAsNonRoot` and `runAsUser` fields in the `securityContext` of the pod. This is done by default for all pods created by Pepr. 
-
-```typescript
-When(a.Pod)
-  .IsCreated()
-  .InNamespace("my-app")
-  .WithName("database")
-  .Mutate(pod => {
-    pod.spec.securityContext = {
-      runAsNonRoot: true,
-      runAsUser: 1000
-    }
-  })
-```
 ## Pepr Store
 
 The store is backed by ETCD in a `PeprStore` resource, and updates happen at 5-second intervals when an array of patches is sent to the Kubernetes API Server. The store is intentionally not designed to be `transactional`; instead, it is built to be eventually consistent, meaning that the last operation within the interval will be persisted, potentially overwriting other operations. In simpler terms, changes to the data are made without a guarantee that they will occur simultaneously, so caution is needed in managing errors and ensuring consistency.  
@@ -85,12 +33,5 @@ When(a.Pod)
     // do consecutive api calls
 ```
 
-## Multiple Modules or Multiple Capabilities
-
-Each module has it's own mutating, validating webhook configurations, admission and watch controllers and stores. This allows for each module to be deployed independently of each other. However, creating multiple modules creates overhead on the kube-apiserver, and the cluster.
-
-Due to the overhead costs, it is recommended to deploy multiple capabilies that share the the same resources. This will simplify analysis of which capabilities are responsible for changes on resources.
-
-However, there are some cases where it is makes sense multiple modules. The recommendation when deploying multiple modules it to separate concerns and keep the modules as small as possible.
 
 [TOP](#pepr-best-practices)

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -1,12 +1,64 @@
-# Pepr Best Practices (WIP)
+# Pepr Best Practices
 
 ## TOC
 
-- [Store](#pepr-store)
+- [Deployment](#deployment)
+- [Keep Modules Small](#keep-modules-small)
+- [core development](#core-development)
+- [debugging](#debugging)
 - [OnSchedule](#onschedule)
+- [Security](#security)
+- [monitoring](#monitoring)
+- [Store](#pepr-store)
 - [Watch](#watch)
+- [multiple-modules-or-multiple-capabilities](#multiple-modules-or-multiple-capabilities)
+
+## Deployment
+
+The recommended approach for production deployments is `declaratively` rather than `imperatively`. `npx pepr deploy` should only be used in development.
+
+## Core Development
+
+When developing new features in Pepr Core, it is recommended to to use `npx pepr 
+deploy -i pepr:dev`, which will deploy Pepr's Kubernetes manifests to the cluster with the development image. This will allow you to test your changes without having to build a new image and push it to a registry. 
 
 
+## Keep Modules Small
+
+Modules are minified and built JavaScript files that are stored in a Kubernetes Secret in the cluster. The Secret is mounted in the Pepr container and is processed by Pepr Core. Due to the nature of the module being packaged in a secret, it is recommended to keep the modules as small as possible to avoid hitting the [1MB limit](https://kubernetes.io/docs/concepts/configuration/secret/#restriction-data-size) of secrets.
+
+Recommendations for keeping models small are:
+- Don't repeat yourself 
+- Only import the part of the library modules that you need
+
+
+
+## Debugging
+
+Pepr can be broken down into two parts: admission and watches. If the focus of the debug is on a mutation or validation, then only pay attention to pods with labels `pepr.dev/controller: admission`. If you are building an operator or dealing with resources that already exist in the cluster (not through admission), then `pepr.dev/controller: watch` are the pods to pay attention to.
+
+
+## Monitoring
+
+Pepr can monitor its validations and mutations through the `npx pepr monitor <module-uuid>` command. This command will display a list of acrtions peformed by Pepr's the Admission Controller.
+
+
+## Security 
+
+Pepr is designed to be secure by default by creating securityContext limiting the scope of privilege on pods. This is done by setting the `runAsNonRoot` and `runAsUser` fields in the `securityContext` of the pod. This is done by default for all pods created by Pepr. 
+
+```typescript
+When(a.Pod)
+  .IsCreated()
+  .InNamespace("my-app")
+  .WithName("database")
+  .Mutate(pod => {
+    pod.spec.securityContext = {
+      runAsNonRoot: true,
+      runAsUser: 1000
+    }
+  })
+```
 ## Pepr Store
 
 The store is backed by ETCD in a `PeprStore` resource, and updates happen at 5-second intervals when an array of patches is sent to the Kubernetes API Server. The store is intentionally not designed to be `transactional`; instead, it is built to be eventually consistent, meaning that the last operation within the interval will be persisted, potentially overwriting other operations. In simpler terms, changes to the data are made without a guarantee that they will occur simultaneously, so caution is needed in managing errors and ensuring consistency.  
@@ -33,5 +85,12 @@ When(a.Pod)
     // do consecutive api calls
 ```
 
+## Multiple Modules or Multiple Capabilities
+
+Each module has it's own mutating, validating webhook configurations, admission and watch controllers and stores. This allows for each module to be deployed independently of each other. However, creating multiple modules creates overhead on the kube-apiserver, and the cluster.
+
+Due to the overhead costs, it is recommended to deploy multiple capabilies that share the the same resources. This will simplify analysis of which capabilities are responsible for changes on resources.
+
+However, there are some cases where it is makes sense multiple modules. The recommendation when deploying multiple modules it to separate concerns and keep the modules as small as possible.
 
 [TOP](#pepr-best-practices)

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -9,22 +9,21 @@ import { RootCmd } from "./root";
 
 export default function (program: RootCmd) {
   program
-    .command("monitor")
-    .description("Monitor Pepr Module(s)")
-    .option("-id, --uuid [<module-uuid>]", "Module UUID. (Found in package.json)")
-    .action(async opts => {
+    .command("monitor [module-uuid]")
+    .description("Monitor a Pepr Module")
+    .action(async uuid => {
       let labels: string[];
       let errorMessage: string;
 
-      if (!opts.uuid) {
+      if (!uuid) {
         labels = ["pepr.dev/controller", "admission"];
         errorMessage = `No pods found with admission labels`;
       } else {
-        labels = ["app", `pepr-${opts.uuid}`];
-        errorMessage = `No pods found for module ${opts.uuid}`;
+        labels = ["app", `pepr-${uuid}`];
+        errorMessage = `No pods found for module ${uuid}`;
       }
 
-      // Get the logs for the label pod selector
+      // Get the logs for the `app=pepr-${module}` or `pepr.dev/controller=admission` pod selector
       const pods = await K8s(kind.Pod)
         .InNamespace("pepr-system")
         .WithLabel(labels[0], labels[1])


### PR DESCRIPTION
## Description

Functionality is left the same, but if module_uuid is not given, then the admission controller logs are returned



## Related Issue

Fixes #495 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
