### PR TITLE
feat: expose envFrom in helm generated chart

### DIFF
--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -105,6 +105,8 @@ export function watcherDeployTemplate(buildTimestamp: string) {
                   {{- toYaml .Values.watcher.resources | nindent 12 }}
                 env:
                   {{- toYaml .Values.watcher.env | nindent 12 }}
+                envFrom:
+                  {{- toYaml .Values.watcher.envFrom | nindent 12 }}
                 securityContext:
                   {{- toYaml .Values.watcher.containerSecurityContext | nindent 12 }}
                 volumeMounts:
@@ -187,6 +189,8 @@ export function admissionDeployTemplate(buildTimestamp: string) {
                   {{- toYaml .Values.admission.resources | nindent 12 }}
                 env:
                   {{- toYaml .Values.admission.env | nindent 12 }}
+                envFrom:
+                  {{- toYaml .Values.admission.envFrom | nindent 12 }}
                 securityContext:
                   {{- toYaml .Values.admission.containerSecurityContext | nindent 12 }}
                 volumeMounts:

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -41,6 +41,7 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       failurePolicy: config.onError === "reject" ? "Fail" : "Ignore",
       webhookTimeout: config.webhookTimeout,
       env: envMapToArray(mergePkgJSONEnv(pkgJSONAdmissionEnv, config.env)),
+      envFrom: [],
       image,
       annotations: {
         "pepr.dev/description": `${config.description}` || "",
@@ -85,6 +86,7 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
     watcher: {
       terminationGracePeriodSeconds: 5,
       env: envMapToArray(mergePkgJSONEnv(pkgJSONWatchEnv, config.env)),
+      envFrom: [],
       image,
       annotations: {
         "pepr.dev/description": `${config.description}` || "",


### PR DESCRIPTION
## Description
Adds `envFrom` to generated helm chart for admission and watcher deployments

## Related Issue
Fixes https://github.com/defenseunicorns/pepr/issues/980

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
