### PR TITLE
fix: dedupe environment variable config values

### DIFF
--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -344,14 +344,10 @@ function genEnv(config: ModuleConfig, watchMode = false): V1EnvVar[] {
   const def = {
     PEPR_WATCH_MODE: watchMode ? "true" : "false",
     PEPR_PRETTY_LOG: "false",
-    LOG_LEVEL: config.logLevel || "debug"
+    LOG_LEVEL: config.logLevel || "debug",
   };
-
   const cfg = config.env || {};
-
-  const env = Object
-    .entries({ ...def, ...cfg })
-    .map(([name, value]) => ({ name, value }));
+  const env = Object.entries({ ...def, ...cfg }).map(([name, value]) => ({ name, value }));
 
   return env;
 }

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -341,17 +341,17 @@ export function moduleSecret(name: string, data: Buffer, hash: string): kind.Sec
 }
 
 function genEnv(config: ModuleConfig, watchMode = false): V1EnvVar[] {
-  const env = [
-    { name: "PEPR_WATCH_MODE", value: watchMode ? "true" : "false" },
-    { name: "PEPR_PRETTY_LOG", value: "false" },
-    { name: "LOG_LEVEL", value: config.logLevel || "debug" },
-  ];
+  const def = {
+    PEPR_WATCH_MODE: watchMode ? "true" : "false",
+    PEPR_PRETTY_LOG: "false",
+    LOG_LEVEL: config.logLevel || "debug"
+  };
 
-  if (config.env) {
-    for (const [name, value] of Object.entries(config.env)) {
-      env.push({ name, value });
-    }
-  }
+  const cfg = config.env || {};
+
+  const env = Object
+    .entries({ ...def, ...cfg })
+    .map(([name, value]) => ({ name, value }));
 
   return env;
 }


### PR DESCRIPTION
## Description

Working through an excellent example test I discovered that trying to use the package.json > pepr > env > LOG_LEVEL: "debug" configuration override didn't work correctly -- the merge logic was duplicating the LOG_LEVEL rather than overriding it.

This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
