### PR TITLE
chore: docs badge link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pepr
 
-[![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](./docs/README.md)
+[![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](https://docs.pepr.dev)
 [![Npm package license](https://badgen.net/npm/license/pepr)](https://npmjs.com/package/pepr)
 [![Known Vulnerabilities](https://snyk.io/test/npm/pepr/badge.svg)](https://snyk.io/advisor/npm-package/pepr)
 [![Npm package version](https://badgen.net/npm/v/pepr)](https://npmjs.com/package/pepr)


### PR DESCRIPTION
## Description

Link on [![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](./docs/README.md) is broken

## Related Issue

Fixes [![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](https://docs.pepr.dev)
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
