### PR TITLE
chore: add commit lint "ignore" rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,8 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  ignores: [
+    // prevent header-max-length error on long dependabot commits
+    //  https://github.com/dependabot/dependabot-core/issues/2445
+    (message) => /^.+: bump .+ from .+ to .+\.$/m.test(message)
+  ],
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   ignores: [
-    // prevent header-max-length error on long dependabot commits
+    // prevent header-max-length error on long, dependabot-gen'd commits titles
     //  https://github.com/dependabot/dependabot-core/issues/2445
-    (message) => /^.+: bump .+ from .+ to .+$/m.test(message)
+    (message) => /^chore: bump .+ from .+ to .+$/m.test(message)
   ],
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,6 @@ module.exports = {
   ignores: [
     // prevent header-max-length error on long dependabot commits
     //  https://github.com/dependabot/dependabot-core/issues/2445
-    (message) => /^.+: bump .+ from .+ to .+\.$/m.test(message)
+    (message) => /^.+: bump .+ from .+ to .+$/m.test(message)
   ],
 };


### PR DESCRIPTION
## Description
Prevents commitlint from throwing  header-max-length errors on long, dependabot-generated commit titles.

## Related Issue
Fixes #1124

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
