### PR TITLE
chore: filter bug

### DIFF
--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -944,26 +944,46 @@ describe("replaceString", () => {
 });
 
 describe("checkOverlap", () => {
-  test("returns true if binding annotation/label does not have value and object value is different", () => {
+  test("should return false since all binding annotations/labels do not exist on the object", () => {
+    expect(checkOverlap({ key1: "", key2: "" }, { key1: "something" })).toBe(false);
+  });
+  test("should return false since all binding annotations/labels values do not match on the object values", () => {
+    expect(checkOverlap({ key1: "key1", key2: "key2" }, { key1: "value1", key2: "key2" })).toBe(false);
+  });
+  test("should return true since all binding annotations/labels keys and values match the object keys and values", () => {
+    expect(checkOverlap({ key1: "key1", key2: "key2" }, { key1: "key1", key2: "key2" })).toBe(true);
+  });
+
+  test("should return true since all binding annotations/labels keys exist on the object", () => {
+    expect(checkOverlap({ key1: "", key2: "" }, { key1: "key1", key2: "key2" })).toBe(true);
+  });
+
+  test("(Mixed) should return true since key and key value match on object", () => {
+    expect(checkOverlap({ key1: "one", key2: "" }, { key1: "one", key2: "something" })).toBe(true);
+  });
+  test("(Mixed) should return false since key1 value is differnet on object", () => {
+    expect(checkOverlap({ key1: "one", key2: "" }, { key1: "different", key2: "" })).toBe(false);
+  });
+  test("should return true since binding annotation/label since object contains binding key", () => {
     expect(checkOverlap({ key1: "" }, { key1: "value1" })).toBe(true);
   });
-  test("returns true if first record is empty", () => {
+  test("should return true if binding has no labels or annotations", () => {
     expect(checkOverlap({}, { key1: "value1" })).toBe(true);
   });
 
-  test("returns false if there is no overlap", () => {
+  test("should return false if there is no overlap", () => {
     expect(checkOverlap({ key1: "value1" }, { key2: "value2" })).toBe(false);
   });
 
-  test("returns true if there is an overlap", () => {
+  test("should return true since object has key1 and value1", () => {
     expect(checkOverlap({ key1: "value1" }, { key1: "value1", key2: "value2" })).toBe(true);
   });
 
-  test("returns false if keys match but values do not", () => {
+  test("should return false since object value does not match binding value", () => {
     expect(checkOverlap({ key1: "value1" }, { key1: "value2" })).toBe(false);
   });
 
-  test("returns true if first record is empty and second record is also empty", () => {
+  test("should return true if the object has no labels and neither does the binding", () => {
     expect(checkOverlap({}, {})).toBe(true);
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -944,6 +944,9 @@ describe("replaceString", () => {
 });
 
 describe("checkOverlap", () => {
+  test("returns true if binding annotation/label does not have value and object value is different", () => {
+    expect(checkOverlap({ key1: "" }, { key1: "value1" })).toBe(true);
+  });
   test("returns true if first record is empty", () => {
     expect(checkOverlap({}, { key1: "value1" })).toBe(true);
   });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -961,7 +961,7 @@ describe("checkOverlap", () => {
   test("(Mixed) should return true since key and key value match on object", () => {
     expect(checkOverlap({ key1: "one", key2: "" }, { key1: "one", key2: "something" })).toBe(true);
   });
-  test("(Mixed) should return false since key1 value is differnet on object", () => {
+  test("(Mixed) should return false since key1 value is different on object", () => {
     expect(checkOverlap({ key1: "one", key2: "" }, { key1: "different", key2: "" })).toBe(false);
   });
   test("should return true if binding has no labels or annotations", () => {

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -964,9 +964,6 @@ describe("checkOverlap", () => {
   test("(Mixed) should return false since key1 value is differnet on object", () => {
     expect(checkOverlap({ key1: "one", key2: "" }, { key1: "different", key2: "" })).toBe(false);
   });
-  test("should return true since binding annotation/label since object contains binding key", () => {
-    expect(checkOverlap({ key1: "" }, { key1: "value1" })).toBe(true);
-  });
   test("should return true if binding has no labels or annotations", () => {
     expect(checkOverlap({}, { key1: "value1" })).toBe(true);
   });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -19,7 +19,18 @@ export function checkOverlap(record1: Record<string, string>, record2: Record<st
   if (Object.keys(record1).length === 0) {
     return true;
   }
+
   for (const key in record1) {
+    // if the binding label/annnotation has key but no value
+    if (
+      Object.prototype.hasOwnProperty.call(record1, key) &&
+      record1[key] === "" &&
+      Object.prototype.hasOwnProperty.call(record2, key)
+    ) {
+      return true;
+    }
+
+    // if the binding label/annoation has key and value
     if (
       Object.prototype.hasOwnProperty.call(record1, key) &&
       Object.prototype.hasOwnProperty.call(record2, key) &&

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -15,31 +15,33 @@ type RBACMap = {
 };
 
 // check for overlap with labels and annotations between bindings and kubernetes objects
-export function checkOverlap(record1: Record<string, string>, record2: Record<string, string>) {
-  if (Object.keys(record1).length === 0) {
+export function checkOverlap(bindingFilters: Record<string, string>, objectFilters: Record<string, string>): boolean {
+  // True if labels/annotations are empty
+  if (Object.keys(bindingFilters).length === 0) {
     return true;
   }
 
-  for (const key in record1) {
-    // if the binding label/annnotation has key but no value
-    if (
-      Object.prototype.hasOwnProperty.call(record1, key) &&
-      record1[key] === "" &&
-      Object.prototype.hasOwnProperty.call(record2, key)
-    ) {
-      return true;
-    }
+  let matchCount = 0;
 
-    // if the binding label/annoation has key and value
-    if (
-      Object.prototype.hasOwnProperty.call(record1, key) &&
-      Object.prototype.hasOwnProperty.call(record2, key) &&
-      record1[key] === record2[key]
-    ) {
-      return true;
+  for (const key in bindingFilters) {
+    // object must have label/annotation
+    if (Object.prototype.hasOwnProperty.call(objectFilters, key)) {
+      const val1 = bindingFilters[key];
+      const val2 = objectFilters[key];
+
+      // If bindingFilter has empty value for this key, only need to ensure objectFilter has this key
+      if (val1 === "" && key in objectFilters) {
+        matchCount++;
+      }
+      // If bindingFilter has a value, it must match the value in objectFilter
+      else if (val1 !== "" && val1 === val2) {
+        matchCount++;
+      }
     }
   }
-  return false;
+
+  // For single-key objects in bindingFilter or matching all keys in multiple-keys scenario
+  return matchCount === Object.keys(bindingFilters).length;
 }
 
 /**


### PR DESCRIPTION
## Description

In Binding Filters, labels do not have to have values, they only have to have keys. In the event that there is not value, there is an implication that the value is "" (empty string).

This scenario was overlooked in the [checkOverlap](https://github.com/defenseunicorns/pepr/blob/ef780c4e449d17ecae29a792da267cab8dcba3cd/src/lib/helpers.ts#L26) function which checks if the binding's filters/annotations have overlap with the objects.

This was causing an error in UDS-Core as a pod was being ignored that contained the same key as the binding but a different value. 


```ts
export function checkOverlap(record1: Record<string, string>, record2: Record<string, string>) {
  if (Object.keys(record1).length === 0) {
    return true;
  }
  for (const key in record1) {
    if (
      Object.prototype.hasOwnProperty.call(record1, key) &&
      Object.prototype.hasOwnProperty.call(record2, key) &&
      record1[key] === record2[key] // VALUES MUST BE THE SAME
    ) {
      return true;
    }
  }
  return false;
}
```

For Example: 
```ts
When(a.ConfigMap)
  .IsCreated()
  .WithLabel("chuck-norris")
  .Mutate(async change => {
    // Try/catch is not needed as a response object will always be returned
    const response = await fetch<TheChuckNorrisJoke>(
      "https://api.chucknorris.io/jokes/random?category=dev",
    );
```
![image](https://github.com/defenseunicorns/pepr/assets/1096507/07115cdf-c175-4418-b8a7-da5f3706b0e3)

![image](https://github.com/defenseunicorns/pepr/assets/1096507/043d7b09-8e5a-4244-96cd-e7a4c0ed7fa5)

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
