### PR TITLE
chore: update build.mjs to get around error

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, latest]
+        node-version: [18, 20, latest]
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, latest]
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, latest]
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/build.mjs
+++ b/build.mjs
@@ -1,11 +1,9 @@
 /* eslint-disable no-undef */
 
 import { analyzeMetafile, build } from "esbuild";
-import { readFile } from 'fs/promises';
+import packageJSON from "./package.json" with { type: "json" };
 
-const { dependencies, peerDependencies } = await loadPackageJSON();
-
-
+const { dependencies, peerDependencies } = packageJSON;
 const external = Object.keys(dependencies).concat(Object.keys(peerDependencies), "@kubernetes/client-node");
 
 const buildOpts = {
@@ -55,16 +53,4 @@ async function builder() {
   }
 }
 
-async function loadPackageJSON() {
-  try {
-    const data = await readFile('./package.json', { encoding: 'utf8' });
-    return JSON.parse(data);
-  } catch (error) {
-    console.error('Error reading package.json', error);
-    process.exit(1);
-  }
-}
-
 builder();
-
-

--- a/build.mjs
+++ b/build.mjs
@@ -1,10 +1,11 @@
 /* eslint-disable no-undef */
 
 import { analyzeMetafile, build } from "esbuild";
+import { readFile } from 'fs/promises';
 
-import packageJSON from "./package.json" assert { type: "json" };
+const { dependencies, peerDependencies } = await loadPackageJSON();
 
-const { dependencies, peerDependencies } = packageJSON;
+
 const external = Object.keys(dependencies).concat(Object.keys(peerDependencies), "@kubernetes/client-node");
 
 const buildOpts = {
@@ -54,4 +55,16 @@ async function builder() {
   }
 }
 
+async function loadPackageJSON() {
+  try {
+    const data = await readFile('./package.json', { encoding: 'utf8' });
+    return JSON.parse(data);
+  } catch (error) {
+    console.error('Error reading package.json', error);
+    process.exit(1);
+  }
+}
+
 builder();
+
+


### PR DESCRIPTION
## Description

Update the build.mjs file so fix the broken assert that causes errors in Node.js v22.0.0 

## Related Issue

Fixes #759 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
