### PR TITLE
chore: add test for when capability is schedule

### DIFF
--- a/src/lib/module.test.ts
+++ b/src/lib/module.test.ts
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { beforeEach, expect, jest, test } from "@jest/globals";
+import { beforeEach, expect, jest, test,describe } from "@jest/globals";
 import { clone } from "ramda";
 import { Capability } from "./capability";
-
+import { Schedule } from "./schedule";
 import { Errors } from "./errors";
 import { PackageJSON, PeprModule } from "./module";
 import { CapabilityExport } from "./types";
+import { on } from "events";
 
 // Mock Controller
 const startServerMock = jest.fn();
@@ -97,4 +98,32 @@ test("should send the capabilities to the parent process if PEPR_MODE is set to 
 
   new PeprModule(packageJSON, [capability]);
   expect(sendMock).toHaveBeenCalledWith([expected]);
+});
+
+describe('Capability', () => {
+  let capability: Capability;
+  let schedule: Schedule;
+
+  beforeEach(() => {
+    capability = new Capability({
+      name: "test",
+      description: "test",
+    });
+    schedule = {
+      name: 'test-name',
+      every: 1,
+      unit: 'seconds',
+      run: jest.fn(),
+      startTime: new Date(),
+      completions: 1,
+    };
+
+  
+  });
+
+  test('should handle OnSchedule', () => {
+    let { OnSchedule } = capability;
+    OnSchedule(schedule);
+    expect(capability.hasSchedule).toBe(true);
+  });
 });

--- a/src/lib/module.test.ts
+++ b/src/lib/module.test.ts
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { beforeEach, expect, jest, test,describe } from "@jest/globals";
+import { beforeEach, expect, jest, test, describe } from "@jest/globals";
 import { clone } from "ramda";
 import { Capability } from "./capability";
 import { Schedule } from "./schedule";
 import { Errors } from "./errors";
 import { PackageJSON, PeprModule } from "./module";
 import { CapabilityExport } from "./types";
-import { on } from "events";
 
 // Mock Controller
 const startServerMock = jest.fn();
@@ -100,7 +99,7 @@ test("should send the capabilities to the parent process if PEPR_MODE is set to 
   expect(sendMock).toHaveBeenCalledWith([expected]);
 });
 
-describe('Capability', () => {
+describe("Capability", () => {
   let capability: Capability;
   let schedule: Schedule;
 
@@ -110,19 +109,17 @@ describe('Capability', () => {
       description: "test",
     });
     schedule = {
-      name: 'test-name',
+      name: "test-name",
       every: 1,
-      unit: 'seconds',
+      unit: "seconds",
       run: jest.fn(),
       startTime: new Date(),
       completions: 1,
     };
-
-  
   });
 
-  test('should handle OnSchedule', () => {
-    let { OnSchedule } = capability;
+  test("should handle OnSchedule", () => {
+    const { OnSchedule } = capability;
     OnSchedule(schedule);
     expect(capability.hasSchedule).toBe(true);
   });


### PR DESCRIPTION
## Description

Add unit test around if capability has schedule

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
