### PR TITLE
chore: error secret over limit

### DIFF
--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -298,15 +298,14 @@ export function deployment(assets: Assets, hash: string): kind.Deployment {
   };
 }
 
-
 export function moduleSecret(name: string, data: Buffer, hash: string): kind.Secret {
   // Compress the data
   const compressed = gzipSync(data);
   const path = `module-${hash}.js.gz`;
   const compressedData = compressed.toString("base64");
   if (secretOverLimit(compressedData)) {
-    let error = new Error(`Module secret for ${name} is over the 1MB limit`);
-    console.error('Uncaught Exception:', error)
+    const error = new Error(`Module secret for ${name} is over the 1MB limit`);
+    console.error("Uncaught Exception:", error);
     process.exit(1);
   } else {
     return {

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -4,7 +4,7 @@
 import { CapabilityExport } from "./types";
 import { createRBACMap, addVerbIfNotExists } from "./helpers";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
-import { parseTimeout } from "./helpers";
+import { parseTimeout, secretOverLimit } from "./helpers";
 import * as commander from "commander";
 import { promises as fs } from "fs";
 import {
@@ -849,5 +849,18 @@ describe("parseTimeout", () => {
   test("should throw an InvalidArgumentError for numeric strings that represent floating point numbers", () => {
     expect(() => parseTimeout("5.5", PREV)).toThrow(commander.InvalidArgumentError);
     expect(() => parseTimeout("20.1", PREV)).toThrow(commander.InvalidArgumentError);
+  });
+});
+
+
+describe('secretOverLimit', () => {
+  test('should return true for a string larger than 1MB', () => {
+    const largeString = 'a'.repeat(1048577); 
+    expect(secretOverLimit(largeString)).toBe(true);
+  });
+
+  test('should return false for a string smaller than 1MB', () => {
+    const smallString = 'a'.repeat(1048575);
+    expect(secretOverLimit(smallString)).toBe(false);
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -853,7 +853,7 @@ describe("parseTimeout", () => {
 });
 
 describe("secretOverLimit", () => {
-  test("should return true for a string larger than 1MB", () => {
+  test("should return true for a string larger than 1MiB", () => {
     const largeString = "a".repeat(1048577);
     expect(secretOverLimit(largeString)).toBe(true);
   });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -852,15 +852,14 @@ describe("parseTimeout", () => {
   });
 });
 
-
-describe('secretOverLimit', () => {
-  test('should return true for a string larger than 1MB', () => {
-    const largeString = 'a'.repeat(1048577); 
+describe("secretOverLimit", () => {
+  test("should return true for a string larger than 1MB", () => {
+    const largeString = "a".repeat(1048577);
     expect(secretOverLimit(largeString)).toBe(true);
   });
 
-  test('should return false for a string smaller than 1MB', () => {
-    const smallString = 'a'.repeat(1048575);
+  test("should return false for a string smaller than 1MB", () => {
+    const smallString = "a".repeat(1048575);
     expect(secretOverLimit(smallString)).toBe(false);
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -858,7 +858,7 @@ describe("secretOverLimit", () => {
     expect(secretOverLimit(largeString)).toBe(true);
   });
 
-  test("should return false for a string smaller than 1MB", () => {
+  test("should return false for a string smaller than 1MiB", () => {
     const smallString = "a".repeat(1048575);
     expect(secretOverLimit(smallString)).toBe(false);
   });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -168,8 +168,8 @@ export function secretOverLimit(str: string): boolean {
   const encoder = new TextEncoder();
   const encoded = encoder.encode(str);
   const sizeInBytes = encoded.length;
-  const oneMBInBytes = 1048576;
-  return sizeInBytes > oneMBInBytes;
+  const oneMiBInBytes = 1048576;
+  return sizeInBytes > oneMiBInBytes;
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -163,7 +163,7 @@ export async function namespaceDeploymentsReady(namespace: string = "pepr-system
   Log.info(`All ${namespace} deployments are ready`);
 }
 
-// check is secret of over the limit in Kubernetes
+// check if secret is over the size limit
 export function secretOverLimit(str: string): boolean {
   const sizeInBytes = Buffer.byteLength(str, "base64");
   return sizeInBytes > 1048576;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -163,6 +163,12 @@ export async function namespaceDeploymentsReady(namespace: string = "pepr-system
   Log.info(`All ${namespace} deployments are ready`);
 }
 
+// check is secret of over the limit in Kubernetes
+export function secretOverLimit(str: string): boolean {
+  const sizeInBytes = Buffer.byteLength(str, "base64");
+  return sizeInBytes > 1048576;
+}
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export const parseTimeout = (value: string, previous: unknown): number => {
   const parsedValue = parseInt(value, 10);

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -165,8 +165,11 @@ export async function namespaceDeploymentsReady(namespace: string = "pepr-system
 
 // check if secret is over the size limit
 export function secretOverLimit(str: string): boolean {
-  const sizeInBytes = Buffer.byteLength(str, "base64");
-  return sizeInBytes > 1048576;
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(str);
+  const sizeInBytes = encoded.length;
+  const oneMBInBytes = 1048576;
+  return sizeInBytes > oneMBInBytes;
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
## Description

Throw an error when Secret is over limit 

[moduleSecret](https://github.com/defenseunicorns/pepr/blob/f111e6724d32c256b78ccb62d94af918b41cec84/src/lib/assets/pods.ts#L301) is called in many places, which made returning an error incur a lot of repeated code. Due to this, the lesser evil was to return a `process.exit(1)` to stop the build.

## Related Issue

Fixes #556 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
