### PR TITLE
feat:  implementation for custom labels

### DIFF
--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -44,7 +44,7 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string) {
       onError: opts.errorBehavior,
       webhookTimeout: 10,
       customLabels: {
-        namespace: {}
+        namespace: {},
       },
       alwaysIgnore: {
         namespaces: [],

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -43,6 +43,9 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string) {
       uuid: pgkVerOverride ? "static-test" : uuid,
       onError: opts.errorBehavior,
       webhookTimeout: 10,
+      customLabels: {
+        namespace: {}
+      },
       alwaysIgnore: {
         namespaces: [],
         labels: [],

--- a/src/lib/assets/deploy.ts
+++ b/src/lib/assets/deploy.ts
@@ -20,7 +20,7 @@ export async function deploy(assets: Assets, force: boolean, webhookTimeout?: nu
   const { name, host, path } = assets;
 
   Log.info("Applying pepr-system namespace");
-  await K8s(kind.Namespace).Apply(namespace);
+  await K8s(kind.Namespace).Apply(namespace(assets.config.customLabels?.namespace));
 
   // Create the mutating webhook configuration if it is needed
   const mutateWebhook = await webhookConfig(assets, "mutate", webhookTimeout);

--- a/src/lib/assets/pods.test.ts
+++ b/src/lib/assets/pods.test.ts
@@ -1,0 +1,27 @@
+import { namespace } from "./pods"; // Adjust the import path as necessary
+import { expect, describe, test } from "@jest/globals";
+
+describe("namespace function", () => {
+  test("should create a namespace object without labels if none are provided", () => {
+    const result = namespace();
+    expect(result).toEqual({
+      apiVersion: "v1",
+      kind: "Namespace",
+      metadata: {
+        name: "pepr-system",
+        labels: {},
+      },
+    });
+  });
+
+  test("should create a namespace object with empty labels if an empty object is provided", () => {
+    const result = namespace({});
+    expect(result.metadata.labels).toEqual({});
+  });
+
+  test("should create a namespace object with provided labels", () => {
+    const labels = { "pepr.dev/controller": "admission", "istio-injection": "enabled" };
+    const result = namespace(labels);
+    expect(result.metadata.labels).toEqual(labels);
+  });
+});

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -10,11 +10,16 @@ import { ModuleConfig } from "../module";
 import { Binding } from "../types";
 
 /** Generate the pepr-system namespace */
-export const namespace: kind.Namespace = {
-  apiVersion: "v1",
-  kind: "Namespace",
-  metadata: { name: "pepr-system" },
-};
+export function namespace(namespaceLabels?: Record<string, string>) {
+  return {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+      name: "pepr-system",
+      labels: namespaceLabels ?? {},
+    },
+  };
+}
 
 export function watcher(assets: Assets, hash: string) {
   const { name, image, capabilities, config } = assets;

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -53,7 +53,7 @@ export async function allYaml(assets: Assets, rbacMode: string) {
   const watchDeployment = watcher(assets, hash);
 
   const resources = [
-    namespace,
+    namespace(assets.config.customLabels?.namespace),
     clusterRole(name, assets.capabilities, rbacMode),
     clusterRoleBinding(name),
     serviceAccount(name),

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -11,6 +11,10 @@ import { CapabilityExport } from "./types";
 import { setupWatch } from "./watch-processor";
 import { Log } from "../lib";
 
+/** Custom Labels Type for package.json */
+export interface CustomLabels {
+  namespace?: Record<string, string>;
+}
 /** Global configuration for the Pepr runtime. */
 export type ModuleConfig = {
   /** The user-defined name for the module */
@@ -33,6 +37,8 @@ export type ModuleConfig = {
   logLevel?: string;
   /** Propagate env variables to in-cluster controllers */
   env?: Record<string, string>;
+  /** Custom Labels for Kubernetes Objects */
+  customLabels?: CustomLabels;
 };
 
 export type PackageJSON = {

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -8,7 +8,7 @@
     "onError": "reject",
     "logLevel": "debug",
     "customLabels": {
-      "namespace": []
+      "namespace": {}
     },
     "alwaysIgnore": {
       "namespaces": [],

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -5,8 +5,11 @@
     "name": "Development Module",
     "uuid": "20e17cf6-a2e4-46b2-b626-75d88d96c88b",
     "description": "Development module for pepr",
-    "onError": "ignore",
+    "onError": "reject",
     "logLevel": "debug",
+    "customLabels": {
+      "namespace": []
+    },
     "alwaysIgnore": {
       "namespaces": [],
       "labels": []


### PR DESCRIPTION
## Description

Through code allows the users to create customLabels for Kubernetes objects. The `customLabels` object is now placed in the module class definition and can be extended as more Kubernetes objects need custom labels 

## Related Issue

Fixes #569 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
