### PR TITLE
fix: validation processor no longer prints [object Object] in logs

### DIFF
--- a/src/lib/validate-processor.ts
+++ b/src/lib/validate-processor.ts
@@ -64,11 +64,11 @@ export async function validateProcessor(
         Log.info(actionMetadata, `Validation Action completed: ${resp.allowed ? "allowed" : "denied"}`);
       } catch (e) {
         // If any validation throws an error, note the failure in the Response
-        Log.error(actionMetadata, `Action failed: ${e}`);
+        Log.error(actionMetadata, `Action failed: ${JSON.stringify(e)}`);
         localResponse.allowed = false;
         localResponse.status = {
           code: 500,
-          message: `Action failed with error: ${e}`,
+          message: `Action failed with error: ${JSON.stringify(e)}`,
         };
         return [localResponse];
       }


### PR DESCRIPTION
## Description

Wrote a failed Validation() handler during Dashies & got something like this as a log message:
```
Action failed with error: [object Object]
```
which, was... not terribly helpful. 

This PR refines validation-processor's error outputs to make them stringify error objects before printing  (so they can be read properly in the log output).


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
