### PR TITLE
fix(dead link): fix dead link to actions readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For example, an action could be responsible for adding a specific label to a Kub
 
 There are both `Mutate()` and `Validate()` Actions that can be used to modify or validate Kubernetes resources within the admission controller lifecycle. There is also a `Watch()` Action that can be used to watch for changes to Kubernetes resources that already exist.
 
-See [actions](./docs/030_user-guide/030_actions.md) for more details.
+See [actions](./docs/030_user-guide/030_actions/README.md) for more details.
 
 ## Logical Pepr Flow
 


### PR DESCRIPTION
## Description

Fixing a dead link in the README.md pointing incorrectly to actions section.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
