### PR TITLE
fix: pepr build works when running inside npm workspaces 

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -168,7 +168,7 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
     }
 
     // Resolve node_modules folder (in support of npm workspaces!)
-    const npmRoot = execFileSync("npm", [ "root" ]).toString().trim();
+    const npmRoot = execFileSync("npm", ["root"]).toString().trim();
 
     // Run `tsc` to validate the module's types & output sourcemaps
     const args = ["--project", `${modulePath}/tsconfig.json`, "--outdir", outputDir];

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -167,9 +167,12 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
       );
     }
 
+    // Resolve node_modules folder (in support of npm workspaces!)
+    const npmRoot = execFileSync("npm", [ "root" ]).toString().trim();
+
     // Run `tsc` to validate the module's types & output sourcemaps
     const args = ["--project", `${modulePath}/tsconfig.json`, "--outdir", outputDir];
-    execFileSync("./node_modules/.bin/tsc", args);
+    execFileSync(`${npmRoot}/.bin/tsc`, args);
 
     // Common build options for all builds
     const ctxCfg: BuildOptions = {


### PR DESCRIPTION
## Description

`pepr build` currently calls for the `./node_modules/.bin/tsc` binary in order to compile typescript source code.

This is a problem because it assumes that the `node_modules` directory exists within "the current directory", which... is not always the case. For example, when using NPM's Workspaces feature, the `node_modules` folder commonly exists in the location of the parent/root package.json -- i.e one or more levels "above" the "current directory" -- rather than in the same directory as the workspaced package.json.

This PR adds-in a simple call to make npm tell the build command where to find the `node_modules` folder -- rather than assuming the "current directory" -- so that pepr can call support npm-installed binaries in both the workspace & non-workspace cases.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
