### PR TITLE
chore: docs

### DIFF
--- a/docs/060_best-practices/README.md
+++ b/docs/060_best-practices/README.md
@@ -115,7 +115,13 @@ If you have a validating webhook, it is recommended to set the failurePolicy to 
     matchPolicy: Equivalent
     timeoutSeconds: 3
 ```
+The failurePolicy and timeout can be set in the `package.json` under `pepr`:
 
+```json
+  "pepr": {
+    "uuid": "static-test",
+    "onError": "ignore", # ignore or reject
+    "webhookTimeout": 10,
 ### Pepr Store
 
 If you need to read all store keys, or you think the PeprStore is malfunctioning, you can check the PeprStore CR:

--- a/docs/060_best-practices/README.md
+++ b/docs/060_best-practices/README.md
@@ -115,13 +115,19 @@ If you have a validating webhook, it is recommended to set the failurePolicy to 
     matchPolicy: Equivalent
     timeoutSeconds: 3
 ```
-The failurePolicy and timeout can be set in the `package.json` under `pepr`:
+
+The failurePolicy and timeout can be set in the `package.json` under `pepr`, and the settings will be reflected in the `*WebhookConfiguration` after the next build:
 
 ```json
   "pepr": {
     "uuid": "static-test",
     "onError": "ignore", # ignore or reject
     "webhookTimeout": 10,
+```
+
+Read more on customization [here](https://docs.pepr.dev/main/user-guide/customization/).
+
+
 ### Pepr Store
 
 If you need to read all store keys, or you think the PeprStore is malfunctioning, you can check the PeprStore CR:

--- a/docs/060_best-practices/README.md
+++ b/docs/060_best-practices/README.md
@@ -106,7 +106,7 @@ kubectl logs -l pepr.dev/controller=watch -n pepr-system
 Error from server (InternalError): Internal error occurred: failed calling webhook "<pepr_module>pepr.dev": failed to call webhook: Post ...
 ```
 
-When an internal error occurs, it is recommended to check the `*WebhookConfiguration` to check the timeout and failurePolicy. If a request cannot be processed within the timeout, the request will be rejected if the failurePolicy is set to `Fail`. If the failurePolicy is set to `Ignore`, he request will be allowed to continue.
+When an internal error occurs, it is recommended to check the `*WebhookConfiguration` to check the timeout and failurePolicy. If a request cannot be processed within the timeout, the request will be rejected if the failurePolicy is set to `Fail`. If the failurePolicy is set to `Ignore`, the request will be allowed to continue.
 
 If you have a validating webhook, it is recommended to set the failurePolicy to `Fail` to ensure that the request is rejected if the webhook fails.
 

--- a/docs/060_best-practices/README.md
+++ b/docs/060_best-practices/README.md
@@ -86,7 +86,7 @@ If the focus of the debug is on a `Mutate()` or `Validate()`, the relevenat logs
 kubectl logs -l pepr.dev/controller=admission -n pepr-system
 ```
 
-For a more refined admission log which can be optionally filter by the module UUID can be obtained [`npx pepr monitor`](https://docs.pepr.dev/main/best-practices/#monitoring):
+More refined admission logs which can be optionally filtered by the module UUID can be obtained [`npx pepr monitor`](https://docs.pepr.dev/main/best-practices/#monitoring):
 
 ```bash
 npx pepr monitor 

--- a/docs/060_best-practices/README.md
+++ b/docs/060_best-practices/README.md
@@ -35,7 +35,7 @@ The workflow for developing features in Pepr is:
 
 _It is always a best practice to add a `Validate` to your `Mutate` to ensure that the object is in a valid state before making changes._
 
-_If you think your Webhook is not being called for a given resource, should check the `*WebhookConfiguration`._
+_If you think your Webhook is not being called for a given resource, check the `*WebhookConfiguration`._
 
 
 ### Using Breakpoints

--- a/docs/060_best-practices/README.md
+++ b/docs/060_best-practices/README.md
@@ -35,6 +35,8 @@ The workflow for developing features in Pepr is:
 
 _It is always a best practice to add a `Validate` to your `Mutate` to ensure that the object is in a valid state before making changes._
 
+_If you think your Webhook is not being called for a given resource, should check the `*WebhookConfiguration`._
+
 
 ### Using Breakpoints
 


### PR DESCRIPTION
## Description

This PR expands the Pepr Debugging docs.

Should show:

npx pepr dev
Logging, admission, watcher and npx pepr monitor
Webhook timeout behavior and suggestions to overcome
Webhook down behavior and suggestions for how to overcome
anomalies that happen when there is not a validate after a mutate
read all store keys by checking the PeprStore CR
debug OnSchedule by checking the PeprStore CR
Check the *WebhookConfiguration to ensure custom types are picked up correctly

## Related Issue

Fixes #856 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
