### PR TITLE
feat: add flag for chart based zarf.yaml and update templated fields in chart deployments

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -89,6 +89,7 @@ Create a [zarf.yaml](https://zarf.dev) and K8s manifest for the current module. 
 - `-i, --custom-image [custom-image]` - Custom Image: Use custom image for Admission and Watcher Deployments.
 - `--registry [GitHub, Iron Bank]` - Container registry: Choose container registry for deployment manifests.
 - `-v, --version <version>. Example: '0.27.3'` - The version of the Pepr image to use in the deployment manifests.
+- `-z, --zarf [manifest|chart]` - The Zarf package type to generate: manifest or chart (default: manifest).
 
 ## `npx pepr kfc`
 

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -50,7 +50,14 @@ export default function (program: RootCmd) {
         "Container registry: Choose container registry for deployment manifests. Can't be used with --custom-image.",
       ).choices(["GitHub", "Iron Bank"]),
     )
-
+    .addOption(
+      new Option(
+        "-z, --zarf [manifest|chart]",
+        "Zarf package type: manifest, chart (default: manifest)",
+      )
+        .choices(["manifest", "chart"])
+        .default("manifest"),
+    )
     .addOption(
       new Option("--rbac-mode [admin|scoped]", "Rbac Mode: admin, scoped (default: admin)")
         .choices(["admin", "scoped"])
@@ -137,7 +144,7 @@ export default function (program: RootCmd) {
       }
 
       const yamlFile = `pepr-module-${uuid}.yaml`;
-
+      const chartPath = `${uuid}-chart`;
       const yamlPath = resolve(outputDir, yamlFile);
       const yaml = await assets.allYaml(opts.rbacMode);
 
@@ -150,8 +157,13 @@ export default function (program: RootCmd) {
       }
 
       const zarfPath = resolve(outputDir, "zarf.yaml");
-      const zarf = assets.zarfYaml(yamlFile);
 
+      let zarf = "";
+      if (opts.zarf === "chart") {
+        zarf = assets.zarfYamlChart(chartPath);
+      } else {
+        zarf = assets.zarfYaml(yamlFile);
+      }
       await fs.writeFile(yamlPath, yaml);
       await fs.writeFile(zarfPath, zarf);
 

--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -70,7 +70,9 @@ export function watcherDeployTemplate(buildTimestamp: string) {
           metadata:
             annotations: 
               buildTimestamp: "${buildTimestamp}"
+              {{- if .Values.watcher.podAnnotations }}
               {{- toYaml .Values.watcher.podAnnotations | nindent 8 }}
+              {{- end }}
             labels:
               app: {{ .Values.uuid }}-watcher
               pepr.dev/controller: watcher
@@ -149,7 +151,9 @@ export function admissionDeployTemplate(buildTimestamp: string) {
           metadata:
             annotations:
               buildTimestamp: "${buildTimestamp}"
+              {{- if .Values.admission.podAnnotations }}
               {{- toYaml .Values.admission.podAnnotations | nindent 8 }}
+              {{- end }}
             labels:
               app: {{ .Values.uuid }}
               pepr.dev/controller: admission

--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -70,6 +70,7 @@ export function watcherDeployTemplate(buildTimestamp: string) {
           metadata:
             annotations: 
               buildTimestamp: "${buildTimestamp}"
+              {{- toYaml .Values.watcher.podAnnotations | nindent 8 }}
             labels:
               app: {{ .Values.uuid }}-watcher
               pepr.dev/controller: watcher
@@ -111,6 +112,9 @@ export function watcherDeployTemplate(buildTimestamp: string) {
                   - name: module
                     mountPath: /app/load
                     readOnly: true
+                  {{- if .Values.watcher.extraVolumeMounts }}
+                  {{- toYaml .Values.watcher.extraVolumeMounts | nindent 12 }}
+                  {{- end }}
             volumes:
               - name: tls-certs
                 secret:
@@ -118,6 +122,9 @@ export function watcherDeployTemplate(buildTimestamp: string) {
               - name: module
                 secret:
                   secretName: {{ .Values.uuid }}-module
+              {{- if .Values.watcher.extraVolumes }}
+              {{- toYaml .Values.watcher.extraVolumes | nindent 8 }}
+              {{- end }}
     `;
 }
 
@@ -142,6 +149,7 @@ export function admissionDeployTemplate(buildTimestamp: string) {
           metadata:
             annotations:
               buildTimestamp: "${buildTimestamp}"
+              {{- toYaml .Values.admission.podAnnotations | nindent 8 }}
             labels:
               app: {{ .Values.uuid }}
               pepr.dev/controller: admission
@@ -187,6 +195,9 @@ export function admissionDeployTemplate(buildTimestamp: string) {
                   - name: module
                     mountPath: /app/load
                     readOnly: true
+                  {{- if .Values.admission.extraVolumeMounts }}
+                  {{- toYaml .Values.admission.extraVolumeMounts | nindent 12 }}
+                  {{- end }}
             volumes:
               - name: tls-certs
                 secret:
@@ -197,5 +208,8 @@ export function admissionDeployTemplate(buildTimestamp: string) {
               - name: module
                 secret:
                   secretName: {{ .Values.uuid }}-module  
+              {{- if .Values.admission.extraVolumes }}
+              {{- toYaml .Values.admission.extraVolumes | nindent 8 }}
+              {{- end }}
     `;
 }

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -9,7 +9,7 @@ import { CapabilityExport } from "../types";
 import { WebhookIgnore } from "../k8s";
 import { deploy } from "./deploy";
 import { loadCapabilities } from "./loader";
-import { allYaml, zarfYaml, overridesFile } from "./yaml";
+import { allYaml, zarfYaml, overridesFile, zarfYamlChart } from "./yaml";
 import { namespaceComplianceValidator, replaceString } from "../helpers";
 import { createDirectoryIfNotExists, dedent } from "../helpers";
 import { resolve } from "path";
@@ -58,6 +58,8 @@ export class Assets {
   };
 
   zarfYaml = (path: string) => zarfYaml(this, path);
+
+  zarfYamlChart = (path: string) => zarfYamlChart(this, path);
 
   allYaml = async (rbacMode: string) => {
     this.capabilities = await loadCapabilities(this.path);

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -68,8 +68,11 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
           drop: ["ALL"],
         },
       },
+      podAnnotations: {},
       nodeSelector: {},
       tolerations: [],
+      extraVolumeMounts: [],
+      extraVolumes: [],
       affinity: {},
     },
     watcher: {
@@ -115,7 +118,10 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       },
       nodeSelector: {},
       tolerations: [],
+      extraVolumeMounts: [],
+      extraVolumes: [],
       affinity: {},
+      podAnnotations: {},
     },
   };
   if (process.env.PEPR_MODE === "dev") {
@@ -145,6 +151,35 @@ export function zarfYaml({ name, image, config }: Assets, path: string) {
             name: "module",
             namespace: "pepr-system",
             files: [path],
+          },
+        ],
+        images: [image],
+      },
+    ],
+  };
+
+  return dumpYaml(zarfCfg, { noRefs: true });
+}
+
+export function zarfYamlChart({ name, image, config }: Assets, path: string) {
+  const zarfCfg = {
+    kind: "ZarfPackageConfig",
+    metadata: {
+      name,
+      description: `Pepr Module: ${config.description}`,
+      url: "https://github.com/defenseunicorns/pepr",
+      version: `${config.appVersion || "0.0.1"}`,
+    },
+    components: [
+      {
+        name: "module",
+        required: true,
+        charts: [
+          {
+            name: "module",
+            namespace: "pepr-system",
+            version: `${config.appVersion || "0.0.1"}`,
+            localPath: path,
           },
         ],
         images: [image],


### PR DESCRIPTION
## Description
Updates `npx pepr build` to take in an optional argument `--zarf chart|manifest` so that the generated zarf yaml will use the generated chart vs the manifest. Default behavior is still to use the manifest. [pepr 822](https://github.com/defenseunicorns/pepr/issues/822)

Also adds templating to the pod annotations on the deployments and extra volume/volumeMounts
in support of [uds-core 417](https://github.com/defenseunicorns/uds-core/issues/417)

I tested the generation locally for both the --zarf flag as well as rendering the templates with a values file that added pod annotations and extra volumes. There didn't seems to be any area really covering testing this right now. The existing tests in helm.test.ts do still generically check the templates are valid that were updated here. 

## Related Issue

Fixes #
[822](https://github.com/defenseunicorns/pepr/issues/822)
Relates to #
[417](https://github.com/defenseunicorns/uds-core/issues/417)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/contributor-guide/#submitting-a-pull-request) followed
