### PR TITLE
chore: remove punycode warning docs

### DIFF
--- a/docs/080_faq/README.md
+++ b/docs/080_faq/README.md
@@ -7,6 +7,13 @@
 export NODE_OPTIONS="--disable-warning=DEP0040"
 ```
 
+or 
+
+```bash
+npx --node-options="--disable-warning=DEP0040" pepr [command]
+```
+
+
 ## How do I add custom labels to Pepr's Kubernetes manifests?
 
 During the build process, custom labels can be added the Kubernetes manifests that Pepr generates based on the Pepr section of the `package.json`. Currently, adding custom labels to `namespace` is supported.  

--- a/docs/080_faq/README.md
+++ b/docs/080_faq/README.md
@@ -1,6 +1,12 @@
 # Frequently Asked Questions
 
 
+## How do I remove the punycode warning?
+
+```bash
+export NODE_OPTIONS="--disable-warning=DEP0040"
+```
+
 ## How do I add custom labels to Pepr's Kubernetes manifests?
 
 During the build process, custom labels can be added the Kubernetes manifests that Pepr generates based on the Pepr section of the `package.json`. Currently, adding custom labels to `namespace` is supported.  

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import kfc from "./cli/kfc";
 if (process.env.npm_lifecycle_event !== "npx") {
   console.warn("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
+// Remove punycode warning
 process.removeAllListeners('warning');
 const program = new RootCmd();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import kfc from "./cli/kfc";
 if (process.env.npm_lifecycle_event !== "npx") {
   console.warn("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
+
 const program = new RootCmd();
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,10 +19,6 @@ import kfc from "./cli/kfc";
 if (process.env.npm_lifecycle_event !== "npx") {
   console.warn("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
-// Remove punycode warning
-if (process.env.PEPR_MODE !== "dev") {
-  process.removeAllListeners("warning");
-}
 const program = new RootCmd();
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import kfc from "./cli/kfc";
 if (process.env.npm_lifecycle_event !== "npx") {
   console.warn("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
-
+process.removeAllListeners('warning');
 const program = new RootCmd();
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ if (process.env.npm_lifecycle_event !== "npx") {
   console.warn("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
 // Remove punycode warning
-process.removeAllListeners('warning');
+process.removeAllListeners("warning");
 const program = new RootCmd();
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,9 @@ if (process.env.npm_lifecycle_event !== "npx") {
   console.warn("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
 // Remove punycode warning
-process.removeAllListeners("warning");
+if (process.env.PEPR_MODE !== "dev") {
+  process.removeAllListeners("warning");
+}
 const program = new RootCmd();
 
 program


### PR DESCRIPTION
## Description

The punycode deprecation warning is intrusive and very ugly in the cli. We need to remove it yet we do not want to suppress all warnings incase there are relevant warnings. This adds documentation around how to suppress that exact punycode warning 

## Related Issue

Fixes #
<!-- or -->
Relates to #811 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
