### PR TITLE
fix: switch to node-lts chainguard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### BUILD ###
 
-FROM docker.io/library/node:20-alpine@sha256:c0a3badbd8a0a760de903e00cedbca94588e609299820557e72cba2a53dbaa2c as with-git
+FROM docker.io/library/node:20-alpine@sha256:ef3f47741e161900ddd07addcaca7e76534a9205e4cd73b2ed091ba339004a75 as with-git
 
 WORKDIR /app
 
@@ -26,12 +26,10 @@ RUN npm ci --omit=dev --omit=peer && \
 COPY --chown=node:node ./dist/  ./node_modules/pepr/dist/
 COPY --chown=node:node ./package.json  ./node_modules/pepr/package.json
 
-
 ##### DELIVER #####
 
-FROM cgr.dev/chainguard/node:20@sha256:f30d39c6980f0a50119f2aa269498307a80c2654928d8e23bb25431b9cbbdc4f
+FROM cgr.dev/chainguard/node-lts@sha256:cc860c41bc65df04dc0f2baba355fc4305bf52fc50ff19facb48fcfc879e0413
 
 WORKDIR /app
 
 COPY --from=with-git --chown=node:node /app/ /app/
-


### PR DESCRIPTION
Chainguard stopped publishing versioned images outside of `latest` last fall and so dependabot never picked up a newer version. Thanks to @eddiezane pointing this out, we were using a very stale image. This switches the upstream image to the equivalent lts version of Node, which will change version in the next couple of months, but matches our current NodeJS compatibility for Pepr.  