### PR TITLE
chore: fully remove store references in watch-processor

### DIFF
--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -53,7 +53,6 @@ describe("WatchProcessor", () => {
     mockWatch.mockImplementation(() => {
       return {
         start: mockStart,
-        getCacheID: jest.fn().mockReturnValue("57332a1dee"),
         events: {
           on: mockEvents,
         },


### PR DESCRIPTION
## Description

There are still references lingering to the store. We need to remove them fully.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
