### PR TITLE
chore: remove ignore labels

### DIFF
--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -49,7 +49,7 @@ Below are the available configurations through `package.json`.
 | `onError`        | Behavior of the webhook failure policy | `reject`, `ignore`              |
 | `webhookTimeout` | Webhook timeout in seconds             | `1` - `30`                      |
 | `customLabels`   | Custom labels for namespaces           | `{namespace: {}}`               |
-| `alwaysIgnore`   | Conditions to always ignore            | `{namespaces: [], labels: []}`  |
+| `alwaysIgnore`   | Conditions to always ignore            | `{namespaces: []}`  |
 | `includedFiles`  | For working with WebAssembly           | ["main.wasm", "wasm_exec.js"]   |
 | `env`            | Environment variables for the container| `{LOG_LEVEL: "warn"}`           |
 

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -49,7 +49,6 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string) {
       },
       alwaysIgnore: {
         namespaces: [],
-        labels: [],
       },
       includedFiles: [],
       env: pgkVerOverride ? testEnv : {},

--- a/src/lib/k8s.ts
+++ b/src/lib/k8s.ts
@@ -166,15 +166,4 @@ export type WebhookIgnore = {
    * Note: `kube-system` and `pepr-system` are always ignored.
    */
   namespaces?: string[];
-  /**
-   * List of Kubernetes labels to always ignore.
-   * Any resources with these labels will be ignored by Pepr.
-   *
-   * The example below will ignore any resources with the label `my-label=ulta-secret`:
-   * ```
-   * alwaysIgnore:
-   *   labels: [{ "my-label": "ultra-secret" }]
-   * ```
-   */
-  labels?: Record<string, string>[];
 };

--- a/src/lib/module.test.ts
+++ b/src/lib/module.test.ts
@@ -33,7 +33,6 @@ const packageJSON: PackageJSON = {
     onError: "ignore",
     alwaysIgnore: {
       namespaces: [],
-      labels: [],
     },
   },
 };

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -13,8 +13,7 @@
       }
     },
     "alwaysIgnore": {
-      "namespaces": [],
-      "labels": []
+      "namespaces": []
     },
     "includedFiles": []
   }


### PR DESCRIPTION
## Description

Ignoring the admission of objects based on given labels is a security risk. Insecure objects could be admitted into the cluster passing the Validating Webhook creating risk. Due to that, we are not implementing ignore labels in Pepr Core.

However, this can be done by the module author. The person creating the Pepr Module (Admission Controller) may choose to create some sort of exception/exemption back door for a given use-case, we recommend that this backdoor is CRD based and RBAC can be applied. 

## Related Issue

Fixes #622 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
