### PR TITLE
chore: node ci patch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Use Node.js latest
+      - name: Use Node.js 22.4.1
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: latest
+          node-version: 22.4.1
           cache: "npm"
       - run: npm ci
       - run: npm run format:check
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, latest]
+        node-version: [18, 20, 22.4.1]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Use Node.js ${{ matrix.node-version }}
@@ -42,10 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Use Node.js latest
+      - name: Use Node.js 22.4.1
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: latest
+          node-version: 22.4.1
           cache: "npm"
       - name: Setup Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0

--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Use Node.js 22.4.1
+      - name: Use Node.js 20
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: 22.4.1
+          node-version: 20
           cache: "npm"
       - name: Install Pepr Dependencies
         run: npm ci

--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Use Node.js latest
+      - name: Use Node.js 22.4.1
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: 20
+          node-version: 22.4.1
           cache: "npm"
       - name: Install Pepr Dependencies
         run: npm ci


### PR DESCRIPTION
## Description

Temporary workaround to for https://github.com/nodejs/node/issues/53902. Replaces latest with `22.4.1`. There is a RC for `v0.33.0` using `npx peppr` and this [image](cmwylie19/pepr-controller:v0.33.0-rc). The team is short right now so we plan on releasing on Tuesday

## Related Issue

Fixes #
<!-- or -->
Relates to #https://github.com/nodejs/node/issues/53902

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
