### PR TITLE
chore: include v in iron bank image

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -135,7 +135,7 @@ export default function (program: RootCmd) {
         console.warn(
           `\n\tThis command assumes the latest release. Pepr's Iron Bank image release cycle is dictated by renovate and is typically released a few days after the GitHub release.\n\tAs an alternative you may consider custom --custom-image to target a specific image and version.`,
         );
-        image = `registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:${cfg.pepr.peprVersion}`;
+        image = `registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v${cfg.pepr.peprVersion}`;
       }
 
       // if image is a custom image, use that instead of the default


### PR DESCRIPTION
## Description

`npx pepr build --registry="Iron Bank"` produces an image missing the "v" on the image tag. Manual change is necessary to correct image. Intention of this PR is to fix. 


Harbor shows the [current latest Pepr image](https://registry1.dso.mil/harbor/projects/3/repositories/opensource%2Fdefenseunicorns%2Fpepr%2Fcontroller/artifacts-tab/artifacts/sha256:69838e9b0f06d5edc0da1abbb0f018a2f776f9614362be0eee9f7d48055a7e9c) as v0.32.2. Clicking the `COPY PULL COMMAND` button you see the actual image.

```bash
docker pull registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.32.2
```

**How to test**
```bash
# Build pepr-test-module on the PR branch
npm test 
cd pepr-test-module

# Update the pepr dependency to ^0.32.2 (as if npx pepr update were issued)
jq '.dependencies.pepr = "^0.32.2"' package.json > package1.json && mv package1.json package.json 

# build the module with the IB image
npx ts-node ../src/cli.ts build --registry="Iron Bank"

# read the dist to make sure the image now has v
cat dist/pepr-module-static-test.yaml | grep  "registry"
```

**expected result** (should match Harbor)
```bash
registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v0.32.2
```
## Related Issue

Fixes #888 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
