### PR TITLE
fix: pepr deploy respects custom webhookTimeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run test:unit && npm run test:journey",
     "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles --coverageDirectory=./coverage",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",
-    "test:journey:prep": "git clone https://github.com/defenseunicorns/pepr-upgrade-test.git",
+    "test:journey:prep": "rm -rf ./pepr-upgrade-test ; git clone https://github.com/defenseunicorns/pepr-upgrade-test.git",
     "test:journey-wasm": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run-wasm",
     "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0' --wait && kubectl rollout status deployment -n kube-system",
     "test:journey:build": "npm run build && npm pack",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run test:unit && npm run test:journey",
     "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles --coverageDirectory=./coverage",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",
-    "test:journey:prep": "rm -rf ./pepr-upgrade-test ; git clone https://github.com/defenseunicorns/pepr-upgrade-test.git",
+    "test:journey:prep": "if [ ! -d /pepr-upgrade-test ]; then git clone https://github.com/defenseunicorns/pepr-upgrade-test.git ; fi",
     "test:journey-wasm": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run-wasm",
     "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0' --wait && kubectl rollout status deployment -n kube-system",
     "test:journey:build": "npm run build && npm pack",

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -46,8 +46,11 @@ export default function (program: RootCmd) {
         webhook.image = opts.image;
       }
 
+      // Identify conf'd webhookTimeout to give to deploy call
+      const timeout = cfg.pepr.webhookTimeout ? cfg.pepr.webhookTimeout : 10
+
       try {
-        await webhook.deploy(opts.force);
+        await webhook.deploy(opts.force, timeout);
         // Wait for the pepr-system resources to be fully up
         await namespaceDeploymentsReady();
         console.info(`✅ Module deployed successfully`);

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -47,7 +47,7 @@ export default function (program: RootCmd) {
       }
 
       // Identify conf'd webhookTimeout to give to deploy call
-      const timeout = cfg.pepr.webhookTimeout ? cfg.pepr.webhookTimeout : 10
+      const timeout = cfg.pepr.webhookTimeout ? cfg.pepr.webhookTimeout : 10;
 
       try {
         await webhook.deploy(opts.force, timeout);


### PR DESCRIPTION
## Description

Simple PR to pull webhookTimeout from package.json config & pass along within the `pepr deploy` command.

Also, updates the package.json test:journey:prep script to allow running the test:journey suite multiple times sequentially.

## Related Issue

Fixes #615 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
