### PR TITLE
chore: onschedule runs always in dev mode

### DIFF
--- a/docs/030_user-guide/080_onschedule.md
+++ b/docs/030_user-guide/080_onschedule.md
@@ -2,9 +2,6 @@
 
 The `OnSchedule` feature allows you to schedule and automate the execution of specific code at predefined intervals or schedules. This feature is designed to simplify recurring tasks and can serve as an alternative to traditional CronJobs. This code is designed to be run at the top level on a Capability, not within a function like `When`.
 
-> **Note -** To use this feature in dev mode you MUST set `PEPR_WATCH_MODE="true"`. This is because the scheduler only runs on the watch controller and the watch controller is not started by default in dev mode.
-
-For example: `PEPR_WATCH_MODE="true" npx pepr dev`
 
 ## Best Practices
 

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -50,7 +50,7 @@ export class Capability implements CapabilityExport {
     const { name, every, unit, run, startTime, completions } = schedule;
     this.hasSchedule = true;
 
-    if (process.env.PEPR_WATCH_MODE === "true") {
+    if (process.env.PEPR_WATCH_MODE === "true" || process.env.PEPR_MODE === "dev") {
       // Only create/watch schedule store if necessary
 
       // Create a new schedule


### PR DESCRIPTION
## Description

When using `npx pepr dev` the schedule is automatically invoked instead of relying on the env vars from the deployments

## Related Issue

Fixes #724 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
