### PR TITLE
chore: fixes bug in log message around RECONNECT events

### DIFF
--- a/docs/030_user-guide/015_sdk.md
+++ b/docs/030_user-guide/015_sdk.md
@@ -6,12 +6,6 @@ To use, import the `sdk` from the `pepr` package:
 import { sdk } from "pepr";
 ```
 
-To use, import the `sdk` from the `pepr` package:
-
-```typescript
-import { sdk } from "pepr";
-```
-
 ## `containers`
 
 Returns list of all containers in a pod. Accepts the following parameters:

--- a/docs/030_user-guide/015_sdk.md
+++ b/docs/030_user-guide/015_sdk.md
@@ -6,6 +6,12 @@ To use, import the `sdk` from the `pepr` package:
 import { sdk } from "pepr";
 ```
 
+To use, import the `sdk` from the `pepr` package:
+
+```typescript
+import { sdk } from "pepr";
+```
+
 ## `containers`
 
 Returns list of all containers in a pod. Accepts the following parameters:

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -95,8 +95,8 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[]) {
   watcher.events.on(WatchEvent.CONNECT, url => logEvent(WatchEvent.CONNECT, url));
 
   watcher.events.on(WatchEvent.DATA_ERROR, err => logEvent(WatchEvent.DATA_ERROR, err.message));
-  watcher.events.on(WatchEvent.RECONNECT, (err, retryCount) =>
-    logEvent(WatchEvent.RECONNECT, err ? `Reconnecting after ${retryCount} attempts` : ""),
+  watcher.events.on(WatchEvent.RECONNECT, retryCount =>
+    logEvent(WatchEvent.RECONNECT, `Reconnecting after ${retryCount} attempt${retryCount === 1 ? "" : "s"}`),
   );
   watcher.events.on(WatchEvent.RECONNECT_PENDING, () => logEvent(WatchEvent.RECONNECT_PENDING));
   watcher.events.on(WatchEvent.GIVE_UP, err => logEvent(WatchEvent.GIVE_UP, err.message));


### PR DESCRIPTION
## Description
Fixes bug in log message around `RECONNECT` events, it was expecting two arguments when only one is emitted. 

There is additional context in this [comment](https://github.com/defenseunicorns/pepr/issues/930#issuecomment-2200391666) on the issue. 

## Related Issue

Fixes #930 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
