### PR TITLE
chore: default relist interval 10 min

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,10 @@ jobs:
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
+          
+      - name: Set package version
+        run: npm --no-git-tag-version version ${{ github.ref_name }} 
+
       - name: Publish package
         id: publish
         uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@5a775b367a56d5bd118a224a811bba288150a563 # v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,6 @@ jobs:
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
-          
-      - name: Set package version
-        run: npm --no-git-tag-version version ${{ github.ref_name }} 
-
       - name: Publish package
         id: publish
         uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@5a775b367a56d5bd118a224a811bba288150a563 # v2.0.0

--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -37,7 +37,7 @@ The Watch configuration is a part of the Pepr module that allows you to watch fo
 | `PEPR_RESYNC_FAILURE_MAX`    | The maximum number of times to fail on a resync interval before re-establishing the watch URL and doing a relist. | default: `"5"`                |
 | `PEPR_RETRY_DELAY_SECONDS`     | The delay between retries in seconds.                                                                            | default: `"10"`                 |
 | `PEPR_LAST_SEEN_LIMIT_SECONDS` | Max seconds to go without receiving a watch event before re-establishing the watch | default: `"300"` (5 mins)       |
-| `PEPR_RELIST_INTERVAL_SECONDS` | Amount of seconds to wait before a relist of the watched resources  | default: `"1800"` (30 mins)       |
+| `PEPR_RELIST_INTERVAL_SECONDS` | Amount of seconds to wait before a relist of the watched resources  | default: `"600"` (10 mins)       |
 
 
 

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -88,7 +88,7 @@ describe("WatchProcessor", () => {
       resyncFailureMax: 5,
       resyncDelaySec: 5,
       lastSeenLimitSeconds: 300,
-      relistIntervalSec: 1800,
+      relistIntervalSec: 600,
     };
 
     capabilities.push({

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -18,7 +18,7 @@ const watchCfg: WatchCfg = {
     : 300,
   relistIntervalSec: process.env.PEPR_RELIST_INTERVAL_SECONDS
     ? parseInt(process.env.PEPR_RELIST_INTERVAL_SECONDS, 10)
-    : 1800,
+    : 600,
 };
 
 // Map the event to the watch phase


### PR DESCRIPTION
## Description

sets default relist interval to 10 mins

End to End Test:  n/a 
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1097 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
