### PR TITLE
chore: add request uid to admission log messages

### DIFF
--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -16,6 +16,7 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
   const { group, kind, version } = binding.kind || {};
   const { namespaces, labels, annotations, name } = binding.filters || {};
   const operation = req.operation.toUpperCase();
+  const uid = req.uid;
   // Use the old object if the request is a DELETE operation
   const srcObject = operation === Operation.DELETE ? req.oldObject : req.object;
   const { metadata } = srcObject || {};
@@ -65,7 +66,7 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
       label = binding.watchCallback!.name;
     }
 
-    logger.debug(`${type} binding (${label}) does not match request namespace "${req.namespace}"`);
+    logger.debug({ uid }, `${type} binding (${label}) does not match request namespace "${req.namespace}"`);
 
     return true;
   }
@@ -76,13 +77,13 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
 
     // First check if the label exists
     if (!testKey) {
-      logger.debug(`Label ${key} does not exist`);
+      logger.debug({ uid }, `Label ${key} does not exist`);
       return true;
     }
 
     // Then check if the value matches, if specified
     if (value && testKey !== value) {
-      logger.debug(`${testKey} does not match ${value}`);
+      logger.debug({ uid }, `${testKey} does not match ${value}`);
       return true;
     }
   }
@@ -93,13 +94,13 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
 
     // First check if the annotation exists
     if (!testKey) {
-      logger.debug(`Annotation ${key} does not exist`);
+      logger.debug({ uid }, `Annotation ${key} does not exist`);
       return true;
     }
 
     // Then check if the value matches, if specified
     if (value && testKey !== value) {
-      logger.debug(`${testKey} does not match ${value}`);
+      logger.debug({ uid }, `${testKey} does not match ${value}`);
       return true;
     }
   }


### PR DESCRIPTION
## Description

Realized that our "skipped request" log messages don't include the admission webhook request correlation id -- this adds it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
