### PR TITLE
chore: excellent examples new path

### DIFF
--- a/.github/workflows/excellent-examples.yml
+++ b/.github/workflows/excellent-examples.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
 
     - name: Install Pepr Dependencies
-      run: npm ci
+      run: npm i
 
     - name: Build Dev Image for Pepr Core
       run: npm run test:journey:image

--- a/.github/workflows/excellent-examples.yml
+++ b/.github/workflows/excellent-examples.yml
@@ -25,18 +25,19 @@ jobs:
 
     - name: Install Excellent Example Dependencies
       run: npm ci
-      working-directory: ./pepr-excellent-examples 
+      working-directory: ./pepr-excellent-examples/pepr-excellent-examples 
 
     - name: "Install K3d"
       run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
       shell: bash
 
     - name: Install Pepr Dependencies
-      run: npm i
+      run: npm ci
+      working-directory: ./pepr-excellent-examples/pepr-excellent-examples 
 
     - name: Build Dev Image for Pepr Core
       run: npm run test:journey:image
 
     - name: Run E2E Tests
       run: npm run test:e2e -- -i pepr:dev
-      working-directory: ./pepr-excellent-examples
+      working-directory: ./pepr-excellent-examples/pepr-excellent-examples 

--- a/.github/workflows/excellent-examples.yml
+++ b/.github/workflows/excellent-examples.yml
@@ -34,6 +34,11 @@ jobs:
     - name: Install Pepr Dependencies
       run: npm ci
       working-directory: ./pepr-excellent-examples/pepr-excellent-examples 
+      
+    - name: List dir contents
+      run: "ls -l"
+      shell: bash
+      working-directory: ./pepr-excellent-examples/pepr-excellent-examples 
 
     - name: Build Dev Image for Pepr Core
       run: npm run test:journey:image


### PR DESCRIPTION
## Description

There are two possibilites why the excellent-examples pipeline is broken:
1. we need to use `npm i` instead of `npm ci ` for some reason? 
2. The project is not being cloned in the directory that we think.

I think it is the latter but in order to test we have to merge in order to test

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
