### PR TITLE
chore: support optional fields in ownerReferences

### DIFF
--- a/docs/030_user-guide/015_sdk.md
+++ b/docs/030_user-guide/015_sdk.md
@@ -50,6 +50,8 @@ let result = containers(peprValidationRequest, "ephemeralContainers")
 Returns the owner reference for a Kubernetes resource as an array. Accepts the following parameters:
 
 - **@param kubernetesResource: GenericKind** The Kubernetes resource to get the owner reference for
+- **@param blockOwnerDeletion: boolean** If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. 
+- **@param controller: boolean** If true, this reference points to the managing controller.
 
 **Usage:**
 

--- a/docs/030_user-guide/015_sdk.md
+++ b/docs/030_user-guide/015_sdk.md
@@ -47,7 +47,7 @@ let result = containers(peprValidationRequest, "ephemeralContainers")
 
 ## `getOwnerRefFrom`
 
-Returns the owner reference for a Kubernetes resource. Accepts the following parameters:
+Returns the owner reference for a Kubernetes resource as an array. Accepts the following parameters:
 
 - **@param kubernetesResource: GenericKind** The Kubernetes resource to get the owner reference for
 

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -165,13 +165,6 @@ describe("writeEvent", () => {
 
 describe("getOwnerRefFrom", () => {
 
-  const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length
-  const crWithoutOptionals = {
-    apiVersion: "v1",
-    kind: "Package",
-    metadata: { name: "test", namespace: "default", uid: "1" },
-  };
-
 
   it("should return the owner reference for the CRD", () => {
     const cr = {
@@ -189,65 +182,47 @@ describe("getOwnerRefFrom", () => {
       },
     ]);
   });
-  it("should return the owner reference for the CRD with optional fields", () => {
-    const customResource: GenericKind = {
-      apiVersion: "v1",
-      kind: "Package",
-      metadata: { name: "test", namespace: "default", uid: "1" },
-      blockOwnerDeletion: true,
-    };
-    const ownerRef = getOwnerRefFrom(customResource);
-    expect(ownerRef).toEqual([
-      {
-        apiVersion: "v1",
-        kind: "Package",
-        name: "test",
-        uid: "1",
-        blockOwnerDeletion: false
-      },
-    ]);
-    expect(Object.keys(ownerRef[0]).length).toEqual(V1OwnerReferenceFieldCount - 1);
-  });
-  it("should return the owner reference for the CRD with optional fields", () => {
-    const customResource: GenericKind = {
-      apiVersion: "v1",
-      kind: "Package",
-      metadata: { name: "test", namespace: "default", uid: "1" },
-      controller: true,
-    };
-    const ownerRef = getOwnerRefFrom(customResource);
-    expect(ownerRef).toEqual([
-      {
-        apiVersion: "v1",
-        kind: "Package",
-        name: "test",
-        uid: "1",
-        controller: true
-      },
-    ]);
-    expect(Object.keys(ownerRef[0]).length).toEqual(V1OwnerReferenceFieldCount - 1);
-  });
 
-  it("should return the owner reference for the CRD with all fields", () => {
-    const customResource: GenericKind = {
-      apiVersion: "v1",
-      kind: "Package",
-      metadata: { name: "test", namespace: "default", uid: "1" },
-      blockOwnerDeletion: true,
-      controller: true,
-    };
-    const ownerRef = getOwnerRefFrom(customResource);
-    expect(ownerRef).toEqual([
+  const crWithoutOptionals = {
+    apiVersion: "v1",
+    kind: "Package",
+    metadata: { name: "test", namespace: "default", uid: "1" },
+  };
+
+  const crWithController = {...crWithoutOptionals, controller: true}
+  const crWithBlockOwnerDeletion = {...crWithoutOptionals, blockOwnerDeletion: false}
+  const crWithAllFields = {...crWithoutOptionals, controller: true, blockOwnerDeletion: true}
+
+  const ownerRefWithoutOptionals = [
       {
         apiVersion: "v1",
         kind: "Package",
         name: "test",
         uid: "1",
-        blockOwnerDeletion: true,
-        controller: true
       },
-    ]);
-    expect(Object.keys(ownerRef[0]).length).toEqual(V1OwnerReferenceFieldCount);
+    ];
+
+  const ownerRefWithController = ownerRefWithoutOptionals.map(item => ({
+    ...item, controller: true
+  }))
+  const ownerRefWithBlockOwnerDeletion= ownerRefWithoutOptionals.map(item => ({
+    ...item, blockOwnerDeletion: false
+  }))
+  const ownerRefWithAllFields = ownerRefWithoutOptionals.map(item => ({
+    ...item, controller: true, blockOwnerDeletion: true
+  }))
+
+  const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length
+
+  test.each([
+    [crWithAllFields, ownerRefWithAllFields, V1OwnerReferenceFieldCount],
+    [crWithBlockOwnerDeletion, ownerRefWithBlockOwnerDeletion, V1OwnerReferenceFieldCount-1],
+    [crWithController, ownerRefWithController, V1OwnerReferenceFieldCount-1],
+    [crWithoutOptionals, ownerRefWithoutOptionals, V1OwnerReferenceFieldCount-2],
+  ]) ("should return the owner reference for the CRD with any combination of V1OwnerReference fields", (customResource, ownerReference, fieldCount) =>{
+    const result = getOwnerRefFrom(customResource)
+    expect(result).toEqual(ownerReference);
+    expect(Object.keys(result[0]).length).toEqual(fieldCount)
   });
 });
 

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -164,8 +164,6 @@ describe("writeEvent", () => {
 });
 
 describe("getOwnerRefFrom", () => {
-
-
   it("should return the owner reference for the CRD", () => {
     const cr = {
       apiVersion: "v1",
@@ -189,41 +187,48 @@ describe("getOwnerRefFrom", () => {
     metadata: { name: "test", namespace: "default", uid: "1" },
   };
 
-  const crWithController = {...crWithoutOptionals, controller: true}
-  const crWithBlockOwnerDeletion = {...crWithoutOptionals, blockOwnerDeletion: false}
-  const crWithAllFields = {...crWithoutOptionals, controller: true, blockOwnerDeletion: true}
+  const crWithController = { ...crWithoutOptionals, controller: true };
+  const crWithBlockOwnerDeletion = { ...crWithoutOptionals, blockOwnerDeletion: false };
+  const crWithAllFields = { ...crWithoutOptionals, controller: true, blockOwnerDeletion: true };
 
   const ownerRefWithoutOptionals = [
-      {
-        apiVersion: "v1",
-        kind: "Package",
-        name: "test",
-        uid: "1",
-      },
-    ];
+    {
+      apiVersion: "v1",
+      kind: "Package",
+      name: "test",
+      uid: "1",
+    },
+  ];
 
   const ownerRefWithController = ownerRefWithoutOptionals.map(item => ({
-    ...item, controller: true
-  }))
-  const ownerRefWithBlockOwnerDeletion= ownerRefWithoutOptionals.map(item => ({
-    ...item, blockOwnerDeletion: false
-  }))
+    ...item,
+    controller: true,
+  }));
+  const ownerRefWithBlockOwnerDeletion = ownerRefWithoutOptionals.map(item => ({
+    ...item,
+    blockOwnerDeletion: false,
+  }));
   const ownerRefWithAllFields = ownerRefWithoutOptionals.map(item => ({
-    ...item, controller: true, blockOwnerDeletion: true
-  }))
+    ...item,
+    controller: true,
+    blockOwnerDeletion: true,
+  }));
 
-  const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length
+  const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length;
 
   test.each([
     [crWithAllFields, ownerRefWithAllFields, V1OwnerReferenceFieldCount],
-    [crWithBlockOwnerDeletion, ownerRefWithBlockOwnerDeletion, V1OwnerReferenceFieldCount-1],
-    [crWithController, ownerRefWithController, V1OwnerReferenceFieldCount-1],
-    [crWithoutOptionals, ownerRefWithoutOptionals, V1OwnerReferenceFieldCount-2],
-  ]) ("should return the owner reference for the CRD with any combination of V1OwnerReference fields", (customResource, ownerReference, fieldCount) =>{
-    const result = getOwnerRefFrom(customResource)
-    expect(result).toEqual(ownerReference);
-    expect(Object.keys(result[0]).length).toEqual(fieldCount)
-  });
+    [crWithBlockOwnerDeletion, ownerRefWithBlockOwnerDeletion, V1OwnerReferenceFieldCount - 1],
+    [crWithController, ownerRefWithController, V1OwnerReferenceFieldCount - 1],
+    [crWithoutOptionals, ownerRefWithoutOptionals, V1OwnerReferenceFieldCount - 2],
+  ])(
+    "should return the owner reference for the CRD with any combination of V1OwnerReference fields",
+    (customResource, ownerReference, fieldCount) => {
+      const result = getOwnerRefFrom(customResource);
+      expect(result).toEqual(ownerReference);
+      expect(Object.keys(result[0]).length).toEqual(fieldCount);
+    },
+  );
 });
 
 describe("sanitizeResourceName Fuzzing Tests", () => {

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -203,7 +203,7 @@ describe("getOwnerRefFrom", () => {
     "should return owner reference for the CRD for combinations of V1OwnerReference fields - Optionals: blockOwnerDeletion (%s), controller (%s)",
     (blockOwnerDeletion, controller, expected) => {
       const result = getOwnerRefFrom(customResource, blockOwnerDeletion, controller);
-      expect(result).toEqual(expected);
+      expect(result).toStrictEqual(expected);
     },
   );
 

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -164,34 +164,14 @@ describe("writeEvent", () => {
 });
 
 describe("getOwnerRefFrom", () => {
-  it("should return the owner reference for the CRD", () => {
-    const cr = {
-      apiVersion: "v1",
-      kind: "Package",
-      metadata: { name: "test", namespace: "default", uid: "1" },
-    };
-    const ownerRef = getOwnerRefFrom(cr as GenericKind);
-    expect(ownerRef).toEqual([
-      {
-        apiVersion: "v1",
-        kind: "Package",
-        name: "test",
-        uid: "1",
-      },
-    ]);
-  });
 
-  const crWithoutOptionals = {
+  const customResource = {
     apiVersion: "v1",
     kind: "Package",
     metadata: { name: "test", namespace: "default", uid: "1" },
   };
 
-  const crWithController = { ...crWithoutOptionals, controller: true };
-  const crWithBlockOwnerDeletion = { ...crWithoutOptionals, blockOwnerDeletion: false };
-  const crWithAllFields = { ...crWithoutOptionals, controller: true, blockOwnerDeletion: true };
-
-  const ownerRefWithoutOptionals = [
+  const ownerRef = [
     {
       apiVersion: "v1",
       kind: "Package",
@@ -200,35 +180,38 @@ describe("getOwnerRefFrom", () => {
     },
   ];
 
-  const ownerRefWithController = ownerRefWithoutOptionals.map(item => ({
+  const ownerRefWithController = ownerRef.map(item => ({
     ...item,
     controller: true,
   }));
-  const ownerRefWithBlockOwnerDeletion = ownerRefWithoutOptionals.map(item => ({
+  const ownerRefWithBlockOwnerDeletion = ownerRef.map(item => ({
     ...item,
     blockOwnerDeletion: false,
   }));
-  const ownerRefWithAllFields = ownerRefWithoutOptionals.map(item => ({
+  const ownerRefWithAllFields = ownerRef.map(item => ({
     ...item,
-    controller: true,
     blockOwnerDeletion: true,
+    controller: false,
   }));
 
-  const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length;
-
   test.each([
-    [crWithAllFields, ownerRefWithAllFields, V1OwnerReferenceFieldCount],
-    [crWithBlockOwnerDeletion, ownerRefWithBlockOwnerDeletion, V1OwnerReferenceFieldCount - 1],
-    [crWithController, ownerRefWithController, V1OwnerReferenceFieldCount - 1],
-    [crWithoutOptionals, ownerRefWithoutOptionals, V1OwnerReferenceFieldCount - 2],
+    [true, false, ownerRefWithAllFields],
+    [false, undefined, ownerRefWithBlockOwnerDeletion],
+    [undefined, true, ownerRefWithController],
+    [undefined, undefined, ownerRef],
   ])(
-    "should return the owner reference for the CRD with any combination of V1OwnerReference fields",
-    (customResource, ownerReference, fieldCount) => {
-      const result = getOwnerRefFrom(customResource);
-      expect(result).toEqual(ownerReference);
-      expect(Object.keys(result[0]).length).toEqual(fieldCount);
+    "should return owner reference for the CRD for combinations of V1OwnerReference fields - Optionals: blockOwnerDeletion (%s), controller (%s)",
+    (blockOwnerDeletion, controller, expected) => {
+      const result = getOwnerRefFrom(customResource, blockOwnerDeletion, controller);
+      expect(result).toEqual(expected);
     },
   );
+
+  it("should support all defined fields in the V1OwnerReference type", () => {
+   const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length;
+    const result = getOwnerRefFrom(customResource, false, true);
+    expect(Object.keys(result[0]).length).toEqual(V1OwnerReferenceFieldCount);
+  });
 });
 
 describe("sanitizeResourceName Fuzzing Tests", () => {

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -164,7 +164,6 @@ describe("writeEvent", () => {
 });
 
 describe("getOwnerRefFrom", () => {
-
   const customResource = {
     apiVersion: "v1",
     kind: "Package",
@@ -208,7 +207,7 @@ describe("getOwnerRefFrom", () => {
   );
 
   it("should support all defined fields in the V1OwnerReference type", () => {
-   const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length;
+    const V1OwnerReferenceFieldCount = Object.getOwnPropertyNames(V1OwnerReference).length;
     const result = getOwnerRefFrom(customResource, false, true);
     expect(Object.keys(result[0]).length).toEqual(V1OwnerReferenceFieldCount);
   });

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -83,23 +83,17 @@ export async function writeEvent(
  * @returns the owner reference array for the custom resource
  */
 export function getOwnerRefFrom(customResource: GenericKind, blockOwnerDeletion?: boolean, controller?: boolean): V1OwnerReference[] {
-  const { name, uid } = customResource.metadata!;
+  const { apiVersion, kind, metadata } = customResource;
+  const { name, uid } = metadata!;
 
-  const ownerReference: V1OwnerReference = {
-    apiVersion: customResource.apiVersion!,
-    kind: customResource.kind!,
+  return [{
+    apiVersion: apiVersion!,
+    kind: kind!,
     uid: uid!,
     name: name!,
-  };
-
-  if (blockOwnerDeletion !== undefined ) {
-    ownerReference.blockOwnerDeletion = blockOwnerDeletion;
-  }
-  if (controller !== undefined) {
-    ownerReference.controller = controller;
-  }
-
-  return [ownerReference];
+    ...(blockOwnerDeletion !== undefined && { blockOwnerDeletion }),
+    ...(controller !== undefined && { controller }),
+  }];
 }
 
 /**

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -92,13 +92,13 @@ export function getOwnerRefFrom(customResource: GenericKind): V1OwnerReference[]
       name: name!,
     };
 
-  if("blockOwnerDeletion" in customResource){
+  if(Object.prototype.hasOwnProperty.call(customResource, "blockOwnerDeletion")){
     ownerReference.blockOwnerDeletion = customResource.blockOwnerDeletion
   }
-  if("controller" in customResource){
+  if(Object.prototype.hasOwnProperty.call(customResource, "controller")){
     ownerReference.controller = customResource.controller
   }
-  //TODO: Why is this an array?
+
   return [ownerReference];
 }
 

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -86,17 +86,17 @@ export function getOwnerRefFrom(customResource: GenericKind): V1OwnerReference[]
   const { name, uid } = customResource.metadata!;
 
   const ownerReference: V1OwnerReference = {
-      apiVersion: customResource.apiVersion!,
-      kind: customResource.kind!,
-      uid: uid!,
-      name: name!,
-    };
+    apiVersion: customResource.apiVersion!,
+    kind: customResource.kind!,
+    uid: uid!,
+    name: name!,
+  };
 
-  if(Object.prototype.hasOwnProperty.call(customResource, "blockOwnerDeletion")){
-    ownerReference.blockOwnerDeletion = customResource.blockOwnerDeletion
+  if (Object.prototype.hasOwnProperty.call(customResource, "blockOwnerDeletion")) {
+    ownerReference.blockOwnerDeletion = customResource.blockOwnerDeletion;
   }
-  if(Object.prototype.hasOwnProperty.call(customResource, "controller")){
-    ownerReference.controller = customResource.controller
+  if (Object.prototype.hasOwnProperty.call(customResource, "controller")) {
+    ownerReference.controller = customResource.controller;
   }
 
   return [ownerReference];

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -82,7 +82,7 @@ export async function writeEvent(
  * @param customResource the custom resource to get the owner reference for
  * @returns the owner reference array for the custom resource
  */
-export function getOwnerRefFrom(customResource: GenericKind): V1OwnerReference[] {
+export function getOwnerRefFrom(customResource: GenericKind, blockOwnerDeletion?: boolean, controller?: boolean): V1OwnerReference[] {
   const { name, uid } = customResource.metadata!;
 
   const ownerReference: V1OwnerReference = {
@@ -92,11 +92,11 @@ export function getOwnerRefFrom(customResource: GenericKind): V1OwnerReference[]
     name: name!,
   };
 
-  if (Object.prototype.hasOwnProperty.call(customResource, "blockOwnerDeletion")) {
-    ownerReference.blockOwnerDeletion = customResource.blockOwnerDeletion;
+  if (blockOwnerDeletion !== undefined ) {
+    ownerReference.blockOwnerDeletion = blockOwnerDeletion;
   }
-  if (Object.prototype.hasOwnProperty.call(customResource, "controller")) {
-    ownerReference.controller = customResource.controller;
+  if (controller !== undefined) {
+    ownerReference.controller = controller;
   }
 
   return [ownerReference];

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -80,6 +80,8 @@ export async function writeEvent(
 /**
  * Get the owner reference for a custom resource
  * @param customResource the custom resource to get the owner reference for
+ * @param blockOwnerDeletion if true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. 
+ * @param controller if true, this reference points to the managing controller.
  * @returns the owner reference array for the custom resource
  */
 export function getOwnerRefFrom(

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -79,20 +79,27 @@ export async function writeEvent(
 
 /**
  * Get the owner reference for a custom resource
- * @param cr the custom resource to get the owner reference for
- * @returns the owner reference for the custom resource
+ * @param customResource the custom resource to get the owner reference for
+ * @returns the owner reference array for the custom resource
  */
-export function getOwnerRefFrom(cr: GenericKind): V1OwnerReference[] {
-  const { name, uid } = cr.metadata!;
+export function getOwnerRefFrom(customResource: GenericKind): V1OwnerReference[] {
+  const { name, uid } = customResource.metadata!;
 
-  return [
-    {
-      apiVersion: cr.apiVersion!,
-      kind: cr.kind!,
+  const ownerReference: V1OwnerReference = {
+      apiVersion: customResource.apiVersion!,
+      kind: customResource.kind!,
       uid: uid!,
       name: name!,
-    },
-  ];
+    };
+
+  if("blockOwnerDeletion" in customResource){
+    ownerReference.blockOwnerDeletion = customResource.blockOwnerDeletion
+  }
+  if("controller" in customResource){
+    ownerReference.controller = customResource.controller
+  }
+  //TODO: Why is this an array?
+  return [ownerReference];
 }
 
 /**

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -80,7 +80,7 @@ export async function writeEvent(
 /**
  * Get the owner reference for a custom resource
  * @param customResource the custom resource to get the owner reference for
- * @param blockOwnerDeletion if true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. 
+ * @param blockOwnerDeletion if true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed.
  * @param controller if true, this reference points to the managing controller.
  * @returns the owner reference array for the custom resource
  */

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -82,18 +82,24 @@ export async function writeEvent(
  * @param customResource the custom resource to get the owner reference for
  * @returns the owner reference array for the custom resource
  */
-export function getOwnerRefFrom(customResource: GenericKind, blockOwnerDeletion?: boolean, controller?: boolean): V1OwnerReference[] {
+export function getOwnerRefFrom(
+  customResource: GenericKind,
+  blockOwnerDeletion?: boolean,
+  controller?: boolean,
+): V1OwnerReference[] {
   const { apiVersion, kind, metadata } = customResource;
   const { name, uid } = metadata!;
 
-  return [{
-    apiVersion: apiVersion!,
-    kind: kind!,
-    uid: uid!,
-    name: name!,
-    ...(blockOwnerDeletion !== undefined && { blockOwnerDeletion }),
-    ...(controller !== undefined && { controller }),
-  }];
+  return [
+    {
+      apiVersion: apiVersion!,
+      kind: kind!,
+      uid: uid!,
+      name: name!,
+      ...(blockOwnerDeletion !== undefined && { blockOwnerDeletion }),
+      ...(controller !== undefined && { controller }),
+    },
+  ];
 }
 
 /**


### PR DESCRIPTION
## Description

This PR adds support for optional fields defined in [ownerReferences](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#System). It also changes the test block to use a parameterized test.

End to End Test:  N/A

## Related Issue

Fixes #1060

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
