### PR TITLE
chore: testing the e2e test

### DIFF
--- a/.github/workflows/excellent-examples.yml
+++ b/.github/workflows/excellent-examples.yml
@@ -1,0 +1,42 @@
+name: E2E Test on Excellent Examples
+
+
+permissions: read-all
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *' # 12AM EST/9PM PST
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout External Repository
+      uses: actions/checkout@v2
+      with:
+        repository: defenseunicorns/pepr-excellent-examples
+        path: 'pepr-excellent-examples' 
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20' 
+
+    - name: Install Excellent Example Dependencies
+      run: npm ci
+      working-directory: ./pepr-excellent-examples 
+
+    - name: "Install K3d"
+      run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+      shell: bash
+
+    - name: Install Pepr Dependencies
+      run: npm ci
+
+    - name: Build Dev Image for Pepr Core
+      run: npm run test:journey:image
+
+    - name: Run E2E Tests
+      run: npm run test:e2e -- -i pepr:dev
+      working-directory: ./pepr-excellent-examples


### PR DESCRIPTION
## Description

Creates a workflow that can be triggered manually and runs at 12am EST that runs the Pepr dev image against the excellent examples.

_other thoughts_: I think we should report the results to Pepr team in slack.

## Related Issue

Fixes #694 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
