### PR TITLE
chore: load_image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:${{ github.ref_name }} .
 
           # Build Pepr dist folder for NPM 
-          docker buildx build --tag pepr-npm . -f Dockerfile.dist
+          docker buildx build --load --tag pepr-npm . -f Dockerfile.dist
 
           docker cp $(docker create --name kim pepr-npm):/app/dist ./dist && docker rm kim
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,6 @@ jobs:
           docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:${{ github.ref_name }} .
 
           # Build Pepr dist folder for NPM 
-          docker buildx build --load --tag pepr-npm . -f Dockerfile.dist
-
-          docker cp $(docker create --name kim pepr-npm):/app/dist ./dist && docker rm kim
+          docker buildx build --output="." --target=dist --no-cache . -f Dockerfile.dist
           
           npm publish --provenance --access public

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -15,3 +15,8 @@ COPY --chown=node:node . .
 RUN npm ci
 
 RUN npm run build 
+
+
+FROM scratch AS dist
+
+COPY --from=build /app/dist ./dist/


### PR DESCRIPTION
## Description

Was not able to load image that contains the `dist` folder to push to npmjs

```bash
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Unable to find image 'pepr-npm:latest' locally
Error response from daemon: pull access denied for pepr-npm, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
must specify at least one container source
npm warn package-json pepr@0.32.1 No bin file found at dist/cli.js
npm warn package-json pepr@0.32.1 No bin file found at dist/cli.js
npm warn package-json pepr@0.32.1 No bin file found at dist/cli.js
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "bin" was converted to an object
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+https://github.com/defenseunicorns/pepr.git"
npm warn package-json pepr@0.32.1 No bin file found at dist/cli.js
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
