### PR TITLE
ci: define least privilege permission for vuln scan workflow

### DIFF
--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -1,5 +1,8 @@
 name: Grype Vulnerability Scan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Description
Fixes the following OSSF scorecard warning:

https://securityscorecards.dev/viewer/?uri=github.com/defenseunicorns/pepr

<img width="865" alt="scorecard" src="https://github.com/defenseunicorns/pepr/assets/87675701/35f78999-3752-44f2-b9fd-e0f0c37796d5">

## Type of change

- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
