### PR TITLE
chore: decouple controller version from package.json and couple to pod image version

### DIFF
--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1174,7 +1174,7 @@ describe("getSubstringAfterLastColon", () => {
   test("returns empty string if there is no colon", () => {
     const input = "registry1.dso.mil";
     const output = getSubstringAfterLastColon(input);
-    expect(output).toBe("");
+    expect(output).toBe("latest");
   });
 
   test("handles strings with multiple colons correctly", () => {

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   validateHash,
   ValidationError,
   validateCapabilityNames,
+  getSubstringAfterLastColon,
 } from "./helpers";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
 import { parseTimeout, secretOverLimit, replaceString } from "./helpers";
@@ -1160,5 +1161,25 @@ describe("validateHash", () => {
     // Example of a valid SHA-256 hash
     const validHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1";
     expect(() => validateHash(validHash)).not.toThrow();
+  });
+});
+
+describe("getSubstringAfterLastColon", () => {
+  test("returns the substring after the last colon", () => {
+    const input = "registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.31.1";
+    const output = getSubstringAfterLastColon(input);
+    expect(output).toEqual("v0.31.1");
+  });
+
+  test("returns empty string if there is no colon", () => {
+    const input = "registry1.dso.mil";
+    const output = getSubstringAfterLastColon(input);
+    expect(output).toBe("");
+  });
+
+  test("handles strings with multiple colons correctly", () => {
+    const input = "registry1:8080/dso.mil/pepr:latest";
+    const output = getSubstringAfterLastColon(input);
+    expect(output).toEqual("latest");
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -10,7 +10,7 @@ import {
   validateHash,
   ValidationError,
   validateCapabilityNames,
-  getSubstringAfterLastColon,
+  ParseAnyReference,
 } from "./helpers";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
 import { parseTimeout, secretOverLimit, replaceString } from "./helpers";
@@ -1164,22 +1164,67 @@ describe("validateHash", () => {
   });
 });
 
-describe("getSubstringAfterLastColon", () => {
-  test("returns the substring after the last colon", () => {
-    const input = "registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.31.1";
-    const output = getSubstringAfterLastColon(input);
-    expect(output).toEqual("v0.31.1");
-  });
+describe("ParseAnyReference", () => {
+  const imageRefs = [
+    "nginx",
+    "nginx:1.23.3",
+    "defenseunicorns/zarf-agent:v0.22.1",
+    "defenseunicorns/zarf-agent@sha256:84605f731c6a18194794c51e70021c671ab064654b751aa57e905bce55be13de",
+    "ghcr.io/stefanprodan/podinfo:6.3.3",
+    "registry1.dso.mil/ironbank/opensource/defenseunicorns/zarf/zarf-agent:v0.25.0",
+    "registry1:8080/dso.mil/pepr",
+  ];
 
-  test("returns empty string if there is no colon", () => {
-    const input = "registry1.dso.mil";
-    const output = getSubstringAfterLastColon(input);
-    expect(output).toBe("latest");
-  });
+  test("parses valid image references correctly", () => {
+    const parsedRefs = imageRefs.map(ref => {
+      return ParseAnyReference(ref);
+    });
 
-  test("handles strings with multiple colons correctly", () => {
-    const input = "registry1:8080/dso.mil/pepr:latest";
-    const output = getSubstringAfterLastColon(input);
-    expect(output).toEqual("latest");
+    const expectedResult = [
+      {
+        host: "",
+        path: "nginx",
+        tag: "",
+        digest: "",
+      },
+      {
+        host: "",
+        path: "nginx",
+        tag: "1.23.3",
+        digest: "",
+      },
+      {
+        host: "",
+        path: "defenseunicorns/zarf-agent",
+        tag: "v0.22.1",
+        digest: "",
+      },
+      {
+        host: "",
+        path: "defenseunicorns/zarf-agent",
+        tag: "",
+        digest: "sha256:84605f731c6a18194794c51e70021c671ab064654b751aa57e905bce55be13de",
+      },
+      {
+        host: "ghcr.io",
+        path: "stefanprodan/podinfo",
+        tag: "6.3.3",
+        digest: "",
+      },
+      {
+        host: "registry1.dso.mil",
+        path: "ironbank/opensource/defenseunicorns/zarf/zarf-agent",
+        tag: "v0.25.0",
+        digest: "",
+      },
+      {
+        host: "registry1:8080",
+        path: "dso.mil/pepr",
+        digest: "",
+        tag: "",
+      },
+    ];
+
+    expect(parsedRefs).toEqual(expectedResult);
   });
 });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -341,11 +341,26 @@ export function replaceString(str: string, stringA: string, stringB: string) {
   return str.replace(regExp, stringB);
 }
 
-// getSubstringAfterLastColon for getting the controller image
-export function getSubstringAfterLastColon(input: string) {
-  const lastColonIndex = input.lastIndexOf(":");
-  if (lastColonIndex === -1) {
-    return "latest";
+// Based on distrubtion/reference implementation in Go
+export function ParseAnyReference(imageString: string) {
+  const pattern = /^(?:([^/]+)\/)?([^:@]+)(?::([^@]+))?(?:@(.+))?$/;
+  const matches = imageString.match(pattern);
+  if (!matches) {
+    throw new Error("Invalid image string");
   }
-  return input.substring(lastColonIndex + 1);
+
+  let [, host, path] = matches;
+  const tag = matches[3] || "";
+  const digest = matches[4] || "";
+
+  if (imageString.split("/").length == 2) {
+    path = host + "/" + path;
+    host = "";
+  }
+  return {
+    host: host || "",
+    path,
+    tag,
+    digest,
+  };
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -340,3 +340,12 @@ export function replaceString(str: string, stringA: string, stringB: string) {
   const regExp = new RegExp(escapedStringA, "g");
   return str.replace(regExp, stringB);
 }
+
+// getSubstringAfterLastColon for getting the controller image
+export function getSubstringAfterLastColon(input: string): string {
+  const lastColonIndex = input.lastIndexOf(":");
+  if (lastColonIndex === -1) {
+    return "";
+  }
+  return input.substring(lastColonIndex + 1);
+}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -342,10 +342,10 @@ export function replaceString(str: string, stringA: string, stringB: string) {
 }
 
 // getSubstringAfterLastColon for getting the controller image
-export function getSubstringAfterLastColon(input: string): string {
+export function getSubstringAfterLastColon(input: string) {
   const lastColonIndex = input.lastIndexOf(":");
   if (lastColonIndex === -1) {
-    return "";
+    return "latest";
   }
   return input.substring(lastColonIndex + 1);
 }


### PR DESCRIPTION
## Description

The Controller (Server) Version is inaccurate when the image was changed. In reality, the server should get the version based on the image on the pods. This decouples the server version from `package.json` since it will be deployed in the cluster to ensure the most accurate results. 

How to test:
1. Pull down PR and run `npm test`
2. re-tag the `pepr:dev` image to the ironbank image: `docker tag pepr:dev registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.31.1`
3. import the new image into the cluster: `k3d image import registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.31.1 -c pepr-dev`
4. build the `pepr-test-module`: `npx pepr build && kubectl apply -f dist` 
5. Change the images on the controllers: ` k set image deploy/pepr-static-test server=registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.31.1 -n pepr-system &&  k set image deploy/pepr-static-test-watcher watcher=registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.31.1 -n pepr-system`
6. Get the logs: `k logs -n pepr-system deploy/pepr-static-test-watcher | egrep "Pepr Controller"`

## Related Issue

Fixes #836 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
