### PR TITLE
fix: reconcile enqueue bindings

### DIFF
--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { Binding, CapabilityExport } from "./types";
-import { createRBACMap, addVerbIfNotExists, checkOverlap, filterMatcher } from "./helpers";
+import { createRBACMap, addVerbIfNotExists, checkOverlap, filterNoMatchReason } from "./helpers";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
 import { parseTimeout, secretOverLimit, replaceString } from "./helpers";
 import { promises as fs } from "fs";
@@ -997,7 +997,7 @@ describe("filterMatcher", () => {
     };
     const obj = {};
     const capabilityNamespaces: string[] = [];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1013,7 +1013,7 @@ describe("filterMatcher", () => {
       metadata: { labels: { anotherKey: "anotherValue" } },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1031,7 +1031,7 @@ describe("filterMatcher", () => {
       metadata: { annotations: { anotherKey: "anotherValue" } },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1047,7 +1047,7 @@ describe("filterMatcher", () => {
       metadata: { namespace: "ns2" },
     };
     const capabilityNamespaces = ["ns1"];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1063,7 +1063,7 @@ describe("filterMatcher", () => {
     };
     const obj = {};
     const capabilityNamespaces = ["ns1", "ns2"];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1081,7 +1081,7 @@ describe("filterMatcher", () => {
       metadata: { namespace: "ns2" },
     };
     const capabilityNamespaces = ["ns1", "ns2"];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1099,7 +1099,7 @@ describe("filterMatcher", () => {
       metadata: { namespace: "ns1", labels: { key: "value" }, annotations: { key: "value" } },
     };
     const capabilityNamespaces = ["ns1"];
-    const result = filterMatcher(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
+import { promises as fs } from "fs";
 import { K8s, KubernetesObject, kind } from "kubernetes-fluent-client";
 import Log from "./logger";
-import { CapabilityExport } from "./types";
-import { promises as fs } from "fs";
-import { Binding } from "./types";
+import { Binding, CapabilityExport } from "./types";
 
 type RBACMap = {
   [key: string]: {
@@ -47,11 +46,11 @@ export function checkOverlap(bindingFilters: Record<string, string>, objectFilte
 /**
  * Decide to run callback after the event comes back from API Server
  **/
-export const filterMatcher = (
+export function filterNoMatchReason(
   binding: Partial<Binding>,
   obj: Partial<KubernetesObject>,
   capabilityNamespaces: string[],
-): string => {
+): string {
   // binding kind is namespace with a InNamespace filter
   if (binding.kind && binding.kind.kind === "Namespace" && binding.filters && binding.filters.namespaces.length !== 0) {
     return `Ignoring Watch Callback: Cannot use a namespace filter in a namespace object.`;
@@ -116,14 +115,15 @@ export const filterMatcher = (
 
   // no problems
   return "";
-};
-export const addVerbIfNotExists = (verbs: string[], verb: string) => {
+}
+
+export function addVerbIfNotExists(verbs: string[], verb: string) {
   if (!verbs.includes(verb)) {
     verbs.push(verb);
   }
-};
+}
 
-export const createRBACMap = (capabilities: CapabilityExport[]): RBACMap => {
+export function createRBACMap(capabilities: CapabilityExport[]): RBACMap {
   return capabilities.reduce((acc: RBACMap, capability: CapabilityExport) => {
     capability.bindings.forEach(binding => {
       const key = `${binding.kind.group}/${binding.kind.version}/${binding.kind.kind}`;
@@ -148,7 +148,7 @@ export const createRBACMap = (capabilities: CapabilityExport[]): RBACMap => {
 
     return acc;
   }, {});
-};
+}
 
 export async function createDirectoryIfNotExists(path: string) {
   try {

--- a/src/lib/queue.test.ts
+++ b/src/lib/queue.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, expect, jest, describe, test } from "@jest/globals";
-import { Queue } from "./queue";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { KubernetesObject } from "@kubernetes/client-node";
+import { WatchPhase } from "kubernetes-fluent-client/dist/fluent/types";
+import { Queue } from "./queue";
+
 describe("Queue", () => {
   let queue: Queue<KubernetesObject>;
 
@@ -12,7 +14,7 @@ describe("Queue", () => {
     const pod = {
       metadata: { name: "test-pod", namespace: "test-pod" },
     };
-    const promise = queue.enqueue(pod);
+    const promise = queue.enqueue(pod, WatchPhase.Added);
     expect(promise).toBeInstanceOf(Promise);
     await promise;
   });
@@ -26,8 +28,8 @@ describe("Queue", () => {
     };
 
     // Enqueue two packages
-    const promise1 = queue.enqueue(mockPod);
-    const promise2 = queue.enqueue(mockPod2);
+    const promise1 = queue.enqueue(mockPod, WatchPhase.Added);
+    const promise2 = queue.enqueue(mockPod2, WatchPhase.Modified);
 
     // Wait for both promises to resolve
     await promise1;
@@ -42,7 +44,7 @@ describe("Queue", () => {
     jest.spyOn(queue, "setReconcile").mockRejectedValueOnce(error as never);
 
     try {
-      await queue.enqueue(mockPod);
+      await queue.enqueue(mockPod, WatchPhase.Added);
     } catch (e) {
       expect(e).toBe(error);
     }
@@ -51,6 +53,6 @@ describe("Queue", () => {
     const mockPod2 = {
       metadata: { name: "test-pod-2", namespace: "test-namespace-2" },
     };
-    await queue.enqueue(mockPod2);
+    await queue.enqueue(mockPod2, WatchPhase.Modified);
   });
 });

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -1,15 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
-import { K8s, WatchCfg, WatchEvent } from "kubernetes-fluent-client";
+import { K8s, KubernetesObject, WatchCfg, WatchEvent } from "kubernetes-fluent-client";
 import { WatchPhase } from "kubernetes-fluent-client/dist/fluent/types";
-import { Queue } from "./queue";
 import { Capability } from "./capability";
+import { filterNoMatchReason } from "./helpers";
 import Log from "./logger";
+import { Queue } from "./queue";
 import { Binding, Event } from "./types";
-import { Watcher } from "kubernetes-fluent-client/dist/fluent/watch";
-import { GenericClass } from "kubernetes-fluent-client";
-import { filterMatcher } from "./helpers";
 
+// Watch configuration
+const watchCfg: WatchCfg = {
+  retryMax: 5,
+  retryDelaySec: 5,
+};
+
+// Map the event to the watch phase
+const eventToPhaseMap = {
+  [Event.Create]: [WatchPhase.Added],
+  [Event.Update]: [WatchPhase.Modified],
+  [Event.CreateOrUpdate]: [WatchPhase.Added, WatchPhase.Modified],
+  [Event.Delete]: [WatchPhase.Deleted],
+  [Event.Any]: [WatchPhase.Added, WatchPhase.Modified, WatchPhase.Deleted],
+};
+
+/**
+ * Entrypoint for setting up watches for all capabilities
+ *
+ * @param capabilities The capabilities to load watches for
+ */
 export function setupWatch(capabilities: Capability[]) {
   capabilities.map(capability =>
     capability.bindings
@@ -18,69 +36,53 @@ export function setupWatch(capabilities: Capability[]) {
   );
 }
 
+/**
+ * Setup a watch for a binding
+ *
+ * @param binding the binding to watch
+ * @param capabilityNamespaces list of namespaces to filter on
+ */
 async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
-  // Map the event to the watch phase
-  const eventToPhaseMap = {
-    [Event.Create]: [WatchPhase.Added],
-    [Event.Update]: [WatchPhase.Modified],
-    [Event.CreateOrUpdate]: [WatchPhase.Added, WatchPhase.Modified],
-    [Event.Delete]: [WatchPhase.Deleted],
-    [Event.Any]: [WatchPhase.Added, WatchPhase.Modified, WatchPhase.Deleted],
-  };
-
-  // Get the phases to match, default to any
+  // Get the phases to match, fallback to any
   const phaseMatch: WatchPhase[] = eventToPhaseMap[binding.event] || eventToPhaseMap[Event.Any];
 
-  const watchCfg: WatchCfg = {
-    retryMax: 5,
-    retryDelaySec: 5,
+  // The watch callback is run when an object is received or dequeued
+  const watchCallback = async (obj: KubernetesObject, type: WatchPhase) => {
+    // First, filter the object based on the phase
+    if (phaseMatch.includes(type)) {
+      try {
+        // Then, check if the object matches the filter
+        const filterMatch = filterNoMatchReason(binding, obj, capabilityNamespaces);
+        if (filterMatch === "") {
+          await binding.watchCallback?.(obj, type);
+        } else {
+          Log.debug(filterMatch);
+        }
+      } catch (e) {
+        // Errors in the watch callback should not crash the controller
+        Log.error(e, "Error executing watch callback");
+      }
+    }
   };
 
-  let watcher: Watcher<GenericClass>;
-  if (binding.isQueue) {
-    const queue = new Queue();
-    // Watch the resource
-    watcher = K8s(binding.model, binding.filters).Watch(async (obj, type) => {
-      Log.debug(obj, `Watch event ${type} received`);
+  const queue = new Queue();
+  queue.setReconcile(watchCallback);
 
-      // If the type matches the phase, call the watch callback
-      if (phaseMatch.includes(type)) {
-        try {
-          const filterMatch = filterMatcher(binding, obj, capabilityNamespaces);
-          if (filterMatch === "") {
-            queue.setReconcile(async () => await binding.watchCallback?.(obj, type));
-            // Enqueue the object for reconciliation through callback
-            await queue.enqueue(obj);
-          } else {
-            Log.debug(filterMatch);
-          }
-        } catch (e) {
-          // Errors in the watch callback should not crash the controller
-          Log.error(e, "Error executing watch callback");
-        }
-      }
-    }, watchCfg);
-  } else {
-    // Watch the resource
-    watcher = K8s(binding.model, binding.filters).Watch(async (obj, type) => {
-      Log.debug(obj, `Watch event ${type} received`);
+  // Setup the resource watch
+  const watcher = K8s(binding.model, binding.filters).Watch(() => {}, watchCfg);
 
-      // If the type matches the phase, call the watch callback
-      if (phaseMatch.includes(type)) {
-        try {
-          const filterMatch = filterMatcher(binding, obj, capabilityNamespaces);
-          if (filterMatch === "") {
-            await binding.watchCallback?.(obj, type);
-          } else {
-            Log.debug(filterMatch);
-          }
-        } catch (e) {
-          // Errors in the watch callback should not crash the controller
-          Log.error(e, "Error executing watch callback");
-        }
-      }
-    }, watchCfg);
-  }
+  // Bind watch to the data event
+  watcher.events.on(WatchEvent.DATA, async (obj, type) => {
+    Log.debug(obj, `Watch event ${type} received`);
+
+    // If the binding is a queue, enqueue the object
+    if (binding.isQueue) {
+      await queue.enqueue(obj, type);
+    } else {
+      // Otherwise, run the watch callback directly
+      await watchCallback(obj, type);
+    }
+  });
 
   // If failure continues, log and exit
   watcher.events.on(WatchEvent.GIVE_UP, err => {

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -69,10 +69,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
   queue.setReconcile(watchCallback);
 
   // Setup the resource watch
-  const watcher = K8s(binding.model, binding.filters).Watch(() => {}, watchCfg);
-
-  // Bind watch to the data event
-  watcher.events.on(WatchEvent.DATA, async (obj, type) => {
+  const watcher = K8s(binding.model, binding.filters).Watch(async (obj, type) => {
     Log.debug(obj, `Watch event ${type} received`);
 
     // If the binding is a queue, enqueue the object
@@ -82,7 +79,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
       // Otherwise, run the watch callback directly
       await watchCallback(obj, type);
     }
-  });
+  }, watchCfg);
 
   // If failure continues, log and exit
   watcher.events.on(WatchEvent.GIVE_UP, err => {


### PR DESCRIPTION
## Description

Ensure k8s objects passed into dequeue functions by reconcile are not overwritten.

## Related Issue

Fixes #625 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
