### PR TITLE
chore: exclude dev deps

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -244,6 +244,10 @@ export async function loadModule(entryPoint = peprTS) {
 export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embed = true) {
   try {
     const { cfg, modulePath, path, uuid } = await loadModule(entryPoint);
+    const excludedDeps = [
+      ...externalLibs,
+      ...Object.keys(cfg.devDependencies).filter(dep => dep !== "typescript"),
+    ];
 
     const validFormat = await peprFormat(true);
 
@@ -265,7 +269,7 @@ export async function buildModule(reloader?: Reloader, entryPoint = peprTS, embe
     const ctxCfg: BuildOptions = {
       bundle: true,
       entryPoints: [entryPoint],
-      external: externalLibs,
+      external: excludedDeps,
       format: "cjs",
       keepNames: true,
       legalComments: "external",


### PR DESCRIPTION
## Description

This excludes devDependencies in the module other than TypeScript. This PR only cuts out the keys from the devDependencies in the built js.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1103 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
