### PR TITLE
chore: pepr backward compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 
 Pepr is on a mission to save Kubernetes from the tyranny of YAML, intimidating glue code, bash scripts, and other makeshift solutions. As a Kubernetes controller, Pepr empowers you to define Kubernetes transformations using TypeScript, without software development expertise thanks to plain-english configurations. Pepr transforms a patchwork of forks, scripts, overlays, and other chaos into a cohesive, well-structured, and maintainable system. With Pepr, you can seamlessly transition IT ops tribal knowledge into code, simplifying documentation, testing, validation, and coordination of changes for a more predictable outcome.
 
-#### _Note: Pepr is still in active development so breaking changes may occur, but will be documented in release notes._
-
 ## Features
 
 - Zero-config K8s webhook mutations and validations


### PR DESCRIPTION
## Description

Remove section in README.md that says, `Note: Pepr is still in active development so breaking changes may occur, but will be documented in release notes.`

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
