### PR TITLE
feat: add slsa verification and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,6 @@ jobs:
           # Build Pepr dist folder for NPM 
           docker buildx build --output="." --target=dist --no-cache . -f Dockerfile.dist
           
-          npm publish --provenance --access public
-
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,17 +67,17 @@ jobs:
           cache: "npm"
       - run: npm ci
 
-
   slsa:
-    needs: format
     permissions:
       id-token: write
       contents: read
       actions: read
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
-
+    with:
+      run-scripts: "ci, build"
+      
   publish:
-    needs: [slsa, format]
+    needs: [slsa]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node registry authentication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           username: dummy
           password: ${{ github.token }}
 
-      - name: Publish to GHCR & NPM
+      - name: Publish to GHCR 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -57,3 +57,45 @@ jobs:
           docker buildx build --output="." --target=dist --no-cache . -f Dockerfile.dist
           
           npm publish --provenance --access public
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Use Node.js latest
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: latest
+          cache: "npm"
+      - run: npm ci
+
+
+  slsa:
+    needs: format
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
+
+  publish:
+    needs: [slsa, format]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node registry authentication
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish package
+        id: publish
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@v2.0.0
+        with:
+          access: public
+          node-auth-token: ${{ secrets.NPM_TOKEN }}
+          package-name: ${{ needs.slsa.outputs.package-name }}
+          package-download-name: ${{ needs.slsa.outputs.package-download-name }}
+          package-download-sha256: ${{ needs.slsa.outputs.package-download-sha256 }}
+          provenance-name: ${{ needs.slsa.outputs.provenance-name }}
+          provenance-download-name: ${{ needs.slsa.outputs.provenance-download-name }}
+          provenance-download-sha256: ${{ needs.slsa.outputs.provenance-download-sha256 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,17 +55,6 @@ jobs:
 
           # Build Pepr dist folder for NPM 
           docker buildx build --output="." --target=dist --no-cache . -f Dockerfile.dist
-          
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Use Node.js latest
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-        with:
-          node-version: latest
-          cache: "npm"
-      - run: npm ci
 
   slsa:
     permissions:
@@ -75,7 +64,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
     with:
       run-scripts: "ci, build"
-      
+
   publish:
     needs: [slsa]
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "files": ["/dist"],
   "version": "0.0.0-development",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "files": ["/dist"],
+  "files": ["/dist", "/src"],
   "version": "0.0.0-development",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",
   "scripts": {
+    "ci": "npm ci",
     "gen-data-json": "node hack/build-template-data.js",
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "build": "tsc && node build.mjs",


### PR DESCRIPTION
## Description

Adds slsa to Pepr release process. Now, in `npmjs` this includes only `dist` and `package.json`, LICENSE, and `README.md`, which is what is necessary to run the CLI. I think this is okay. Lets chat further about this.

https://www.npmjs.com/package/peppr?activeTab=code
```bash
┌─[cmwylie19@Cases-MacBook-Pro] - [~/not-pepr/pepr] - [2024-07-29 11:35:08]
└─[0] <git:(938 1a9636b) > npx peppr -V             
0.37.9-rc
```

## Related Issue

Fixes #938 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
