### PR TITLE
chore: store startup speed

### DIFF
--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -110,13 +110,9 @@ export class PeprControllerStore {
       }
     };
 
-    if (this.#onReady) {
-      debounced();
-    }
-
     // Debounce the update to 1 second to avoid multiple rapid calls
     clearTimeout(this.#sendDebounce);
-    this.#sendDebounce = setTimeout(debounced, debounceBackoff);
+    this.#sendDebounce = setTimeout(debounced, this.#onReady ? 0 : debounceBackoff);
   };
 
   #send = (capabilityName: string) => {

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -65,7 +65,7 @@ export class PeprControllerStore {
           .then(this.#setupWatch)
           // Otherwise, create the resource
           .catch(this.#createStoreResource),
-      Math.random() * 1000,
+      Math.random() * 3000,
     );
   }
 

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -105,12 +105,14 @@ export class PeprControllerStore {
 
       // Call the onReady callback if this is the first time the secret has been read
       if (this.#onReady) {
-        debounced;
         this.#onReady();
         this.#onReady = undefined;
-        return;
       }
     };
+
+    if (this.#onReady) {
+      debounced();
+    }
 
     // Debounce the update to 1 second to avoid multiple rapid calls
     clearTimeout(this.#sendDebounce);

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -105,8 +105,10 @@ export class PeprControllerStore {
 
       // Call the onReady callback if this is the first time the secret has been read
       if (this.#onReady) {
+        debounced
         this.#onReady();
         this.#onReady = undefined;
+        return;
       }
     };
 

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -105,7 +105,7 @@ export class PeprControllerStore {
 
       // Call the onReady callback if this is the first time the secret has been read
       if (this.#onReady) {
-        debounced
+        debounced;
         this.#onReady();
         this.#onReady = undefined;
         return;


### PR DESCRIPTION
## Description

Skip debounce timeout on first read of the store which counts against time to be ready by the store and controller. Saves us 5 seconds

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
