### PR TITLE
chore: squash filter namespace bug validate/mutate

### DIFF
--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -47,7 +47,7 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
   }
 
   // Test for matching namespaces
-  if (combinedNamespaces.length && !combinedNamespaces.includes(req.namespace || "")) {
+  if (combinedNamespaces.length && !combinedNamespaces.includes(req.namespace || "") || !namespaces.includes(req.namespace || "") && capabilityNamespaces.length !== 0) {
     logger.debug("Namespace does not match");
     return true;
   }

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -49,7 +49,7 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
   // Test for matching namespaces
   if (
     (combinedNamespaces.length && !combinedNamespaces.includes(req.namespace || "")) ||
-    (!namespaces.includes(req.namespace || "") && capabilityNamespaces.length !== 0)
+    (!namespaces.includes(req.namespace || "") && capabilityNamespaces.length !== 0 && namespaces.length !== 0)
   ) {
     logger.debug("Namespace does not match");
     return true;

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -47,7 +47,10 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
   }
 
   // Test for matching namespaces
-  if (combinedNamespaces.length && !combinedNamespaces.includes(req.namespace || "") || !namespaces.includes(req.namespace || "") && capabilityNamespaces.length !== 0) {
+  if (
+    (combinedNamespaces.length && !combinedNamespaces.includes(req.namespace || "")) ||
+    (!namespaces.includes(req.namespace || "") && capabilityNamespaces.length !== 0)
+  ) {
     logger.debug("Namespace does not match");
     return true;
   }


### PR DESCRIPTION
## Description

Binding namespace filters are not being respected for Admission and Watch when a object is from the capability owned namespace.

Adds a clause to skip running the callback if the namespace filter is not the same as the objects 'namespace and the capability namespaces are not all namespaces.

<img width="1460" alt="image" src="https://github.com/defenseunicorns/pepr/assets/1096507/de49e374-721e-4c54-8870-389231741e38">


## Related Issue

Fixes #605 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
