### PR TITLE
chore: vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -1,0 +1,30 @@
+name: Grype Vulnerability Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  grype-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Use Node.js latest
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Install Pepr Dependencies
+        run: npm ci
+      - name: Build Pepr Dev Image
+        run: npm run build:image
+      - name: Scan image
+        uses: anchore/scan-action@v3
+        with:
+          image: "pepr:dev"
+          fail-build: true
+          severity-cutoff: high

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gen-data-json": "node hack/build-template-data.js",
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "build": "tsc && node build.mjs",
+    "build:image": "test:journey:build && docker buildx build --tag pepr:dev .",
     "test": "npm run test:unit && npm run test:journey",
     "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles --coverageDirectory=./coverage",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gen-data-json": "node hack/build-template-data.js",
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "build": "tsc && node build.mjs",
-    "build:image": "test:journey:build && docker buildx build --tag pepr:dev .",
+    "build:image": "npm run test:journey:build && docker buildx build --tag pepr:dev .",
     "test": "npm run test:unit && npm run test:journey",
     "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles --coverageDirectory=./coverage",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gen-data-json": "node hack/build-template-data.js",
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "build": "tsc && node build.mjs",
-    "build:image": "npm run test:journey:build && docker buildx build --tag pepr:dev .",
+    "build:image": "npm run build && docker buildx build --tag pepr:dev .",
     "test": "npm run test:unit && npm run test:journey",
     "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles --coverageDirectory=./coverage",
     "test:journey": "npm run test:journey:k3d && npm run test:journey:build && npm run test:journey:image && npm run test:journey:run",


### PR DESCRIPTION
## Description

Chainguard stopped publishing versioned images outside of `latest` last fall and so dependabot never picked up a newer version. This led to a stale Pepr Controller image that had vulnerabilities from not being maintained. This step in CI will fail if there are high vulnerabilities in the `pepr:dev` image which is the candidate image for release. If there are vulnerabilities it will trigger our team to research why the vulnerabilities are there, ie checking to ensure we have the latest and correct images.

CC: Thanks @eddiezane @jeff-mccoy for pointing it out 

## Related Issue

Fixes #
<!-- or -->
Relates to #716 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
