### PR TITLE
feat: include service monitors in generated chart

### DIFF
--- a/src/lib/assets/helm.test.ts
+++ b/src/lib/assets/helm.test.ts
@@ -44,7 +44,7 @@ describe("Kubernetes Template Generators", () => {
 
   describe("admissionServiceMonitor", () => {
     test("should generate a Service Monitor template for the admission controller correctly", () => {
-      const result = serviceMonitorTemplate('admission');
+      const result = serviceMonitorTemplate("admission");
       expect(result).toContain("apiVersion: monitoring.coreos.com/v1");
       expect(result).toContain("kind: ServiceMonitor");
       expect(result).toContain("name: admission");
@@ -54,7 +54,7 @@ describe("Kubernetes Template Generators", () => {
 
   describe("watcherServiceMonitor", () => {
     test("should generate a Service Monitor template for the watcher controller correctly", () => {
-      const result = serviceMonitorTemplate('watcher');
+      const result = serviceMonitorTemplate("watcher");
       expect(result).toContain("apiVersion: monitoring.coreos.com/v1");
       expect(result).toContain("kind: ServiceMonitor");
       expect(result).toContain("name: watcher");

--- a/src/lib/assets/helm.test.ts
+++ b/src/lib/assets/helm.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { nsTemplate, chartYaml, watcherDeployTemplate, admissionDeployTemplate } from "./helm";
+import { nsTemplate, chartYaml, watcherDeployTemplate, admissionDeployTemplate, serviceMonitorTemplate } from "./helm";
 import { expect, describe, test } from "@jest/globals";
 describe("Kubernetes Template Generators", () => {
   describe("nsTemplate", () => {
@@ -39,6 +39,26 @@ describe("Kubernetes Template Generators", () => {
       expect(result).toContain("apiVersion: apps/v1");
       expect(result).toContain("kind: Deployment");
       expect(result).toContain("name: {{ .Values.uuid }}");
+    });
+  });
+
+  describe("admissionServiceMonitor", () => {
+    test("should generate a Service Monitor template for the admission controller correctly", () => {
+      const result = serviceMonitorTemplate('admission');
+      expect(result).toContain("apiVersion: monitoring.coreos.com/v1");
+      expect(result).toContain("kind: ServiceMonitor");
+      expect(result).toContain("name: admission");
+      expect(result).toContain("pepr.dev/controller: admission");
+    });
+  });
+
+  describe("watcherServiceMonitor", () => {
+    test("should generate a Service Monitor template for the watcher controller correctly", () => {
+      const result = serviceMonitorTemplate('watcher');
+      expect(result).toContain("apiVersion: monitoring.coreos.com/v1");
+      expect(result).toContain("kind: ServiceMonitor");
+      expect(result).toContain("name: watcher");
+      expect(result).toContain("pepr.dev/controller: watcher");
     });
   });
 });

--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -221,3 +221,30 @@ export function admissionDeployTemplate(buildTimestamp: string) {
               {{- end }}
     `;
 }
+
+export function serviceMonitorTemplate(name: string) {
+  return `
+      {{- if .Values.${name}.serviceMonitor.enabled }}
+      apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: ${name}
+        annotations:
+          {{- toYaml .Values.${name}.serviceMonitor.annotations | nindent 4 }}
+        labels:
+          {{- toYaml .Values.${name}.serviceMonitor.labels | nindent 4 }}
+      spec:
+        selector:
+          matchLabels:
+            pepr.dev/controller: ${name}
+        namespaceSelector:
+          matchNames:
+            - pepr-system
+        endpoints:
+          - targetPort: 3000
+            scheme: https
+            tlsConfig:
+              insecureSkipVerify: true
+      {{- end }}
+    `;
+}

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -13,7 +13,7 @@ import { allYaml, zarfYaml, overridesFile, zarfYamlChart } from "./yaml";
 import { namespaceComplianceValidator, replaceString } from "../helpers";
 import { createDirectoryIfNotExists, dedent } from "../helpers";
 import { resolve } from "path";
-import { chartYaml, nsTemplate, admissionDeployTemplate, watcherDeployTemplate } from "./helm";
+import { chartYaml, nsTemplate, admissionDeployTemplate, watcherDeployTemplate, serviceMonitorTemplate } from "./helm";
 import { promises as fs } from "fs";
 import { webhookConfig } from "./webhooks";
 import { apiTokenSecret, service, tlsSecret, watcherService } from "./networking";
@@ -82,7 +82,9 @@ export class Assets {
     const mutationWebhookPath = resolve(CHAR_TEMPLATES_DIR, `mutation-webhook.yaml`);
     const validationWebhookPath = resolve(CHAR_TEMPLATES_DIR, `validation-webhook.yaml`);
     const admissionDeployPath = resolve(CHAR_TEMPLATES_DIR, `admission-deployment.yaml`);
+    const admissionServiceMonitorPath = resolve(CHAR_TEMPLATES_DIR, `admission-service-monitor.yaml`);
     const watcherDeployPath = resolve(CHAR_TEMPLATES_DIR, `watcher-deployment.yaml`);
+    const watcherServiceMonitorPath = resolve(CHAR_TEMPLATES_DIR, `watcher-service-monitor.yaml`);
     const tlsSecretPath = resolve(CHAR_TEMPLATES_DIR, `tls-secret.yaml`);
     const apiTokenSecretPath = resolve(CHAR_TEMPLATES_DIR, `api-token-secret.yaml`);
     const moduleSecretPath = resolve(CHAR_TEMPLATES_DIR, `module-secret.yaml`);
@@ -134,6 +136,7 @@ export class Assets {
 
       if (validateWebhook || mutateWebhook) {
         await fs.writeFile(admissionDeployPath, dedent(admissionDeployTemplate(this.buildTimestamp)));
+        await fs.writeFile(admissionServiceMonitorPath, dedent(serviceMonitorTemplate('admission')));
       }
 
       if (mutateWebhook) {
@@ -166,6 +169,7 @@ export class Assets {
 
       if (watchDeployment) {
         await fs.writeFile(watcherDeployPath, dedent(watcherDeployTemplate(this.buildTimestamp)));
+        await fs.writeFile(watcherServiceMonitorPath, dedent(serviceMonitorTemplate('watcher')));
       }
     } catch (err) {
       console.error(`Error generating helm chart: ${err.message}`);

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -136,7 +136,7 @@ export class Assets {
 
       if (validateWebhook || mutateWebhook) {
         await fs.writeFile(admissionDeployPath, dedent(admissionDeployTemplate(this.buildTimestamp)));
-        await fs.writeFile(admissionServiceMonitorPath, dedent(serviceMonitorTemplate('admission')));
+        await fs.writeFile(admissionServiceMonitorPath, dedent(serviceMonitorTemplate("admission")));
       }
 
       if (mutateWebhook) {
@@ -169,7 +169,7 @@ export class Assets {
 
       if (watchDeployment) {
         await fs.writeFile(watcherDeployPath, dedent(watcherDeployTemplate(this.buildTimestamp)));
-        await fs.writeFile(watcherServiceMonitorPath, dedent(serviceMonitorTemplate('watcher')));
+        await fs.writeFile(watcherServiceMonitorPath, dedent(serviceMonitorTemplate("watcher")));
       }
     } catch (err) {
       console.error(`Error generating helm chart: ${err.message}`);

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -82,6 +82,11 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       extraVolumeMounts: [],
       extraVolumes: [],
       affinity: {},
+      serviceMonitor: {
+        enabled: false,
+        labels: {},
+        annotations: {}
+      }
     },
     watcher: {
       terminationGracePeriodSeconds: 5,
@@ -127,7 +132,12 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       extraVolumes: [],
       affinity: {},
       podAnnotations: {},
-    },
+      serviceMonitor: {
+        enabled: false,
+        labels: {},
+        annotations: {},
+      }
+    }
   };
 
   await fs.writeFile(path, dumpYaml(overrides, { noRefs: true, forceQuotes: true }));

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -85,8 +85,8 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       serviceMonitor: {
         enabled: false,
         labels: {},
-        annotations: {}
-      }
+        annotations: {},
+      },
     },
     watcher: {
       terminationGracePeriodSeconds: 5,
@@ -136,8 +136,8 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
         enabled: false,
         labels: {},
         annotations: {},
-      }
-    }
+      },
+    },
   };
 
   await fs.writeFile(path, dumpYaml(overrides, { noRefs: true, forceQuotes: true }));


### PR DESCRIPTION
## Description
Adds a ServiceMonitor for watcher and admission which should enable discovery for metrics endpoints in environments where `ServiceMonitor` CRDS are supported.

ServiceMonitor can be enabled configuring helm values:

```
admission:
  serviceMonitor:
    enabled: true
watcher:
  serviceMonitor:
    enabled: true
```


Fixes https://github.com/defenseunicorns/pepr/issues/993

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
