### PR TITLE
chore: dont do patch operation if store is empty

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -107,10 +107,11 @@ export class Storage implements PeprStore {
   };
 
   clear = () => {
-    this.#dispatchUpdate(
-      "remove",
-      Object.keys(this.#store).map(key => pointer.escape(key)),
-    );
+    Object.keys(this.#store).length > 0 &&
+      this.#dispatchUpdate(
+        "remove",
+        Object.keys(this.#store).map(key => pointer.escape(key)),
+      );
   };
 
   removeItem = (key: string) => {


### PR DESCRIPTION
## Description

`Store.clear()` will fail is store is empty. This prevents the patch operation from being called if the store is empty allowing you to call `Store.clear()` on an empty store without clearing an error and wasting an API call. 

End to End Test: https://github.com/defenseunicorns/pepr-excellent-examples/pull/80

## Related Issue

Fixes #1181
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
