### PR TITLE
chore: add patch/create crds

### DIFF
--- a/journey/resources/clusterrole.yaml
+++ b/journey/resources/clusterrole.yaml
@@ -13,6 +13,13 @@ rules:
       - patch
       - watch
   - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - patch
+      - create
+  - apiGroups:
       - ''
     resources:
       - namespaces

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -294,6 +294,10 @@ describe("createRBACMap", () => {
         verbs: ["create", "get", "patch", "watch"],
         plural: "peprstores",
       },
+      "apiextensions.k8s.io/v1/customresourcedefinition":{
+        verbs: ["patch","create"],
+        plural: "customresourcedefinitions",
+      },
       "/v1/Namespace": { verbs: ["watch"], plural: "namespaces" },
       "/v1/ConfigMap": { verbs: ["watch"], plural: "configmaps" },
     };

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -294,8 +294,8 @@ describe("createRBACMap", () => {
         verbs: ["create", "get", "patch", "watch"],
         plural: "peprstores",
       },
-      "apiextensions.k8s.io/v1/customresourcedefinition":{
-        verbs: ["patch","create"],
+      "apiextensions.k8s.io/v1/customresourcedefinition": {
+        verbs: ["patch", "create"],
         plural: "customresourcedefinitions",
       },
       "/v1/Namespace": { verbs: ["watch"], plural: "namespaces" },

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -120,6 +120,11 @@ export const createRBACMap = (capabilities: CapabilityExport[]): RBACMap => {
         plural: "peprstores",
       };
 
+      acc["apiextensions.k8s.io/v1/customresourcedefinition"] = {
+        verbs: ["patch", "create"],
+        plural: "customresourcedefinitions",
+      };
+
       if (!acc[key] && binding.isWatch) {
         acc[key] = {
           verbs: ["watch"],


### PR DESCRIPTION
## Description

https://github.com/defenseunicorns/pepr/issues/577

UDS ran into this problem:
```
Helm Problem Each Pepr module creates the CRD for PeprStore. A problem arrises when multiple Pepr modules are packaged in a helm chart. Helm will not render resources that already exist.
```

We fixed it in #580 which used the KFC to ServerSide Apply the PeprStore `CustomResourceDefinition`.

This led to a regression when building the pepr moduled with scoped rbac `npx pepr build --rbac-mode=scoped`

```json
{
  "level": 50,
  "time": 1710435728180,
  "pid": 1,
  "hostname": "pepr-6e43c347-0370-5954-bda3-552d74a5e3bd-6f8ddbb9dd-fvjrf",
  "data": {
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "customresourcedefinitions.apiextensions.k8s.io \"peprstores.pepr.dev\" is forbidden: ",
    "reason": "Forbidden",
    "details": {
      "name": "peprstores.pepr.dev",
      "group": "apiextensions.k8s.io",
      "kind": "customresourcedefinitions"
    },
    "code": 403
  },
  "ok": false,
  "status": 403,
  "statusText": "Forbidden"
}
{
  "level": 50,
  "time": 1710435597286,
  "pid": 1,
  "hostname": "pepr-6e43c347-0370-5954-bda3-552d74a5e3bd-6f8ddbb9dd-2q5vr",
  "data": {
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "customresourcedefinitions.apiextensions.k8s.io \"peprstores.pepr.dev\" is forbidden: User \"system:serviceaccount:pepr-system:pepr-6e43c347-0370-5954-bda3-552d74a5e3bd\" cannot patch resource \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the cluster scope",
    "reason": "Forbidden",
    "details": {
      "name": "peprstores.pepr.dev",
      "group": "apiextensions.k8s.io",
      "kind": "customresourcedefinitions"
    },
    "code": 403
  },
```

The code that generates the RBAC did not take into account this new criteria that it needed permissions to `patch`,`update` `CustomResourceDefinitions`.

This PR adds the necessary code so that RBAC mode gives the Pepr service account appropriate permissions to do the job

issue: Pods do not come up, permanent `CrashLoopBackOff`
```bash
┌─[cmwylie19@Cases-MacBook-Pro] - [~/deadass] - [2024-03-14 12:57:06]
└─[0] <git:(main✈) > k get po -n pepr-system 
NAME                                                         READY   STATUS             RESTARTS     AGE
pepr-6e43c347-0370-5954-bda3-552d74a5e3bd-6f8ddbb9dd-shj6j   0/1     CrashLoopBackOff   1 (3s ago)   8s
pepr-6e43c347-0370-5954-bda3-552d74a5e3bd-6f8ddbb9dd-mndd6   0/1     CrashLoopBackOff   1 (3s ago)   8s
```


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
