### PR TITLE
chore: add fuzzing and property based testing to Pepr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@commitlint/cli": "19.3.0",
         "@commitlint/config-conventional": "19.2.2",
+        "@fast-check/jest": "^1.8.2",
         "@jest/globals": "29.7.0",
         "@types/eslint": "8.56.10",
         "@types/express": "4.17.21",
@@ -31,6 +32,7 @@
         "@types/node-forge": "1.3.11",
         "@types/prompts": "2.4.9",
         "@types/uuid": "9.0.8",
+        "fast-check": "^3.19.0",
         "jest": "29.7.0",
         "nock": "13.5.4",
         "ts-jest": "29.1.5"
@@ -1602,6 +1604,38 @@
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fast-check/jest": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@fast-check/jest/-/jest-1.8.2.tgz",
+      "integrity": "sha512-+UgQKZ0og0olUZXWgZ5Zcw42eN+3OB0Nfw0CU9OnlHBhHFnd8xppUYviX5HriAyUsAko1t/li5LZ9mSIIakmhg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "fast-check": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@fast-check/worker": ">=0.0.7 <0.5.0",
+        "@jest/expect": ">=28.0.0",
+        "@jest/globals": ">=25.5.2"
+      },
+      "peerDependenciesMeta": {
+        "@fast-check/worker": {
+          "optional": true
+        },
+        "@jest/expect": {
+          "optional": true
+        }
       }
     },
     "node_modules/@glideapps/ts-necessities": {
@@ -4318,6 +4352,28 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/fast-check": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.19.0.tgz",
+      "integrity": "sha512-CO2JX/8/PT9bDGO1iXa5h5ey1skaKI1dvecERyhH4pp3PGjwd3KIjMAXEg79Ps9nclsdt4oPbfqiAnLU0EwrAQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
@@ -6931,9 +6987,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@commitlint/cli": "19.3.0",
     "@commitlint/config-conventional": "19.2.2",
+    "@fast-check/jest": "^1.8.2",
     "@jest/globals": "29.7.0",
     "@types/eslint": "8.56.10",
     "@types/express": "4.17.21",
@@ -51,6 +52,7 @@
     "@types/node-forge": "1.3.11",
     "@types/prompts": "2.4.9",
     "@types/uuid": "9.0.8",
+    "fast-check": "^3.19.0",
     "jest": "29.7.0",
     "nock": "13.5.4",
     "ts-jest": "29.1.5"
@@ -68,4 +70,3 @@
     "uuid": "9.0.1"
   }
 }
-

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -5,46 +5,55 @@ import { expect, test, describe } from "@jest/globals";
 import * as fc from "fast-check";
 import { Errors, ErrorList, ValidateError } from "./errors";
 
-describe('ValidateError Fuzz Testing', () => {
-  test('should only accept predefined error values', () => {
+describe("ValidateError Fuzz Testing", () => {
+  test("should only accept predefined error values", () => {
     fc.assert(
-      fc.property(fc.string(), (error) => {
+      fc.property(fc.string(), error => {
         if (ErrorList.includes(error)) {
           expect(() => ValidateError(error)).not.toThrow();
         } else {
-          expect(() => ValidateError(error)).toThrow(`Invalid error: ${error}. Must be one of: ${ErrorList.join(", ")}`);
+          expect(() => ValidateError(error)).toThrow(
+            `Invalid error: ${error}. Must be one of: ${ErrorList.join(", ")}`,
+          );
         }
       }),
-      { verbose: true }
+      { verbose: true },
     );
   });
 });
-describe('ValidateError Fake Data Testing', () => {
-  test('should correctly handle typical fake error data', () => {
+describe("ValidateError Fake Data Testing", () => {
+  test("should correctly handle typical fake error data", () => {
     const fakeErrors = ["error", "failure", "null", "undefined", "exception"];
     fakeErrors.forEach(fakeError => {
       if (ErrorList.includes(fakeError)) {
         expect(() => ValidateError(fakeError)).not.toThrow();
       } else {
-        expect(() => ValidateError(fakeError)).toThrow(`Invalid error: ${fakeError}. Must be one of: ${ErrorList.join(", ")}`);
+        expect(() => ValidateError(fakeError)).toThrow(
+          `Invalid error: ${fakeError}. Must be one of: ${ErrorList.join(", ")}`,
+        );
       }
     });
   });
 });
-describe('ValidateError Property-Based Testing', () => {
-  test('should only validate errors that are part of the ErrorList', () => {
+describe("ValidateError Property-Based Testing", () => {
+  test("should only validate errors that are part of the ErrorList", () => {
     fc.assert(
-      fc.property(fc.constantFrom(...ErrorList), (validError) => {
+      fc.property(fc.constantFrom(...ErrorList), validError => {
         expect(() => ValidateError(validError)).not.toThrow();
       }),
-      { verbose: true }
+      { verbose: true },
     );
 
     fc.assert(
-      fc.property(fc.string().filter(e => !ErrorList.includes(e)), (invalidError) => {
-        expect(() => ValidateError(invalidError)).toThrow(`Invalid error: ${invalidError}. Must be one of: ${ErrorList.join(", ")}`);
-      }),
-      { verbose: true }
+      fc.property(
+        fc.string().filter(e => !ErrorList.includes(e)),
+        invalidError => {
+          expect(() => ValidateError(invalidError)).toThrow(
+            `Invalid error: ${invalidError}. Must be one of: ${ErrorList.join(", ")}`,
+          );
+        },
+      ),
+      { verbose: true },
     );
   });
 });

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -2,8 +2,18 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { expect, test } from "@jest/globals";
-
+import * as fc from "fast-check";
 import { Errors, ErrorList, ValidateError } from "./errors";
+
+// Property based test
+test("should always return the key as its value for each property", () => {
+  type ErrorKey = keyof typeof Errors;
+  fc.assert(
+    fc.property(fc.constantFrom<ErrorKey>("audit", "ignore", "reject"), key => {
+      expect(Errors[key]).toEqual(key);
+    }),
+  );
+});
 
 test("Errors object should have correct properties", () => {
   expect(Errors).toEqual({

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,18 +1,52 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, test } from "@jest/globals";
+import { expect, test, describe } from "@jest/globals";
 import * as fc from "fast-check";
 import { Errors, ErrorList, ValidateError } from "./errors";
 
-// Property based test
-test("should always return the key as its value for each property", () => {
-  type ErrorKey = keyof typeof Errors;
-  fc.assert(
-    fc.property(fc.constantFrom<ErrorKey>("audit", "ignore", "reject"), key => {
-      expect(Errors[key]).toEqual(key);
-    }),
-  );
+describe('ValidateError Fuzz Testing', () => {
+  test('should only accept predefined error values', () => {
+    fc.assert(
+      fc.property(fc.string(), (error) => {
+        if (ErrorList.includes(error)) {
+          expect(() => ValidateError(error)).not.toThrow();
+        } else {
+          expect(() => ValidateError(error)).toThrow(`Invalid error: ${error}. Must be one of: ${ErrorList.join(", ")}`);
+        }
+      }),
+      { verbose: true }
+    );
+  });
+});
+describe('ValidateError Fake Data Testing', () => {
+  test('should correctly handle typical fake error data', () => {
+    const fakeErrors = ["error", "failure", "null", "undefined", "exception"];
+    fakeErrors.forEach(fakeError => {
+      if (ErrorList.includes(fakeError)) {
+        expect(() => ValidateError(fakeError)).not.toThrow();
+      } else {
+        expect(() => ValidateError(fakeError)).toThrow(`Invalid error: ${fakeError}. Must be one of: ${ErrorList.join(", ")}`);
+      }
+    });
+  });
+});
+describe('ValidateError Property-Based Testing', () => {
+  test('should only validate errors that are part of the ErrorList', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...ErrorList), (validError) => {
+        expect(() => ValidateError(validError)).not.toThrow();
+      }),
+      { verbose: true }
+    );
+
+    fc.assert(
+      fc.property(fc.string().filter(e => !ErrorList.includes(e)), (invalidError) => {
+        expect(() => ValidateError(invalidError)).toThrow(`Invalid error: ${invalidError}. Must be one of: ${ErrorList.join(", ")}`);
+      }),
+      { verbose: true }
+    );
+  });
 });
 
 test("Errors object should have correct properties", () => {

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -9,6 +9,7 @@ describe("ValidateError Fuzz Testing", () => {
   test("should only accept predefined error values", () => {
     fc.assert(
       fc.property(fc.string(), error => {
+        console.log("error", error);
         if (ErrorList.includes(error)) {
           expect(() => ValidateError(error)).not.toThrow();
         } else {

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -11,6 +11,8 @@ import {
   ValidationError,
   validateCapabilityNames,
 } from "./helpers";
+import { sanitizeResourceName } from "../sdk/sdk";
+import * as fc from "fast-check";
 import { expect, describe, test, jest, beforeEach, afterEach } from "@jest/globals";
 import { parseTimeout, secretOverLimit, replaceString } from "./helpers";
 import { promises as fs } from "fs";
@@ -292,6 +294,31 @@ const mockCapabilities: CapabilityExport[] = JSON.parse(`[
         ]
     }
 ]`);
+
+describe("validateCapabilityNames Property-Based Tests", () => {
+  test("should only accept names that are valid after sanitation", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            name: fc.string(),
+            bindings: fc.array(fc.anything()),
+            hasSchedule: fc.boolean(),
+          }),
+        ),
+        capabilities => {
+          if (capabilities.every(cap => cap.name === sanitizeResourceName(cap.name))) {
+            expect(() => validateCapabilityNames(capabilities as CapabilityExport[])).not.toThrow();
+          } else {
+            expect(() => validateCapabilityNames(capabilities as CapabilityExport[])).toThrowError(
+              /not a valid Kubernetes resource name/,
+            );
+          }
+        },
+      ),
+    );
+  });
+});
 describe("validateCapabilityNames", () => {
   test("should return true if all capability names are valid", () => {
     const capabilities = mockCapabilities;


### PR DESCRIPTION
## Description

Today in Pepr testing, we specify the inputs and outputs we want to use and observe.

The problem with our current approach to testing software is that it places the responsibility of identifying bugs solely on the developers writing the tests. They must think about all the things that could go wrong if they want their tests to find all potential bugs. While it's possible to think about common failure cases with enough experience, it's not really feasible to consider all possible edge cases without proving the code line by line.

This PR intends to **start** experimentally adding property based, fuzzing and fake data tests to Pepr.

We think it should also increase our Scorecard score

Shows library injecting random strings
![image](https://github.com/defenseunicorns/pepr/assets/1096507/255756ac-ab90-4480-9ff7-83bca2ac05dc)



## Related Issue

Fixes #742 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
