### PR TITLE
chore: update dependabot to include peerDependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,19 +12,7 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
-      peer-dependencies:
-        patterns:
-          - "@typescript-eslint/eslint-plugin"
-          - "@typescript-eslint/parser"
-          - "commander"
-          - "esbuild"
-          - "eslint"
-          - "node-forge"
-          - "prettier"
-          - "prompts"
-          - "typescript"
-          - "uuid"
-
+ 
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+      peer-dependencies:
+        patterns:
+          - "@typescript-eslint/eslint-plugin"
+          - "@typescript-eslint/parser"
+          - "commander"
+          - "esbuild"
+          - "eslint"
+          - "node-forge"
+          - "prettier"
+          - "prompts"
+          - "typescript"
+          - "uuid"
 
   - package-ecosystem: github-actions
     directory: /

--- a/package.json
+++ b/package.json
@@ -53,7 +53,17 @@
     "@types/uuid": "9.0.8",
     "jest": "29.7.0",
     "nock": "13.5.4",
-    "ts-jest": "29.1.4"
+    "ts-jest": "29.1.4",
+    "@typescript-eslint/eslint-plugin": "6.15.0",
+    "@typescript-eslint/parser": "6.15.0",
+    "commander": "11.1.0",
+    "esbuild": "0.19.10",
+    "eslint": "8.56.0",
+    "node-forge": "1.3.1",
+    "prettier": "3.1.1",
+    "prompts": "2.4.2",
+    "typescript": "5.3.3",
+    "uuid": "9.0.1"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "6.15.0",


### PR DESCRIPTION
## Description
It appears that the packages listed under peerDependencies in package.json aren't being updated by dependabot. All of the peerDependencies are not updating.
...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
