### PR TITLE
feat: add custom liveness and readiness probes to helm chart

### DIFF
--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -68,6 +68,8 @@ Below are the available Helm override configurations after you have built your P
 | `annotations`                                | Deployment annotations                                              |
 | `labels`                                     | Deployment labels                                                   |
 | `securityContext`                            | Pod security context                                                |
+| `readinessProbe`                             | Pod readiness probe definition                                      |
+| `livenessProbe`                              | Pod liveness probe definition                                       |
 | `resources`                                  | Resource limits                                                     |
 | `containerSecurityContext`                   | Container's security context                                        |
 | `nodeSelector`                               | Node selection constraints                                          |

--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -90,15 +90,9 @@ export function watcherDeployTemplate(buildTimestamp: string) {
                   - /app/node_modules/pepr/dist/controller.js
                   - {{ .Values.hash }}
                 readinessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 3000
-                    scheme: HTTPS
+                  {{- toYaml .Values.watcher.readinessProbe | nindent 12 }}
                 livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 3000
-                    scheme: HTTPS
+                  {{- toYaml .Values.watcher.livenessProbe | nindent 12 }}
                 ports:
                   - containerPort: 3000
                 resources:
@@ -176,15 +170,9 @@ export function admissionDeployTemplate(buildTimestamp: string) {
                   - /app/node_modules/pepr/dist/controller.js
                   - {{ .Values.hash }}
                 readinessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 3000
-                    scheme: HTTPS
+                  {{- toYaml .Values.admission.readinessProbe | nindent 12 }}
                 livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 3000
-                    scheme: HTTPS
+                  {{- toYaml .Values.admission.livenessProbe | nindent 12 }}
                 ports:
                   - containerPort: 3000
                 resources:

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -111,6 +111,7 @@ export function watcher(assets: Assets, hash: string, buildTimestamp: string, im
                   port: 3000,
                   scheme: "HTTPS",
                 },
+                initialDelaySeconds: 10,
               },
               livenessProbe: {
                 httpGet: {
@@ -118,6 +119,7 @@ export function watcher(assets: Assets, hash: string, buildTimestamp: string, im
                   port: 3000,
                   scheme: "HTTPS",
                 },
+                initialDelaySeconds: 10,
               },
               ports: [
                 {
@@ -248,6 +250,7 @@ export function deployment(
                   port: 3000,
                   scheme: "HTTPS",
                 },
+                initialDelaySeconds: 10,
               },
               livenessProbe: {
                 httpGet: {
@@ -255,6 +258,7 @@ export function deployment(
                   port: 3000,
                   scheme: "HTTPS",
                 },
+                initialDelaySeconds: 10,
               },
               ports: [
                 {

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -45,6 +45,22 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
         runAsNonRoot: true,
         fsGroup: 65532,
       },
+      readinessProbe: {
+        httpGet: {
+          path: "/healthz",
+          port: 3000,
+          scheme: "HTTPS",
+        },
+        initialDelaySeconds: 10,
+      },
+      livenessProbe: {
+        httpGet: {
+          path: "/healthz",
+          port: 3000,
+          scheme: "HTTPS",
+        },
+        initialDelaySeconds: 10,
+      },
       resources: {
         requests: {
           memory: "64Mi",
@@ -94,6 +110,22 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
         runAsGroup: 65532,
         runAsNonRoot: true,
         fsGroup: 65532,
+      },
+      readinessProbe: {
+        httpGet: {
+          path: "/healthz",
+          port: 3000,
+          scheme: "HTTPS",
+        },
+        initialDelaySeconds: 10,
+      },
+      livenessProbe: {
+        httpGet: {
+          path: "/healthz",
+          port: 3000,
+          scheme: "HTTPS",
+        },
+        initialDelaySeconds: 10,
       },
       resources: {
         requests: {


### PR DESCRIPTION
## Description
This PR replaces the hard-coded readiness and liveness probes in the helm chart with values references to allow for overrides.  `initialDelaySeconds` have also been added to the helm values defaults and the pod definitions to account for nominal startup time of the Pepr pods.
...

## Related Issue

Fixes #1085

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
