### PR TITLE
chore: clear cache on failure

### DIFF
--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -167,10 +167,7 @@ export class PeprControllerStore {
       } catch (err) {
         Log.error(err, "Pepr store update failure");
 
-        // On failure to update, re-add the operations to the cache to be retried
-        for (const idx of indexes) {
-          sendCache[idx] = payload[Number(idx)];
-        }
+        Object.keys(sendCache).forEach(key => delete sendCache[key]);
       }
     };
 

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -167,7 +167,14 @@ export class PeprControllerStore {
       } catch (err) {
         Log.error(err, "Pepr store update failure");
 
-        Object.keys(sendCache).forEach(key => delete sendCache[key]);
+        if (err.status === 422) {
+          Object.keys(sendCache).forEach(key => delete sendCache[key]);
+        } else {
+          // On failure to update, re-add the operations to the cache to be retried
+          for (const idx of indexes) {
+            sendCache[idx] = payload[Number(idx)];
+          }
+        }
       }
     };
 


### PR DESCRIPTION
## Description

We were seeing behavior where on a `Store.removeItem()`, if the item was not there the .Patch call returns a 422 but not clear the body of the patch. This means that every proceeding patch will also fail. This clears the cache on failure.

## Related Issue

Fixes #865 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
