### PR TITLE
chore: update error messages

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -152,7 +152,7 @@ export default function (program: RootCmd) {
         // wait for capabilities to be loaded and test names
         validateCapabilityNames(assets.capabilities);
       } catch (e) {
-        console.error(`Error loading capability: ${e.message}`);
+        console.error(`Error loading capability:`, e);
         process.exit(1);
       }
 
@@ -310,7 +310,7 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
 
     return { ctx, path, cfg, uuid };
   } catch (e) {
-    console.error(`Error building module: ${e.message}`);
+    console.error(`Error building module:`, e);
 
     if (e.stdout) {
       const out = e.stdout.toString() as string;

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -152,7 +152,7 @@ export default function (program: RootCmd) {
         // wait for capabilities to be loaded and test names
         validateCapabilityNames(assets.capabilities);
       } catch (e) {
-        console.error(e.message);
+        console.error(`Error loading capability: ${e.message}`);
         process.exit(1);
       }
 
@@ -310,7 +310,7 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
 
     return { ctx, path, cfg, uuid };
   } catch (e) {
-    console.error(e.message);
+    console.error(`Error building module: ${e.message}`);
 
     if (e.stdout) {
       const out = e.stdout.toString() as string;

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -57,7 +57,7 @@ export default function (program: RootCmd) {
         await namespaceDeploymentsReady();
         console.info(`✅ Module deployed successfully`);
       } catch (e) {
-        console.error(`Error deploying module: ${e.message}`);
+        console.error(`Error deploying module:`, e);
         process.exit(1);
       }
     });

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -65,7 +65,7 @@ export default function (program: RootCmd) {
             // wait for capabilities to be loaded and test names
             validateCapabilityNames(webhook.capabilities);
           } catch (e) {
-            console.error(`Error validating capability names: ${e.message}`);
+            console.error(`Error validating capability names:`, e);
             process.exit(1);
           }
 
@@ -111,7 +111,7 @@ export default function (program: RootCmd) {
           }
         });
       } catch (e) {
-        console.error(`Error deploying module: ${e.message}`);
+        console.error(`Error deploying module:`, e);
         process.exit(1);
       }
     });

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -65,7 +65,7 @@ export default function (program: RootCmd) {
             // wait for capabilities to be loaded and test names
             validateCapabilityNames(webhook.capabilities);
           } catch (e) {
-            console.error(e.message);
+            console.error(`Error validating capability names: ${e.message}`);
             process.exit(1);
           }
 

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -76,7 +76,7 @@ export async function peprFormat(validateOnly: boolean) {
 
       return !hasFailure;
     } catch (e) {
-      console.error(`Error formatting module: ${e.message}`);
+      console.error(`Error formatting module:`, e);
       return false;
     }
   }

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -76,7 +76,7 @@ export async function peprFormat(validateOnly: boolean) {
 
       return !hasFailure;
     } catch (e) {
-      console.error(e.message);
+      console.error(`Error formatting module: ${e.message}`);
       return false;
     }
   }

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -90,7 +90,7 @@ export default function (program: RootCmd) {
           console.log(`Open VSCode or your editor of choice in ${dirName} to get started!`);
         } catch (e) {
           if (e instanceof Error) {
-            console.error(e.message);
+            console.error(`Error creating Pepr module: ${e.message}`);
           }
           process.exit(1);
         }

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -90,7 +90,7 @@ export default function (program: RootCmd) {
           console.log(`Open VSCode or your editor of choice in ${dirName} to get started!`);
         } catch (e) {
           if (e instanceof Error) {
-            console.error(`Error creating Pepr module: ${e.message}`);
+            console.error(`Error creating Pepr module:`, e);
           }
           process.exit(1);
         }

--- a/src/cli/kfc.ts
+++ b/src/cli/kfc.ts
@@ -38,7 +38,7 @@ export default function (program: RootCmd) {
           stdio: "inherit",
         });
       } catch (e) {
-        console.error(`Error creating CRD generated class: ${e.message}`);
+        console.error(`Error creating CRD generated class:`, e);
         process.exit(1);
       }
     });

--- a/src/cli/kfc.ts
+++ b/src/cli/kfc.ts
@@ -38,7 +38,7 @@ export default function (program: RootCmd) {
           stdio: "inherit",
         });
       } catch (e) {
-        console.error(e.message);
+        console.error(`Error creating CRD generated class: ${e.message}`);
         process.exit(1);
       }
     });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -55,7 +55,7 @@ export default function (program: RootCmd) {
 
         console.log(`✅ Module updated successfully`);
       } catch (e) {
-        console.error(e.message);
+        console.error(`Error updating Pepr module: ${e.message}`);
         process.exit(1);
       }
     });
@@ -88,7 +88,7 @@ export default function (program: RootCmd) {
           }
         }
       } catch (e) {
-        console.error(e.message);
+        console.error(`Error updating template files: ${e.message}`);
         process.exit(1);
       }
     });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -55,7 +55,7 @@ export default function (program: RootCmd) {
 
         console.log(`✅ Module updated successfully`);
       } catch (e) {
-        console.error(`Error updating Pepr module: ${e.message}`);
+        console.error(`Error updating Pepr module:`, e);
         process.exit(1);
       }
     });
@@ -88,7 +88,7 @@ export default function (program: RootCmd) {
           }
         }
       } catch (e) {
-        console.error(`Error updating template files: ${e.message}`);
+        console.error(`Error updating template files:`, e);
         process.exit(1);
       }
     });

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -182,7 +182,7 @@ export class Controller {
     try {
       res.send(await this.#metricsCollector.getMetrics());
     } catch (err) {
-      Log.error(err, `Error getting metrics: ${err}`);
+      Log.error(err, `Error getting metrics`);
       res.status(500).send("Internal Server Error");
     }
   };
@@ -277,7 +277,7 @@ export class Controller {
 
         this.#metricsCollector.observeEnd(startTime, admissionKind);
       } catch (err) {
-        Log.error(err, `Error processing ${admissionKind} request: ${err}`);
+        Log.error(err, `Error processing ${admissionKind} request`);
         res.status(500).send("Internal Server Error");
         this.#metricsCollector.error();
       }
@@ -319,7 +319,7 @@ export class Controller {
     try {
       res.send("OK");
     } catch (err) {
-      Log.error(err, `Error processing health check: ${err}`);
+      Log.error(err, `Error processing health check`);
       res.status(500).send("Internal Server Error");
     }
   }

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -182,7 +182,7 @@ export class Controller {
     try {
       res.send(await this.#metricsCollector.getMetrics());
     } catch (err) {
-      Log.error(err);
+      Log.error(err, `Error getting metrics: ${err}`);
       res.status(500).send("Internal Server Error");
     }
   };
@@ -277,7 +277,7 @@ export class Controller {
 
         this.#metricsCollector.observeEnd(startTime, admissionKind);
       } catch (err) {
-        Log.error(err);
+        Log.error(err, `Error processing ${admissionKind} request: ${err}`);
         res.status(500).send("Internal Server Error");
         this.#metricsCollector.error();
       }
@@ -319,7 +319,7 @@ export class Controller {
     try {
       res.send("OK");
     } catch (err) {
-      Log.error(err);
+      Log.error(err, `Error processing health check: ${err}`);
       res.status(500).send("Internal Server Error");
     }
   }

--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -67,9 +67,9 @@ const startup = async () => {
     validateHash(hash);
     runModule(hash);
   } catch (err) {
-    Log.error(err);
+    Log.error(err, `Error starting Pepr Store CRD: ${err.message}`);
     process.exit(1);
   }
 };
 
-startup().catch(err => Log.error(err));
+startup().catch(err => Log.error(err, `Error starting Pepr Controller: ${err.message}`));

--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -67,9 +67,9 @@ const startup = async () => {
     validateHash(hash);
     runModule(hash);
   } catch (err) {
-    Log.error(err, `Error starting Pepr Store CRD: ${err}`);
+    Log.error(err, `Error starting Pepr Store CRD`);
     process.exit(1);
   }
 };
 
-startup().catch(err => Log.error(err, `Error starting Pepr Controller: ${err}`));
+startup().catch(err => Log.error(err, `Error starting Pepr Controller`));

--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -67,9 +67,9 @@ const startup = async () => {
     validateHash(hash);
     runModule(hash);
   } catch (err) {
-    Log.error(err, `Error starting Pepr Store CRD: ${err.message}`);
+    Log.error(err, `Error starting Pepr Store CRD: ${err}`);
     process.exit(1);
   }
 };
 
-startup().catch(err => Log.error(err, `Error starting Pepr Controller: ${err.message}`));
+startup().catch(err => Log.error(err, `Error starting Pepr Controller: ${err}`));


### PR DESCRIPTION
## Description
We have noticed that where we throw an error and only use e as the message, we may not display readable and helpful information in the Pepr logs. Throwing the error with a specific message results in the Pepr logs displaying helpful information about what went wrong. We should check Pepr and KFC for additional instances of throwing errors using just e and update the error messages.
...

## Related Issue

Fixes #843 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
