### PR TITLE
chore: remove loglevel from docs and audit logs in the cli

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -16,7 +16,7 @@ Initialize a new Pepr Module.
 
 **Options:**
 
-- `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
+
 - `--skip-post-init` - Skip npm install, git init and VSCode launch
 
 ---
@@ -27,7 +27,7 @@ Update the current Pepr Module to the latest SDK version and update the global P
 
 **Options:**
 
-- `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
+
 - `--skip-template-update` - Skip updating the template files
 
 ---
@@ -38,7 +38,6 @@ Connect a local cluster to a local version of the Pepr Controller to do real-tim
 
 **Options:**
 
-- `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
 - `-h, --host [host]` - Host to listen on (default: "host.k3d.internal")
 - `--confirm` - Skip confirmation prompt
 
@@ -50,7 +49,6 @@ Deploy the current module into a Kubernetes cluster, useful for CI systems. Not 
 
 **Options:**
 
-- `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
 - `-i, --image [image]` - Override the image tag
 - `--confirm` - Skip confirmation prompt
 
@@ -68,7 +66,6 @@ npx pepr monitor [options] [module-uuid]
 
 **Options:**
 
-- `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
 - `-h, --help` - Display help for command
 
 ---
@@ -89,7 +86,6 @@ Create a [zarf.yaml](https://zarf.dev) and K8s manifest for the current module. 
 
 **Options:**
 
-- `-l, --log-level [level]` - Log level: debug, info, warn, error (default: "info")
 - `-e, --entry-point [file]` - Specify the entry point file to build with. (default: "pepr.ts")
 - `-n, --no-embed` - Disables embedding of deployment files into output module. Useful when creating library modules intended solely for reuse/distribution via NPM
 - `-r, --registry-info [<registry>/<username>]` - Registry Info: Image registry and username. Note: You must be signed into the registry

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -62,7 +62,7 @@ export default function (program: RootCmd) {
       if (opts.outputDir) {
         outputDir = opts.outputDir;
         createDirectoryIfNotExists(outputDir).catch(error => {
-          console.error(`Error creating output directory: ${error}`);
+          console.error(`Error creating output directory: ${error.message}`);
           process.exit(1);
         });
       }

--- a/src/cli/kfc.ts
+++ b/src/cli/kfc.ts
@@ -24,14 +24,9 @@ export default function (program: RootCmd) {
         return;
       }
 
-      console.log("Preparing to execute the requested KFC command...");
-
       try {
         // If the user doesn't provide any kfc arguments, show the kfc help
         if (args.length === 0) {
-          console.log(
-            "No kubernetes-fluent-client arguments provided. Showing kubernetes-fluent-client help...",
-          );
           args.push("--help");
         }
 
@@ -42,8 +37,6 @@ export default function (program: RootCmd) {
         execSync(`kubernetes-fluent-client ${argsString}`, {
           stdio: "inherit",
         });
-
-        console.log(`✅ KFC command executed successfully`);
       } catch (e) {
         console.error(e.message);
         process.exit(1);

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -77,7 +77,7 @@ export default function (program: RootCmd) {
                   .map((r: ResponseItem) => r.status.message);
                 if (filteredFailures.length > 0) {
                   console.log(`\n❌  VALIDATE   ${name} (${uid})`);
-                  console.debug(`\u001b[1;31m${filteredFailures}\u001b[0m`);
+                  console.log(`\u001b[1;31m${filteredFailures}\u001b[0m`);
                 } else {
                   console.log(`\n✅  VALIDATE   ${name} (${uid})`);
                 }

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -3,19 +3,10 @@
 
 import { Command } from "commander";
 
-import Log from "../lib/logger";
-
 export class RootCmd extends Command {
   // eslint-disable-next-line class-methods-use-this
   createCommand(name: string) {
     const cmd = new Command(name);
-
-    cmd.option("-l, --log-level [level]", "Log level: debug, info, warn, error", "info");
-
-    cmd.hook("preAction", run => {
-      Log.level = run.opts().logLevel;
-    });
-
     return cmd;
   }
 }


### PR DESCRIPTION
## Description

As a team due to #659 we have decided to audit our logs. The `CLI` uses console while `pino` is used in the controllers. We are looking for standardization to improve the Pepr experience.

We:
- removed unnecessary log messages
- removed the log level from the cli which was not needed
- updated the docs to reflect this work
- updated an error message where necessary 

![image](https://github.com/defenseunicorns/pepr/assets/1096507/a4b20d1e-e4c7-48a6-b78e-96d59c8d6bc4)

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
