### PR TITLE
chore: remove webhooks after exiting `npx pepr dev`

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -22,7 +22,7 @@ Update the current Pepr Module to the latest SDK version. This command is not re
 
 ## `npx pepr dev`
 
-Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module. Note the `npx pepr dev` assumes a K3d cluster is running by default. If you are working with Kind or another docker-based K8s distro, you will need to pass the `--host host.docker.internal` option to `npx pepr dev`. If working with a remote cluster you will have to give Pepr a host path to your machine that is reachable from the K8s cluster.
+Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module. Note the `npx pepr dev` assumes a K3d cluster is running by default. If you are working with Kind or another docker-based K8s distro, you will need to pass the `--host host.docker.internal` option to `npx pepr dev`. If working with a remote cluster you will have to give Pepr a host path to your machine that is reachable from the K8s cluster. Please note that this command installs the `pepr-system` namespace and the `PeprStore` CRD into the cluster.
 
 **Options:**
 

--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -22,7 +22,13 @@ Update the current Pepr Module to the latest SDK version. This command is not re
 
 ## `npx pepr dev`
 
-Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module. Note the `npx pepr dev` assumes a K3d cluster is running by default. If you are working with Kind or another docker-based K8s distro, you will need to pass the `--host host.docker.internal` option to `npx pepr dev`. If working with a remote cluster you will have to give Pepr a host path to your machine that is reachable from the K8s cluster. Please note that this command installs the `pepr-system` namespace and the `PeprStore` CRD into the cluster.
+Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module. Note the `npx pepr dev` assumes a K3d cluster is running by default. If you are working with Kind or another docker-based K8s distro, you will need to pass the `--host host.docker.internal` option to `npx pepr dev`. If working with a remote cluster you will have to give Pepr a host path to your machine that is reachable from the K8s cluster.
+
+NOTE: This command, by necessity, installs resources into the cluster you run it against.  Generally, these resources are removed once the `pepr dev` session ends but there are two notable exceptions:
+- the `pepr-system` namespace, and
+- the `PeprStore` CRD.
+
+These can't be auto-removed because they're global in scope & doing so would risk wrecking any other Pepr deployments that are already running in-cluster.  If (for some strange reason) you're _not_ `pepr dev`-ing against an ephemeral dev cluster and need to keep the cluster clean, you'll have to remove these hold-overs yourself (or not)!
 
 **Options:**
 

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -9,7 +9,7 @@ import { Assets } from "../lib/assets";
 import { buildModule, loadModule } from "./build";
 import { RootCmd } from "./root";
 import { K8s, kind } from "kubernetes-fluent-client";
-
+import { PeprStore } from "../lib/k8s";
 export default function (program: RootCmd) {
   program
     .command("dev")
@@ -51,6 +51,8 @@ export default function (program: RootCmd) {
       try {
         let program: ChildProcess;
         const name = `pepr-${cfg.pepr.uuid}`;
+        const scheduleStore = `pepr-${cfg.pepr.uuid}-schedule`;
+        const store = `pepr-${cfg.pepr.uuid}-store`;
 
         // Run the processed javascript file
         const runFork = async () => {
@@ -84,6 +86,8 @@ export default function (program: RootCmd) {
             await Promise.all([
               K8s(kind.MutatingWebhookConfiguration).Delete(name),
               K8s(kind.ValidatingWebhookConfiguration).Delete(name),
+              K8s(PeprStore).InNamespace("pepr-system").Delete(scheduleStore),
+              K8s(PeprStore).InNamespace("pepr-system").Delete(store),
             ]);
           });
 

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -84,16 +84,16 @@ export async function mutateProcessor(
         // Add annotations to the request to indicate that the capability succeeded
         updateStatus("succeeded");
       } catch (e) {
-        Log.warn(actionMetadata, `Action failed: ${e}`);
+        Log.warn(actionMetadata, `Action failed: ${JSON.stringify(e)}`);
         updateStatus("warning");
 
         // Annoying ts false positive
         response.warnings = response.warnings || [];
-        response.warnings.push(`Action failed: ${e}`);
+        response.warnings.push(`Action failed: ${JSON.stringify(e)}`);
 
         switch (config.onError) {
           case Errors.reject:
-            Log.error(actionMetadata, `Action failed: ${e}`);
+            Log.error(actionMetadata, `Action failed: ${JSON.stringify(e)}`);
             response.result = "Pepr module configured to reject on error";
             return response;
 

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -84,16 +84,16 @@ export async function mutateProcessor(
         // Add annotations to the request to indicate that the capability succeeded
         updateStatus("succeeded");
       } catch (e) {
-        Log.warn(actionMetadata, `Action failed: ${JSON.stringify(e)}`);
+        Log.warn(actionMetadata, `Action failed: ${e}`);
         updateStatus("warning");
 
         // Annoying ts false positive
         response.warnings = response.warnings || [];
-        response.warnings.push(`Action failed: ${JSON.stringify(e)}`);
+        response.warnings.push(`Action failed: ${e}`);
 
         switch (config.onError) {
           case Errors.reject:
-            Log.error(actionMetadata, `Action failed: ${JSON.stringify(e)}`);
+            Log.error(actionMetadata, `Action failed: ${e}`);
             response.result = "Pepr module configured to reject on error";
             return response;
 


### PR DESCRIPTION
## Description

This clears up issue 739 and removes the webhooks by listening for `SIGINT` on the process and listening for `close` on the program (child process) and upon receiving the signal removing the webhooks with a `Promise.all`.

Test:
```bash
# in one terminal
$> npm test 
$> cd pepr-test-module
$> npx pepr dev --confirm
# in another terminal
$> k get mutatingwebhookconfiguration,validatingwebhookconfiguration -oyaml # should be two
# HIT CTRL+C IN TERMINAL 1
$> k get mutatingwebhookconfiguration,validatingwebhookconfiguration -oyaml # should be 0
```



## Related Issue

Fixes #739 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
