### PR TITLE
fix(release-action): pin SLSA publish action to specific commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@5a775b367a56d5bd118a224a811bba288150a563 # v2.0.0
     with:
       run-scripts: "ci, build"
 


### PR DESCRIPTION
## Description

This PR addresses a code scanning alert related to unpinned dependencies in our release action workflow. Specifically, it updates the [SLSA framework's](https://github.com/slsa-framework/slsa-github-generator/) publish action to use a pinned commit hash instead of a version tag.

## Related Issue

Fixes #1004
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
