### PR TITLE
chore: fix ns bug on watch and queue

### DIFF
--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { CapabilityExport } from "./types";
-import { createRBACMap, addVerbIfNotExists } from "./helpers";
+import { Binding, CapabilityExport } from "./types";
+import { createRBACMap, addVerbIfNotExists, checkOverlap, filterMatcher } from "./helpers";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
 import { parseTimeout, secretOverLimit, replaceString } from "./helpers";
 import * as commander from "commander";
@@ -941,5 +941,136 @@ describe("replaceString", () => {
     const stringB = "";
     const expected = "Remove.";
     expect(replaceString(original, stringA, stringB)).toBe(expected);
+  });
+});
+
+describe("checkOverlap", () => {
+  test("returns true if first record is empty", () => {
+    expect(checkOverlap({}, { key1: "value1" })).toBe(true);
+  });
+
+  test("returns false if there is no overlap", () => {
+    expect(checkOverlap({ key1: "value1" }, { key2: "value2" })).toBe(false);
+  });
+
+  test("returns true if there is an overlap", () => {
+    expect(checkOverlap({ key1: "value1" }, { key1: "value1", key2: "value2" })).toBe(true);
+  });
+
+  test("returns false if keys match but values do not", () => {
+    expect(checkOverlap({ key1: "value1" }, { key1: "value2" })).toBe(false);
+  });
+
+  test("returns true if first record is empty and second record is also empty", () => {
+    expect(checkOverlap({}, {})).toBe(true);
+  });
+});
+
+describe("filterMatcher", () => {
+  test("returns namespace filter error for namespace objects with namespace filters", () => {
+    const binding = {
+      kind: { kind: "Namespace" },
+      filters: { namespaces: ["ns1"] },
+    };
+    const obj = {};
+    const capabilityNamespaces: string[] = [];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("Cannot use a namespace filter in a namespace object");
+  });
+
+  test("returns label overlap error when there is no overlap between binding and object labels", () => {
+    const binding = {
+      filters: { labels: { key: "value" } },
+    };
+    const obj = {
+      metadata: { labels: { anotherKey: "anotherValue" } },
+    };
+    const capabilityNamespaces: string[] = [];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("No overlap between binding and object labels");
+  });
+
+  test("returns annotation overlap error when there is no overlap between binding and object annotations", () => {
+    const binding = {
+      filters: { annotations: { key: "value" } },
+    };
+    const obj = {
+      metadata: { annotations: { anotherKey: "anotherValue" } },
+    };
+    const capabilityNamespaces: string[] = [];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("No overlap between binding and object annotations");
+  });
+
+  test("returns capability namespace error when object is not in capability namespaces", () => {
+    const binding = {};
+    const obj = {
+      metadata: { namespace: "ns2" },
+    };
+    const capabilityNamespaces = ["ns1"];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("No overlap between capability namespace and object");
+  });
+
+  test("returns binding namespace error when filter namespace is not part of capability namespaces", () => {
+    const binding = {
+      filters: { namespaces: ["ns3"] },
+    };
+    const obj = {};
+    const capabilityNamespaces = ["ns1", "ns2"];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("Binding namespace is not part of capability namespaces");
+  });
+
+  test("returns binding and object namespace error when they do not overlap", () => {
+    const binding = {
+      filters: { namespaces: ["ns1"] },
+    };
+    const obj = {
+      metadata: { namespace: "ns2" },
+    };
+    const capabilityNamespaces = ["ns1", "ns2"];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("No overlap between binding namespace and object");
+  });
+
+  test("returns empty string when all checks pass", () => {
+    const binding = {
+      filters: { namespaces: ["ns1"], labels: { key: "value" }, annotations: { key: "value" } },
+    };
+    const obj = {
+      metadata: { namespace: "ns1", labels: { key: "value" }, annotations: { key: "value" } },
+    };
+    const capabilityNamespaces = ["ns1"];
+    const result = filterMatcher(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual("");
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -5,7 +5,6 @@ import { Binding, CapabilityExport } from "./types";
 import { createRBACMap, addVerbIfNotExists, checkOverlap, filterMatcher } from "./helpers";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
 import { parseTimeout, secretOverLimit, replaceString } from "./helpers";
-import * as commander from "commander";
 import { promises as fs } from "fs";
 
 import {
@@ -839,18 +838,18 @@ describe("parseTimeout", () => {
   });
 
   test("should throw an InvalidArgumentError for non-numeric strings", () => {
-    expect(() => parseTimeout("abc", PREV)).toThrow(commander.InvalidArgumentError);
-    expect(() => parseTimeout("", PREV)).toThrow(commander.InvalidArgumentError);
+    expect(() => parseTimeout("abc", PREV)).toThrow(Error);
+    expect(() => parseTimeout("", PREV)).toThrow(Error);
   });
 
   test("should throw an InvalidArgumentError for numbers outside the 1-30 range", () => {
-    expect(() => parseTimeout("0", PREV)).toThrow(commander.InvalidArgumentError);
-    expect(() => parseTimeout("31", PREV)).toThrow(commander.InvalidArgumentError);
+    expect(() => parseTimeout("0", PREV)).toThrow(Error);
+    expect(() => parseTimeout("31", PREV)).toThrow(Error);
   });
 
   test("should throw an InvalidArgumentError for numeric strings that represent floating point numbers", () => {
-    expect(() => parseTimeout("5.5", PREV)).toThrow(commander.InvalidArgumentError);
-    expect(() => parseTimeout("20.1", PREV)).toThrow(commander.InvalidArgumentError);
+    expect(() => parseTimeout("5.5", PREV)).toThrow(Error);
+    expect(() => parseTimeout("20.1", PREV)).toThrow(Error);
   });
 });
 

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -978,7 +978,7 @@ describe("filterMatcher", () => {
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
     );
-    expect(result).toEqual("Cannot use a namespace filter in a namespace object");
+    expect(result).toEqual("Ignoring Watch Callback: Cannot use a namespace filter in a namespace object.");
   });
 
   test("returns label overlap error when there is no overlap between binding and object labels", () => {
@@ -994,7 +994,9 @@ describe("filterMatcher", () => {
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
     );
-    expect(result).toEqual("No overlap between binding and object labels");
+    expect(result).toEqual(
+      'Ignoring Watch Callback: No overlap between binding and object labels. Binding labels {"key":"value"}, Object Labels {"anotherKey":"anotherValue"}.',
+    );
   });
 
   test("returns annotation overlap error when there is no overlap between binding and object annotations", () => {
@@ -1010,7 +1012,9 @@ describe("filterMatcher", () => {
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
     );
-    expect(result).toEqual("No overlap between binding and object annotations");
+    expect(result).toEqual(
+      'Ignoring Watch Callback: No overlap between binding and object annotations. Binding annotations {"key":"value"}, Object annotations {"anotherKey":"anotherValue"}.',
+    );
   });
 
   test("returns capability namespace error when object is not in capability namespaces", () => {
@@ -1024,7 +1028,9 @@ describe("filterMatcher", () => {
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
     );
-    expect(result).toEqual("No overlap between capability namespace and object");
+    expect(result).toEqual(
+      "Ignoring Watch Callback: Object is not in the capability namespace. Capability namespaces: ns1, Object namespace: ns2.",
+    );
   });
 
   test("returns binding namespace error when filter namespace is not part of capability namespaces", () => {
@@ -1038,7 +1044,9 @@ describe("filterMatcher", () => {
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
     );
-    expect(result).toEqual("Binding namespace is not part of capability namespaces");
+    expect(result).toEqual(
+      "Ignoring Watch Callback: Binding namespace is not part of capability namespaces. Capability namespaces: ns1, ns2, Binding namespaces: ns3.",
+    );
   });
 
   test("returns binding and object namespace error when they do not overlap", () => {
@@ -1054,7 +1062,9 @@ describe("filterMatcher", () => {
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
     );
-    expect(result).toEqual("No overlap between binding namespace and object");
+    expect(result).toEqual(
+      "Ignoring Watch Callback: Binding namespace and object namespace are not the same. Binding namespaces: ns1, Object namespace: ns2.",
+    );
   });
 
   test("returns empty string when all checks pass", () => {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -5,7 +5,6 @@ import { K8s, KubernetesObject, kind } from "kubernetes-fluent-client";
 import Log from "./logger";
 import { CapabilityExport } from "./types";
 import { promises as fs } from "fs";
-import commander from "commander";
 import { Binding } from "./types";
 
 type RBACMap = {
@@ -259,11 +258,11 @@ export const parseTimeout = (value: string, previous: unknown): number => {
   const parsedValue = parseInt(value, 10);
   const floatValue = parseFloat(value);
   if (isNaN(parsedValue)) {
-    throw new commander.InvalidArgumentError("Not a number.");
+    throw new Error("Not a number.");
   } else if (parsedValue !== floatValue) {
-    throw new commander.InvalidArgumentError("Value must be an integer.");
+    throw new Error("Value must be an integer.");
   } else if (parsedValue < 1 || parsedValue > 30) {
-    throw new commander.InvalidArgumentError("Number must be between 1 and 30.");
+    throw new Error("Number must be between 1 and 30.");
   }
   return parsedValue;
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -60,6 +60,7 @@ export const filterMatcher = (
 
   // obj is in the capability namespaces
   if (
+    Array.isArray(capabilityNamespaces) &&
     capabilityNamespaces.length > 0 &&
     obj.metadata &&
     obj.metadata.namespace &&
@@ -70,8 +71,10 @@ export const filterMatcher = (
 
   // every filter namespace is a capability namespace
   if (
+    Array.isArray(capabilityNamespaces) &&
     capabilityNamespaces.length > 0 &&
     binding.filters &&
+    Array.isArray(binding.filters.namespaces) &&
     binding.filters.namespaces.length > 0 &&
     !binding.filters.namespaces.every(ns => capabilityNamespaces.includes(ns))
   ) {
@@ -81,6 +84,7 @@ export const filterMatcher = (
   // filter namespace is not the same of object namespace
   if (
     binding.filters &&
+    Array.isArray(binding.filters.namespaces) &&
     binding.filters.namespaces.length > 0 &&
     obj.metadata &&
     obj.metadata.namespace &&

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -100,7 +100,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
             // Enqueue the object for reconciliation through callback
             await queue.enqueue(obj);
           } else {
-            throw new Error(filterMatch);
+            Log.debug(filterMatch);
           }
         } catch (e) {
           // Errors in the watch callback should not crash the controller
@@ -120,7 +120,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
           if (filterMatch === "") {
             await binding.watchCallback?.(obj, type);
           } else {
-            throw new Error(filterMatch);
+            Log.debug(filterMatch);
           }
         } catch (e) {
           // Errors in the watch callback should not crash the controller

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -11,6 +11,7 @@ import Log from "./logger";
 import { Binding, Event } from "./types";
 import { Watcher } from "kubernetes-fluent-client/dist/fluent/watch";
 import { GenericClass } from "kubernetes-fluent-client";
+import { filterMatcher } from "./helpers";
 
 // Track if the store has been updated
 let storeUpdates = false;
@@ -58,13 +59,14 @@ export async function setupStore(uuid: string) {
 export async function setupWatch(uuid: string, capabilities: Capability[]) {
   await setupStore(uuid);
 
-  capabilities
-    .flatMap(c => c.bindings)
-    .filter(binding => binding.isWatch)
-    .forEach(runBinding);
+  capabilities.map(capability =>
+    capability.bindings
+      .filter(binding => binding.isWatch)
+      .forEach(bindingElement => runBinding(bindingElement, capability.namespaces)),
+  );
 }
 
-async function runBinding(binding: Binding) {
+async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
   // Map the event to the watch phase
   const eventToPhaseMap = {
     [Event.Create]: [WatchPhase.Added],
@@ -92,13 +94,13 @@ async function runBinding(binding: Binding) {
       // If the type matches the phase, call the watch callback
       if (phaseMatch.includes(type)) {
         try {
-          if (
-            !binding.filters.namespaces ||
-            (binding.filters.namespaces && binding.filters.namespaces.includes(obj.metadata.namespace))
-          ) {
+          const filterMatch = filterMatcher(binding, obj, capabilityNamespaces);
+          if (filterMatch === "") {
             queue.setReconcile(async () => await binding.watchCallback?.(obj, type));
             // Enqueue the object for reconciliation through callback
             await queue.enqueue(obj);
+          } else {
+            throw new Error(filterMatch);
           }
         } catch (e) {
           // Errors in the watch callback should not crash the controller
@@ -114,12 +116,11 @@ async function runBinding(binding: Binding) {
       // If the type matches the phase, call the watch callback
       if (phaseMatch.includes(type)) {
         try {
-          if (
-            !binding.filters.namespaces ||
-            (binding.filters.namespaces && binding.filters.namespaces.includes(obj.metadata.namespace))
-          ) {
-            // Perform the watch callback
+          const filterMatch = filterMatcher(binding, obj, capabilityNamespaces);
+          if (filterMatch === "") {
             await binding.watchCallback?.(obj, type);
+          } else {
+            throw new Error(filterMatch);
           }
         } catch (e) {
           // Errors in the watch callback should not crash the controller

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -92,9 +92,14 @@ async function runBinding(binding: Binding) {
       // If the type matches the phase, call the watch callback
       if (phaseMatch.includes(type)) {
         try {
-          queue.setReconcile(async () => await binding.watchCallback?.(obj, type));
-          // Enqueue the object for reconciliation through callback
-          await queue.enqueue(obj);
+          if (
+            !binding.filters.namespaces ||
+            (binding.filters.namespaces && binding.filters.namespaces.includes(obj.metadata.namespace))
+          ) {
+            queue.setReconcile(async () => await binding.watchCallback?.(obj, type));
+            // Enqueue the object for reconciliation through callback
+            await queue.enqueue(obj);
+          }
         } catch (e) {
           // Errors in the watch callback should not crash the controller
           Log.error(e, "Error executing watch callback");
@@ -109,8 +114,13 @@ async function runBinding(binding: Binding) {
       // If the type matches the phase, call the watch callback
       if (phaseMatch.includes(type)) {
         try {
-          // Perform the watch callback
-          await binding.watchCallback?.(obj, type);
+          if (
+            !binding.filters.namespaces ||
+            (binding.filters.namespaces && binding.filters.namespaces.includes(obj.metadata.namespace))
+          ) {
+            // Perform the watch callback
+            await binding.watchCallback?.(obj, type);
+          }
         } catch (e) {
           // Errors in the watch callback should not crash the controller
           Log.error(e, "Error executing watch callback");


### PR DESCRIPTION
## Description

Fixes bug on watch processor around firing callbacks for bindings where object namespace is different than binding namespace filter. 

```ts
const { When } = HelloPepr;
let watchCount = 0;
When(a.Pod)
.IsCreatedOrUpdated()
.InNamespace("pepr-demo")
.Watch(() => {
  Log.info(`watchCount is ${watchCount++}.`)
})

```
## Related Issue

Fixes #610 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
