### PR TITLE
feat: choose controller image version during generation of manifests

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -87,4 +87,5 @@ Create a [zarf.yaml](https://zarf.dev) and K8s manifest for the current module. 
 - `--timeout [timeout]` - How long the API server should wait for a webhook to respond before treating the call as a failure
 - `--rbac-mode [admin|scoped]` - Rbac Mode: admin, scoped (default: admin) (choices: "admin", "scoped", default: "admin")
 - `-i, --custom-image [custom-image]` - Custom Image: Use custom image for Admission and Watcher Deployments.
-- `--registry [GitHub, Iron Bank]`, - Container registry: Choose container registry for deployment manifests.
+- `--registry [GitHub, Iron Bank]` - Container registry: Choose container registry for deployment manifests.
+- `-v, --version <version>. Example: '0.27.3'` - The version of the Pepr image to use in the deployment manifests.

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -110,7 +110,7 @@ export default function (program: RootCmd) {
       }
 
       // set the image version if provided
-      if (opts.version !== undefined) {
+      if (opts.version) {
         cfg.pepr.peprVersion = opts.version;
       }
 

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -28,18 +28,22 @@ export default function (program: RootCmd) {
       "Disables embedding of deployment files into output module.  Useful when creating library modules intended solely for reuse/distribution via NPM.",
     )
     .option(
-      "-i, --custom-image [custom-image]",
+      "-i, --custom-image <custom-image>",
       "Custom Image: Use custom image for Admission and Watch Deployments.",
     )
     .option(
       "-r, --registry-info [<registry>/<username>]",
       "Registry Info: Image registry and username. Note: You must be signed into the registry",
     )
-    .option("-o, --output-dir [output directory]", "Define where to place build output")
+    .option("-o, --output-dir <output directory>", "Define where to place build output")
     .option(
-      "--timeout [timeout]",
+      "--timeout <timeout>",
       "How long the API server should wait for a webhook to respond before treating the call as a failure",
       parseTimeout,
+    )
+    .option(
+      "-v, --version <version>. Example: '0.27.3'",
+      "The version of the Pepr image to use in the deployment manifests.",
     )
     .addOption(
       new Option(
@@ -103,6 +107,11 @@ export default function (program: RootCmd) {
       if (!opts.embed) {
         console.info(`✅ Module built successfully at ${path}`);
         return;
+      }
+
+      // set the image version if provided
+      if (opts.version !== undefined) {
+        cfg.pepr.peprVersion = opts.version;
       }
 
       // Generate a secret for the module


### PR DESCRIPTION
## Description

Choose controller image version during generation of manifests. 

```bash
┌─[cmwylie19@Cases-MacBook-Pro] - [~/pepr/pepr-test-module] - [2024-03-07 12:43:40]
└─[0] <git:(main✈) > npx ts-node ../src/cli.ts  build -v "99.99.99"   

  dist/pepr-static-test.js            3.6kb  100.0%
   ├ capabilities/hello-pepr.ts       2.8kb   77.4%
   ├ package.json                     667b    18.0%
   └ pepr.ts                           46b     1.2%

  dist/pepr-static-test.js.LEGAL.txt    0b   100.0%

Registered Pepr Capability "hello-pepr"
Module static-test has capability: hello-pepr
Module static-test has capability: hello-pepr
Module static-test has capability: hello-pepr
Module static-test has capability: hello-pepr
✅ K8s resource for the module saved to /Users/cmwylie19/pepr/pepr-test-module/dist/pepr-module-static-test.yaml
┌─[cmwylie19@Cases-MacBook-Pro] - [~/pepr/pepr-test-module] - [2024-03-07 12:43:51]
└─[0] <git:(main✈) > cat dist/pepr-module-static-test.yaml | egrep "image:"
          image: ghcr.io/defenseunicorns/pepr/controller:v99.99.99
          image: ghcr.io/defenseunicorns/pepr/controller:v99.99.99
```

Fixes for mandatory values that were marked as optional.

## Related Issue

Fixes #581 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
