### PR TITLE
chore: update husky install due to deprecation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:journey:upgrade": "npm run test:journey:k3d && npm run test:journey:image && jest --detectOpenHandles journey/pepr-upgrade.test.ts",
     "format:check": "eslint src && prettier src --check",
     "format:fix": "eslint src --fix && prettier src --write",
-    "prepare": "if [ \"$NODE_ENV\" != 'production' ]; then husky install; fi"
+    "prepare": "if [ \"$NODE_ENV\" != 'production' ]; then husky; fi"
   },
   "dependencies": {
     "@types/ramda": "0.30.2",

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -26,9 +26,7 @@ jest.mock("./metrics", () => ({
     incRetryCount: jest.fn(),
   },
 }));
-it("something", () => {
-  expect(1).toBe(1);
-});
+
 describe("WatchProcessor", () => {
   const mockStart = jest.fn();
   const mockK8s = jest.mocked(K8s);

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -26,7 +26,9 @@ jest.mock("./metrics", () => ({
     incRetryCount: jest.fn(),
   },
 }));
-
+it("something", () => {
+  expect(1).toBe(1);
+});
 describe("WatchProcessor", () => {
   const mockStart = jest.fn();
   const mockK8s = jest.mocked(K8s);


### PR DESCRIPTION
## Description

Husky command is deprecated, the install changed [link](https://typicode.github.io/husky/how-to.html)

![image](https://github.com/user-attachments/assets/0252074b-3482-4717-972b-15e8deaf81ae)


End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1166 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
