### PR TITLE
refactor: remove filterNoMatchReasonRegex / shouldSkipRequestRegex wrappers

### DIFF
--- a/src/lib/adjudicators.test.ts
+++ b/src/lib/adjudicators.test.ts
@@ -137,6 +137,38 @@ describe("ignoresName", () => {
   });
 });
 
+describe("definedNameRegex", () => {
+  //[ Binding, result ]
+  it.each([
+    [{}, ""],
+    [{ filters: {} }, ""],
+    [{ filters: { regexName: null } }, ""],
+    [{ filters: { regexName: "n.me" } }, "n.me"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const binding = given as DeepPartial<Binding>;
+
+    const result = sut.definedNameRegex(binding);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("definesNameRegex", () => {
+  //[ Binding, result ]
+  it.each([
+    [{}, false],
+    [{ filters: {} }, false],
+    [{ filters: { regexName: null } }, false],
+    [{ filters: { regexName: "n.me" } }, true],
+  ])("given %j, returns %s", (given, expected) => {
+    const binding = given as DeepPartial<Binding>;
+
+    const result = sut.definesNameRegex(binding);
+
+    expect(result).toBe(expected);
+  });
+});
+
 describe("carriedName", () => {
   //[ KubernetesObject, result ]
   it.each([
@@ -197,6 +229,28 @@ describe("mismatchedName", () => {
     const object = obj as DeepPartial<KubernetesObject>;
 
     const result = sut.mismatchedName(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedNameRegex", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { name: "name" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, {}, true],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "name" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "neme" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nime" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nome" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nume" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "n3me" } }, true],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<KubernetesObject>;
+
+    const result = sut.mismatchedNameRegex(binding, object);
 
     expect(result).toBe(expected);
   });

--- a/src/lib/adjudicators.test.ts
+++ b/src/lib/adjudicators.test.ts
@@ -277,6 +277,42 @@ describe("definesNamespaces", () => {
   });
 });
 
+describe("definedNamespaceRegexes", () => {
+  //[ Binding, result ]
+  it.each([
+    [{}, []],
+    [{ filters: {} }, []],
+    [{ filters: { regexNamespaces: null } }, []],
+    [{ filters: { regexNamespaces: [] } }, []],
+    [{ filters: { regexNamespaces: ["n.mesp.ce"] } }, ["n.mesp.ce"]],
+    [{ filters: { regexNamespaces: ["n.me", "sp.ce"] } }, ["n.me", "sp.ce"]],
+  ])("given %j, returns %j", (given, expected) => {
+    const binding = given as DeepPartial<Binding>;
+
+    const result = sut.definedNamespaceRegexes(binding);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("definesNamespaceRegexes", () => {
+  //[ Binding, result ]
+  it.each([
+    [{}, false],
+    [{ filters: {} }, false],
+    [{ filters: { regexNamespaces: null } }, false],
+    [{ filters: { regexNamespaces: [] } }, false],
+    [{ filters: { regexNamespaces: ["n.mesp.ce"] } }, true],
+    [{ filters: { regexNamespaces: ["n.me", "sp.ce"] } }, true],
+  ])("given %j, returns %s", (given, expected) => {
+    const binding = given as DeepPartial<Binding>;
+
+    const result = sut.definesNamespaceRegexes(binding);
+
+    expect(result).toBe(expected);
+  });
+});
+
 describe("carriedNamespace", () => {
   //[ KubernetesObject, result ]
   it.each([
@@ -324,6 +360,37 @@ describe("mismatchedNamespace", () => {
     const object = obj as DeepPartial<Binding>;
 
     const result = sut.mismatchedNamespace(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedNamespaceRegex", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { namespace: "namespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n.mespace$"] } }, {}, true],
+
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "namespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nemespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nimespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nomespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "numespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "n3mespace" } }, true],
+
+    [{ filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } }, { metadata: { namespace: "name" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } }, { metadata: { namespace: "space" } }, false],
+    [
+      { filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } },
+      { metadata: { namespace: "namespace" } },
+      true,
+    ],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<Binding>;
+
+    const result = sut.mismatchedNamespaceRegex(binding, object);
 
     expect(result).toBe(expected);
   });

--- a/src/lib/adjudicators.test.ts
+++ b/src/lib/adjudicators.test.ts
@@ -723,6 +723,35 @@ describe("uncarryableNamespace", () => {
   });
 });
 
+describe("carriesIgnoredNamespace", () => {
+  //[ ignored ns's, KubernetesObject, result ]
+  it.each([
+    [[], {}, false],
+    [[], { metadata: { namespace: "whatever" } }, false],
+
+    [["ignored"], {}, false],
+    [["ignored"], { metadata: {} }, false],
+    [["ignored"], { metadata: { namespace: null } }, false],
+    [["ignored"], { metadata: { namespace: "" } }, false],
+    [["ignored"], { metadata: { namespace: "namespace" } }, false],
+    [["ignored"], { metadata: { namespace: "ignored" } }, true],
+
+    [["ign", "ored"], {}, false],
+    [["ign", "ored"], { metadata: {} }, false],
+    [["ign", "ored"], { metadata: { namespace: null } }, false],
+    [["ign", "ored"], { metadata: { namespace: "" } }, false],
+    [["ign", "ored"], { metadata: { namespace: "ign" } }, true],
+    [["ign", "ored"], { metadata: { namespace: "ored" } }, true],
+    [["ign", "ored"], { metadata: { namespace: "namespace" } }, false],
+  ])("given capabilityNamespaces %j and object %j, returns %s", (nss, obj, expected) => {
+    const object = obj as DeepPartial<Binding>;
+
+    const result = sut.carriesIgnoredNamespace(nss, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
 describe("unbindableNamespaces", () => {
   //[ capa ns's, Binding, result ]
   it.each([

--- a/src/lib/adjudicators.ts
+++ b/src/lib/adjudicators.ts
@@ -5,6 +5,7 @@ import { Event, Operation } from "./types";
 import {
   __,
   allPass,
+  any,
   anyPass,
   complement,
   curry,
@@ -65,6 +66,9 @@ export const ignoresName = complement(definesName);
 
 export const definedNamespaces = pipe(binding => binding?.filters?.namespaces, defaultTo([]));
 export const definesNamespaces = pipe(definedNamespaces, equals([]), not);
+
+export const definedNamespaceRegexes = pipe(binding => binding?.filters?.regexNamespaces, defaultTo([]));
+export const definesNamespaceRegexes = pipe(definedNamespaceRegexes, equals([]), not);
 
 export const definedAnnotations = pipe(binding => binding?.filters?.annotations, defaultTo({}));
 export const definesAnnotations = pipe(definedAnnotations, equals({}), not);
@@ -129,6 +133,16 @@ export const misboundNamespace = allPass([bindsToNamespace, definesNamespaces]);
 export const mismatchedNamespace = allPass([
   pipe(nthArg(0), definesNamespaces),
   pipe((bnd, obj) => definedNamespaces(bnd).includes(carriedNamespace(obj)), not),
+]);
+
+export const mismatchedNamespaceRegex = allPass([
+  pipe(nthArg(0), definesNamespaceRegexes),
+  pipe((bnd, obj) =>
+    pipe(
+      any((rex: string) => new RegExp(rex).test(carriedNamespace(obj))),
+      not,
+    )(definedNamespaceRegexes(bnd)),
+  ),
 ]);
 
 export const metasMismatch = pipe(

--- a/src/lib/adjudicators.ts
+++ b/src/lib/adjudicators.ts
@@ -64,6 +64,9 @@ export const definedName = pipe(binding => binding?.filters?.name, defaultTo("")
 export const definesName = pipe(definedName, equals(""), not);
 export const ignoresName = complement(definesName);
 
+export const definedNameRegex = pipe(binding => binding?.filters?.regexName, defaultTo(""));
+export const definesNameRegex = pipe(definedNameRegex, equals(""), not);
+
 export const definedNamespaces = pipe(binding => binding?.filters?.namespaces, defaultTo([]));
 export const definesNamespaces = pipe(definedNamespaces, equals([]), not);
 
@@ -122,6 +125,11 @@ export const mismatchedDeletionTimestamp = allPass([
 export const mismatchedName = allPass([
   pipe(nthArg(0), definesName),
   pipe((bnd, obj) => definedName(bnd) !== carriedName(obj)),
+]);
+
+export const mismatchedNameRegex = allPass([
+  pipe(nthArg(0), definesNameRegex),
+  pipe((bnd, obj) => new RegExp(definedNameRegex(bnd)).test(carriedName(obj)), not),
 ]);
 
 export const bindsToKind = curry(

--- a/src/lib/adjudicators.ts
+++ b/src/lib/adjudicators.ts
@@ -194,6 +194,12 @@ export const uncarryableNamespace = allPass([
   pipe((nss, obj) => nss.includes(carriedNamespace(obj)), not),
 ]);
 
+export const carriesIgnoredNamespace = allPass([
+  pipe(nthArg(0), length, gt(__, 0)),
+  pipe(nthArg(1), carriesNamespace),
+  pipe((nss, obj) => nss.includes(carriedNamespace(obj))),
+]);
+
 export const unbindableNamespaces = allPass([
   pipe(nthArg(0), length, gt(__, 0)),
   pipe(nthArg(1), definesNamespaces),

--- a/src/lib/filter.test.ts
+++ b/src/lib/filter.test.ts
@@ -5,14 +5,14 @@ import { expect, test, describe } from "@jest/globals";
 import { kind, modelToGroupVersionKind } from "kubernetes-fluent-client";
 import * as fc from "fast-check";
 import { CreatePod, DeletePod } from "../fixtures/loader";
-import { shouldSkipRequestRegex } from "./filter";
+import { shouldSkipRequest } from "./filter";
 import { AdmissionRequest, Binding, Event } from "./types";
 
 export const callback = () => undefined;
 
 export const podKind = modelToGroupVersionKind(kind.Pod.name);
 
-describe("Fuzzing shouldSkipRequestRegex", () => {
+describe("Fuzzing shouldSkipRequest", () => {
   test("should handle random inputs without crashing", () => {
     fc.assert(
       fc.property(
@@ -50,7 +50,7 @@ describe("Fuzzing shouldSkipRequestRegex", () => {
         fc.array(fc.string()),
         (binding, req, capabilityNamespaces) => {
           expect(() =>
-            shouldSkipRequestRegex(binding as Binding, req as AdmissionRequest, capabilityNamespaces),
+            shouldSkipRequest(binding as Binding, req as AdmissionRequest, capabilityNamespaces),
           ).not.toThrow();
         },
       ),
@@ -58,7 +58,7 @@ describe("Fuzzing shouldSkipRequestRegex", () => {
     );
   });
 });
-describe("Property-Based Testing shouldSkipRequestRegex", () => {
+describe("Property-Based Testing shouldSkipRequest", () => {
   test("should only skip requests that do not match the binding criteria", () => {
     fc.assert(
       fc.property(
@@ -95,7 +95,7 @@ describe("Property-Based Testing shouldSkipRequestRegex", () => {
         }),
         fc.array(fc.string()),
         (binding, req, capabilityNamespaces) => {
-          const shouldSkip = shouldSkipRequestRegex(binding as Binding, req as AdmissionRequest, capabilityNamespaces);
+          const shouldSkip = shouldSkipRequest(binding as Binding, req as AdmissionRequest, capabilityNamespaces);
           expect(typeof shouldSkip).toBe("boolean");
         },
       ),
@@ -121,7 +121,7 @@ test("create: should reject when regex name does not match", () => {
     callback,
   };
   const pod = CreatePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 test("create: should not reject when regex name does match", () => {
   const binding = {
@@ -140,7 +140,7 @@ test("create: should not reject when regex name does match", () => {
     callback,
   };
   const pod = CreatePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 test("delete: should reject when regex name does not match", () => {
   const binding = {
@@ -159,7 +159,7 @@ test("delete: should reject when regex name does not match", () => {
     callback,
   };
   const pod = DeletePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 test("delete: should not reject when regex name does match", () => {
   const binding = {
@@ -178,7 +178,7 @@ test("delete: should not reject when regex name does match", () => {
     callback,
   };
   const pod = DeletePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("create: should not reject when regex namespace does match", () => {
@@ -198,7 +198,7 @@ test("create: should not reject when regex namespace does match", () => {
     callback,
   };
   const pod = CreatePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("create: should reject when regex namespace does not match", () => {
@@ -218,7 +218,7 @@ test("create: should reject when regex namespace does not match", () => {
     callback,
   };
   const pod = CreatePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("delete: should reject when regex namespace does not match", () => {
@@ -238,7 +238,7 @@ test("delete: should reject when regex namespace does not match", () => {
     callback,
   };
   const pod = DeletePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("delete: should not reject when regex namespace does match", () => {
@@ -258,7 +258,7 @@ test("delete: should not reject when regex namespace does match", () => {
     callback,
   };
   const pod = DeletePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("delete: should reject when name does not match", () => {
@@ -278,7 +278,7 @@ test("delete: should reject when name does not match", () => {
     callback,
   };
   const pod = DeletePod();
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 test("should reject when kind does not match", () => {
   const binding = {
@@ -298,7 +298,7 @@ test("should reject when kind does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should reject when group does not match", () => {
@@ -319,7 +319,7 @@ test("should reject when group does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should reject when version does not match", () => {
@@ -344,7 +344,7 @@ test("should reject when version does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when group, version, and kind match", () => {
@@ -365,7 +365,7 @@ test("should allow when group, version, and kind match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should allow when kind match and others are empty", () => {
@@ -390,7 +390,7 @@ test("should allow when kind match and others are empty", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should reject when the capability namespace does not match", () => {
@@ -411,7 +411,7 @@ test("should reject when the capability namespace does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, ["bleh", "bleh2"])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, ["bleh", "bleh2"])).toBe(true);
 });
 
 test("should reject when namespace does not match", () => {
@@ -432,7 +432,7 @@ test("should reject when namespace does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when namespace is match", () => {
@@ -453,7 +453,7 @@ test("should allow when namespace is match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should reject when label does not match", () => {
@@ -476,7 +476,7 @@ test("should reject when label does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when label is match", () => {
@@ -507,7 +507,7 @@ test("should allow when label is match", () => {
     test2: "test2",
   };
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should reject when annotation does not match", () => {
@@ -530,7 +530,7 @@ test("should reject when annotation does not match", () => {
   };
   const pod = CreatePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should allow when annotation is match", () => {
@@ -561,7 +561,7 @@ test("should allow when annotation is match", () => {
     test2: "test2",
   };
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should use `oldObject` when the operation is `DELETE`", () => {
@@ -587,7 +587,7 @@ test("should use `oldObject` when the operation is `DELETE`", () => {
 
   const pod = DeletePod();
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });
 
 test("should skip processing when deletionTimestamp is not present on pod", () => {
@@ -618,7 +618,7 @@ test("should skip processing when deletionTimestamp is not present on pod", () =
     test2: "test2",
   };
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(true);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(true);
 });
 
 test("should processing when deletionTimestamp is not present on pod", () => {
@@ -650,5 +650,5 @@ test("should processing when deletionTimestamp is not present on pod", () => {
     test2: "test2",
   };
 
-  expect(shouldSkipRequestRegex(binding, pod, [])).toBe(false);
+  expect(shouldSkipRequest(binding, pod, [])).toBe(false);
 });

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -3,8 +3,8 @@
 
 import { AdmissionRequest, Binding, Operation } from "./types";
 // import { ignoredNSObjectViolation, matchesRegex } from "./helpers";
-import { ignoredNSObjectViolation } from "./helpers";
 import {
+  carriesIgnoredNamespace,
   misboundDeleteWithDeletionTimestamp,
   mismatchedDeletionTimestamp,
   mismatchedAnnotations,
@@ -27,9 +27,6 @@ export function shouldSkipRequestRegex(
   capabilityNamespaces: string[],
   ignoredNamespaces?: string[],
 ): boolean {
-  // const { regexName } = binding.filters || {};
-  // const operation = req.operation.toUpperCase();
-
   const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
 
   const result = shouldSkipRequest(binding, req, capabilityNamespaces);
@@ -37,38 +34,13 @@ export function shouldSkipRequestRegex(
     if (mismatchedNamespaceRegex(binding, obj)) {
       return true;
     }
-    // if (regexNamespaces && regexNamespaces.length > 0) {
-    //   for (const regexNamespace of regexNamespaces) {
-    //     if (
-    //       !matchesRegex(
-    //         regexNamespace,
-    //         (operation === Operation.DELETE ? req.oldObject?.metadata?.namespace : req.object.metadata?.namespace) ||
-    //           "",
-    //       )
-    //     ) {
-    //       return true;
-    //     }
-    //   }
-    // }
 
     if (mismatchedNameRegex(binding, obj)) {
       return true;
     }
-    // if (
-    //   regexName &&
-    //   regexName !== "" &&
-    //   !matchesRegex(
-    //     regexName,
-    //     (operation === Operation.DELETE ? req.oldObject?.metadata?.name : req.object.metadata?.name) || "",
-    //   )
-    // ) {
-    //   return true;
-    // }
   }
 
-  // check ignored namespaces
-  const ignoredNS = ignoredNSObjectViolation(req, {}, ignoredNamespaces);
-  if (ignoredNS) {
+  if (carriesIgnoredNamespace(ignoredNamespaces, obj)) {
     return true;
   }
 

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { AdmissionRequest, Binding, Operation } from "./types";
-// import { ignoredNSObjectViolation, matchesRegex } from "./helpers";
 import {
   carriesIgnoredNamespace,
   misboundDeleteWithDeletionTimestamp,
@@ -20,15 +19,6 @@ import {
   unbindableNamespaces,
   uncarryableNamespace,
 } from "./adjudicators";
-
-export function shouldSkipRequestRegex(
-  binding: Binding,
-  req: AdmissionRequest,
-  capabilityNamespaces: string[],
-  ignoredNamespaces?: string[],
-): boolean {
-  return shouldSkipRequest(binding, req, capabilityNamespaces, ignoredNamespaces);
-}
 
 /**
  * shouldSkipRequest determines if a request should be skipped based on the binding filters.

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -2,14 +2,17 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { AdmissionRequest, Binding, Operation } from "./types";
-import { ignoredNSObjectViolation, matchesRegex } from "./helpers";
+// import { ignoredNSObjectViolation, matchesRegex } from "./helpers";
+import { ignoredNSObjectViolation } from "./helpers";
 import {
   misboundDeleteWithDeletionTimestamp,
   mismatchedDeletionTimestamp,
   mismatchedAnnotations,
   mismatchedLabels,
   mismatchedName,
+  mismatchedNameRegex,
   mismatchedNamespace,
+  mismatchedNamespaceRegex,
   mismatchedEvent,
   mismatchedGroup,
   mismatchedVersion,
@@ -24,34 +27,43 @@ export function shouldSkipRequestRegex(
   capabilityNamespaces: string[],
   ignoredNamespaces?: string[],
 ): boolean {
-  const { regexNamespaces, regexName } = binding.filters || {};
-  const result = shouldSkipRequest(binding, req, capabilityNamespaces);
-  const operation = req.operation.toUpperCase();
-  if (!result) {
-    if (regexNamespaces && regexNamespaces.length > 0) {
-      for (const regexNamespace of regexNamespaces) {
-        if (
-          !matchesRegex(
-            regexNamespace,
-            (operation === Operation.DELETE ? req.oldObject?.metadata?.namespace : req.object.metadata?.namespace) ||
-              "",
-          )
-        ) {
-          return true;
-        }
-      }
-    }
+  // const { regexName } = binding.filters || {};
+  // const operation = req.operation.toUpperCase();
 
-    if (
-      regexName &&
-      regexName !== "" &&
-      !matchesRegex(
-        regexName,
-        (operation === Operation.DELETE ? req.oldObject?.metadata?.name : req.object.metadata?.name) || "",
-      )
-    ) {
+  const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
+
+  const result = shouldSkipRequest(binding, req, capabilityNamespaces);
+  if (!result) {
+    if (mismatchedNamespaceRegex(binding, obj)) {
       return true;
     }
+    // if (regexNamespaces && regexNamespaces.length > 0) {
+    //   for (const regexNamespace of regexNamespaces) {
+    //     if (
+    //       !matchesRegex(
+    //         regexNamespace,
+    //         (operation === Operation.DELETE ? req.oldObject?.metadata?.namespace : req.object.metadata?.namespace) ||
+    //           "",
+    //       )
+    //     ) {
+    //       return true;
+    //     }
+    //   }
+    // }
+
+    if (mismatchedNameRegex(binding, obj)) {
+      return true;
+    }
+    // if (
+    //   regexName &&
+    //   regexName !== "" &&
+    //   !matchesRegex(
+    //     regexName,
+    //     (operation === Operation.DELETE ? req.oldObject?.metadata?.name : req.object.metadata?.name) || "",
+    //   )
+    // ) {
+    //   return true;
+    // }
   }
 
   // check ignored namespaces

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -28,25 +28,6 @@ export function shouldSkipRequestRegex(
   ignoredNamespaces?: string[],
 ): boolean {
   return shouldSkipRequest(binding, req, capabilityNamespaces, ignoredNamespaces);
-
-  // const result = shouldSkipRequest(binding, req, capabilityNamespaces, ignoredNamespaces);
-
-  // const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
-  // if (!result) {
-  //   if (mismatchedNamespaceRegex(binding, obj)) {
-  //     return true;
-  //   }
-
-  //   if (mismatchedNameRegex(binding, obj)) {
-  //     return true;
-  //   }
-  // }
-
-  // if (carriesIgnoredNamespace(ignoredNamespaces, obj)) {
-  //   return true;
-  // }
-
-  // return result;
 }
 
 /**

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -27,24 +27,26 @@ export function shouldSkipRequestRegex(
   capabilityNamespaces: string[],
   ignoredNamespaces?: string[],
 ): boolean {
-  const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
+  return shouldSkipRequest(binding, req, capabilityNamespaces, ignoredNamespaces);
 
-  const result = shouldSkipRequest(binding, req, capabilityNamespaces);
-  if (!result) {
-    if (mismatchedNamespaceRegex(binding, obj)) {
-      return true;
-    }
+  // const result = shouldSkipRequest(binding, req, capabilityNamespaces, ignoredNamespaces);
 
-    if (mismatchedNameRegex(binding, obj)) {
-      return true;
-    }
-  }
+  // const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
+  // if (!result) {
+  //   if (mismatchedNamespaceRegex(binding, obj)) {
+  //     return true;
+  //   }
 
-  if (carriesIgnoredNamespace(ignoredNamespaces, obj)) {
-    return true;
-  }
+  //   if (mismatchedNameRegex(binding, obj)) {
+  //     return true;
+  //   }
+  // }
 
-  return result;
+  // if (carriesIgnoredNamespace(ignoredNamespaces, obj)) {
+  //   return true;
+  // }
+
+  // return result;
 }
 
 /**
@@ -54,7 +56,12 @@ export function shouldSkipRequestRegex(
  * @param req the incoming request
  * @returns
  */
-export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capabilityNamespaces: string[]): boolean {
+export function shouldSkipRequest(
+  binding: Binding,
+  req: AdmissionRequest,
+  capabilityNamespaces: string[],
+  ignoredNamespaces?: string[],
+): boolean {
   const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
 
   // prettier-ignore
@@ -71,6 +78,9 @@ export function shouldSkipRequest(binding: Binding, req: AdmissionRequest, capab
     mismatchedNamespace(binding, obj) ? true :
     mismatchedLabels(binding, obj) ? true :
     mismatchedAnnotations(binding, obj) ? true :
+    mismatchedNamespaceRegex(binding, obj) ? true :
+    mismatchedNameRegex(binding, obj) ? true :
+    carriesIgnoredNamespace(ignoredNamespaces, obj) ? true :
 
     false
   );

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -8,7 +8,7 @@ import {
   createDirectoryIfNotExists,
   createRBACMap,
   checkDeploymentStatus,
-  filterNoMatchReasonRegex,
+  filterNoMatchReason,
   dedent,
   generateWatchNamespaceError,
   hasAnyOverlap,
@@ -1067,7 +1067,7 @@ describe("replaceString", () => {
   });
 });
 
-describe("filterMatcher", () => {
+describe("filterNoMatchReason", () => {
   test("returns regex namespace filter error for Pods whos namespace does not match the regex", () => {
     const binding = {
       kind: { kind: "Pod" },
@@ -1083,7 +1083,7 @@ describe("filterMatcher", () => {
     ];
     const capabilityNamespaces: string[] = [];
     objArray.map(object => {
-      const result = filterNoMatchReasonRegex(
+      const result = filterNoMatchReason(
         binding as unknown as Partial<Binding>,
         object as unknown as Partial<KubernetesObject>,
         capabilityNamespaces,
@@ -1109,7 +1109,7 @@ describe("filterMatcher", () => {
     ];
     const capabilityNamespaces: string[] = [];
     objArray.map(object => {
-      const result = filterNoMatchReasonRegex(
+      const result = filterNoMatchReason(
         binding as unknown as Partial<Binding>,
         object as unknown as Partial<KubernetesObject>,
         capabilityNamespaces,
@@ -1134,7 +1134,7 @@ describe("filterMatcher", () => {
     ];
     const capabilityNamespaces: string[] = [];
     objArray.map(object => {
-      const result = filterNoMatchReasonRegex(
+      const result = filterNoMatchReason(
         binding as unknown as Partial<Binding>,
         object as unknown as Partial<KubernetesObject>,
         capabilityNamespaces,
@@ -1161,7 +1161,7 @@ describe("filterMatcher", () => {
     ];
     const capabilityNamespaces: string[] = [];
     objArray.map(object => {
-      const result = filterNoMatchReasonRegex(
+      const result = filterNoMatchReason(
         binding as unknown as Partial<Binding>,
         object as unknown as Partial<KubernetesObject>,
         capabilityNamespaces,
@@ -1177,7 +1177,7 @@ describe("filterMatcher", () => {
     };
     const obj = {};
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1195,7 +1195,7 @@ describe("filterMatcher", () => {
       },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1210,7 +1210,7 @@ describe("filterMatcher", () => {
       metadata: { name: "pepr" },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1226,7 +1226,7 @@ describe("filterMatcher", () => {
       metadata: {},
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1244,7 +1244,7 @@ describe("filterMatcher", () => {
       },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1260,7 +1260,7 @@ describe("filterMatcher", () => {
       metadata: { labels: { anotherKey: "anotherValue" } },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1278,7 +1278,7 @@ describe("filterMatcher", () => {
       metadata: { annotations: { anotherKey: "anotherValue" } },
     };
     const capabilityNamespaces: string[] = [];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1313,7 +1313,7 @@ describe("filterMatcher", () => {
       metadata: { namespace: "ns2", name: "bleh" },
     };
     const capabilityNamespaces = ["ns1"];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as Binding,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1329,7 +1329,7 @@ describe("filterMatcher", () => {
     };
     const obj = {};
     const capabilityNamespaces = ["ns1", "ns2"];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1347,7 +1347,7 @@ describe("filterMatcher", () => {
       metadata: { namespace: "ns2" },
     };
     const capabilityNamespaces = ["ns1", "ns2"];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1364,7 +1364,7 @@ describe("filterMatcher", () => {
     };
     const capabilityNamespaces = ["ns3"];
     const ignoredNamespaces = ["ns3"];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,
@@ -1383,7 +1383,7 @@ describe("filterMatcher", () => {
       metadata: { namespace: "ns1", labels: { key: "value" }, annotations: { key: "value" } },
     };
     const capabilityNamespaces = ["ns1"];
-    const result = filterNoMatchReasonRegex(
+    const result = filterNoMatchReason(
       binding as unknown as Partial<Binding>,
       obj as unknown as Partial<KubernetesObject>,
       capabilityNamespaces,

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -9,7 +9,6 @@ import {
   createRBACMap,
   checkDeploymentStatus,
   filterNoMatchReasonRegex,
-  ignoredNSObjectViolation,
   dedent,
   generateWatchNamespaceError,
   hasAnyOverlap,
@@ -32,7 +31,6 @@ import { promises as fs } from "fs";
 import { SpiedFunction } from "jest-mock";
 import { K8s, GenericClass, KubernetesObject, kind } from "kubernetes-fluent-client";
 import { K8sInit } from "kubernetes-fluent-client/dist/fluent/types";
-import { Operation } from "./types";
 
 export const callback = () => undefined;
 
@@ -1359,12 +1357,12 @@ describe("filterMatcher", () => {
 
   test("return watch violation message when object is in an ignored namespace", () => {
     const binding = {
-      filters: { namespaces: ["ns1"], regexNamespaces: [] },
+      filters: { namespaces: ["ns3"] },
     };
     const obj = {
       metadata: { namespace: "ns3" },
     };
-    const capabilityNamespaces = ["ns1", "ns2"];
+    const capabilityNamespaces = ["ns3"];
     const ignoredNamespaces = ["ns3"];
     const result = filterNoMatchReasonRegex(
       binding as unknown as Partial<Binding>,
@@ -1484,84 +1482,5 @@ describe("matchesRegex", () => {
     const testString = "invalid-email.com";
     const result = matchesRegex(new RegExp(pattern).source, testString);
     expect(result).toBe(false);
-  });
-});
-
-describe("ignoredNSObjectViolation", () => {
-  test("should return false when ignoredNamespaces is empty and req has uid", () => {
-    const req = { uid: "12345" };
-    const result = ignoredNSObjectViolation(req, {}, []);
-    expect(result).toBe(false);
-  });
-
-  test("should return an empty string when ignoredNamespaces is empty and req has no uid", () => {
-    const result = ignoredNSObjectViolation({}, {});
-    expect(result).toBe("");
-  });
-
-  test("should return true when operation is DELETE and oldObject is in an ignored namespace", () => {
-    const req = {
-      uid: "12345",
-      operation: Operation.DELETE,
-      oldObject: { metadata: { namespace: "ignored-ns" } },
-    };
-    const ignoredNamespaces = ["ignored-ns"];
-    const result = ignoredNSObjectViolation(req, {}, ignoredNamespaces);
-    expect(result).toBe(true);
-  });
-
-  test("should return true when operation is not DELETE and object is in an ignored namespace", () => {
-    const req = {
-      uid: "12345",
-      operation: Operation.CREATE,
-      object: { metadata: { namespace: "ignored-ns" } },
-    };
-    const ignoredNamespaces = ["ignored-ns"];
-    const result = ignoredNSObjectViolation(req, {}, ignoredNamespaces);
-    expect(result).toBe(true);
-  });
-
-  test("should return watch violation message when object is in an ignored namespace", () => {
-    const obj = {
-      metadata: {
-        namespace: "ignored-ns",
-        name: "test-object",
-      },
-    };
-    const ignoredNamespaces = ["ignored-ns"];
-    const result = ignoredNSObjectViolation({}, obj, ignoredNamespaces);
-    expect(result).toBe("Ignoring Watch Callback: Object name test-object is in an ignored namespace ignored-ns.");
-  });
-
-  test("should return an empty string when object is not in an ignored namespace", () => {
-    const obj = {
-      metadata: {
-        namespace: "allowed-ns",
-        name: "test-object",
-      },
-    };
-    const ignoredNamespaces = ["ignored-ns"];
-    const result = ignoredNSObjectViolation({}, obj, ignoredNamespaces);
-    expect(result).toBe("");
-  });
-
-  test("should return false when no violations are found and req has uid", () => {
-    const req = {
-      uid: "12345",
-      operation: Operation.CREATE,
-      object: { metadata: { namespace: "allowed-ns" } },
-    };
-    const ignoredNamespaces = ["ignored-ns"];
-    const result = ignoredNSObjectViolation(req, {}, ignoredNamespaces);
-    expect(result).toBe(false);
-
-    const req2 = {
-      uid: "12345",
-      operation: Operation.CREATE,
-      oldObject: { metadata: { namespace: "allowed-ns" } },
-    };
-    const ignoredNamespaces2 = ["ignored-ns"];
-    const result2 = ignoredNSObjectViolation(req2, {}, ignoredNamespaces2);
-    expect(result2).toBe(false);
   });
 });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1321,7 +1321,7 @@ describe("filterMatcher", () => {
       capabilityNamespaces,
     );
     expect(result).toEqual(
-      `Ignoring Watch Callback: Object carries namespace 'ns2' but namespaces allowed by Capability are '["ns1"]'`,
+      `Ignoring Watch Callback: Object carries namespace 'ns2' but namespaces allowed by Capability are '["ns1"]'.`,
     );
   });
 
@@ -1337,7 +1337,7 @@ describe("filterMatcher", () => {
       capabilityNamespaces,
     );
     expect(result).toEqual(
-      `Ignoring Watch Callback: Binding defines namespaces ["ns3"] but namespaces allowed by Capability are '["ns1","ns2"]'`,
+      `Ignoring Watch Callback: Binding defines namespaces ["ns3"] but namespaces allowed by Capability are '["ns1","ns2"]'.`,
     );
   });
 
@@ -1355,6 +1355,26 @@ describe("filterMatcher", () => {
       capabilityNamespaces,
     );
     expect(result).toEqual(`Ignoring Watch Callback: Binding defines namespaces '["ns1"]' but Object carries 'ns2'.`);
+  });
+
+  test("return watch violation message when object is in an ignored namespace", () => {
+    const binding = {
+      filters: { namespaces: ["ns1"], regexNamespaces: [] },
+    };
+    const obj = {
+      metadata: { namespace: "ns3" },
+    };
+    const capabilityNamespaces = ["ns1", "ns2"];
+    const ignoredNamespaces = ["ns3"];
+    const result = filterNoMatchReasonRegex(
+      binding as unknown as Partial<Binding>,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+      ignoredNamespaces,
+    );
+    expect(result).toEqual(
+      `Ignoring Watch Callback: Object carries namespace 'ns3' but ignored namespaces include '["ns3"]'.`,
+    );
   });
 
   test("returns empty string when all checks pass", () => {

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1124,11 +1124,11 @@ describe("filterMatcher", () => {
   test("returns regex name filter error for Pods whos name does not match the regex", () => {
     const binding = {
       kind: { kind: "Pod" },
-      filters: { regexName: /^system/, namespaces: [] },
+      filters: { regexName: "^system", namespaces: [] },
     };
     const obj = { metadata: { name: "pepr-demo" } };
     const objArray = [
-      { ...obj, metadata: { name: "pepr-demo" } },
+      { ...obj },
       { ...obj, metadata: { name: "pepr-uds" } },
       { ...obj, metadata: { name: "pepr-core" } },
       { ...obj, metadata: { name: "uds-ns" } },
@@ -1142,7 +1142,7 @@ describe("filterMatcher", () => {
         capabilityNamespaces,
       );
       expect(result).toEqual(
-        `Ignoring Watch Callback: Object name ${object.metadata?.name} does not match regex ${binding.filters.regexName}.`,
+        `Ignoring Watch Callback: Binding defines name regex '^system' but Object carries '${object?.metadata?.name}'.`,
       );
     });
   });

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1073,11 +1073,11 @@ describe("filterMatcher", () => {
   test("returns regex namespace filter error for Pods whos namespace does not match the regex", () => {
     const binding = {
       kind: { kind: "Pod" },
-      filters: { regexNamespaces: [/(.*)-system/], namespaces: [] },
+      filters: { regexNamespaces: ["(.*)-system"], namespaces: [] },
     };
     const obj = { metadata: { namespace: "pepr-demo" } };
     const objArray = [
-      { ...obj, metadata: { namespace: "pepr-demo" } },
+      { ...obj },
       { ...obj, metadata: { namespace: "pepr-uds" } },
       { ...obj, metadata: { namespace: "pepr-core" } },
       { ...obj, metadata: { namespace: "uds-ns" } },
@@ -1091,7 +1091,7 @@ describe("filterMatcher", () => {
         capabilityNamespaces,
       );
       expect(result).toEqual(
-        `Ignoring Watch Callback: Object namespace ${object.metadata?.namespace} does not match regex ${binding.filters.regexNamespaces[0]}.`,
+        `Ignoring Watch Callback: Binding defines namespace regexes '["(.*)-system"]' but Object carries '${object?.metadata?.namespace}'.`,
       );
     });
   });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -14,6 +14,7 @@ import {
   definedAnnotations,
   definedLabels,
   definedName,
+  definedNameRegex,
   definedNamespaces,
   definedNamespaceRegexes,
   misboundNamespace,
@@ -25,6 +26,7 @@ import {
   mismatchedNamespaceRegex,
   unbindableNamespaces,
   uncarryableNamespace,
+  mismatchedNameRegex,
 } from "./adjudicators";
 
 export function ignoredNSObjectViolation(
@@ -110,7 +112,6 @@ export function filterNoMatchReasonRegex(
 ): string {
   const prefix = "Ignoring Watch Callback:";
 
-  const { regexName } = binding.filters || {};
   const result = filterNoMatchReason(binding, obj, capabilityNamespaces);
   if (result === "") {
     if (mismatchedNamespaceRegex(binding, obj)) {
@@ -121,8 +122,11 @@ export function filterNoMatchReasonRegex(
       );
     }
 
-    if (regexName && regexName !== "" && !matchesRegex(regexName, obj.metadata?.name || "")) {
-      return `Ignoring Watch Callback: Object name ${obj.metadata?.name} does not match regex ${regexName}.`;
+    if (mismatchedNameRegex(binding, obj)) {
+      return (
+        `${prefix} Binding defines name regex '${definedNameRegex(binding)}' ` +
+        `but Object carries '${carriedName(obj)}'.`
+      );
     }
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -68,15 +68,6 @@ type RBACMap = {
   };
 };
 
-export function filterNoMatchReasonRegex(
-  binding: Partial<Binding>,
-  obj: Partial<KubernetesObject>,
-  capabilityNamespaces: string[],
-  ignoredNamespaces?: string[],
-): string {
-  return filterNoMatchReason(binding, obj, capabilityNamespaces, ignoredNamespaces);
-}
-
 /**
  * Decide to run callback after the event comes back from API Server
  **/

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -11,6 +11,7 @@ import {
   carriedLabels,
   carriedName,
   carriedNamespace,
+  carriesIgnoredNamespace,
   definedAnnotations,
   definedLabels,
   definedName,
@@ -22,11 +23,11 @@ import {
   mismatchedDeletionTimestamp,
   mismatchedLabels,
   mismatchedName,
+  mismatchedNameRegex,
   mismatchedNamespace,
   mismatchedNamespaceRegex,
   unbindableNamespaces,
   uncarryableNamespace,
-  mismatchedNameRegex,
 } from "./adjudicators";
 
 export function ignoredNSObjectViolation(
@@ -130,9 +131,11 @@ export function filterNoMatchReasonRegex(
     }
   }
 
-  const ignoredNS = ignoredNSObjectViolation({}, obj, ignoredNamespaces);
-  if (ignoredNS !== "" && typeof ignoredNS === "string") {
-    return ignoredNS;
+  if (carriesIgnoredNamespace(ignoredNamespaces, obj)) {
+    return (
+      `${prefix} Object carries namespace '${carriedNamespace(obj)}' ` +
+      `but ignored namespaces include '${JSON.stringify(ignoredNamespaces)}'.`
+    );
   }
 
   return result;
@@ -174,13 +177,13 @@ export function filterNoMatchReason(
     uncarryableNamespace(capabilityNamespaces, obj) ?
       (
         `${prefix} Object carries namespace '${carriedNamespace(obj)}' ` +
-        `but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'`
+        `but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'.`
       ) :
 
     unbindableNamespaces(capabilityNamespaces, binding) ?
       (
         `${prefix} Binding defines namespaces ${JSON.stringify(definedNamespaces(binding))} ` +
-        `but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'`
+        `but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'.`
       ) :
 
     mismatchedNamespace(binding, obj) ?

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -6,7 +6,7 @@ import { kind } from "kubernetes-fluent-client";
 
 import { Capability } from "./capability";
 import { Errors } from "./errors";
-import { shouldSkipRequestRegex } from "./filter";
+import { shouldSkipRequest } from "./filter";
 import { MutateResponse } from "./k8s";
 import { AdmissionRequest } from "./types";
 import Log from "./logger";
@@ -50,7 +50,7 @@ export async function mutateProcessor(
       }
 
       // Continue to the next action without doing anything if this one should be skipped
-      if (shouldSkipRequestRegex(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
+      if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
         continue;
       }
 

--- a/src/lib/validate-processor.ts
+++ b/src/lib/validate-processor.ts
@@ -4,7 +4,7 @@
 import { kind } from "kubernetes-fluent-client";
 
 import { Capability } from "./capability";
-import { shouldSkipRequestRegex } from "./filter";
+import { shouldSkipRequest } from "./filter";
 import { ValidateResponse } from "./k8s";
 import { AdmissionRequest } from "./types";
 import Log from "./logger";
@@ -44,7 +44,7 @@ export async function validateProcessor(
       };
 
       // Continue to the next action without doing anything if this one should be skipped
-      if (shouldSkipRequestRegex(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
+      if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
         continue;
       }
 

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -3,7 +3,7 @@
 import { K8s, KubernetesObject, WatchCfg, WatchEvent } from "kubernetes-fluent-client";
 import { WatchPhase } from "kubernetes-fluent-client/dist/fluent/types";
 import { Capability } from "./capability";
-import { filterNoMatchReasonRegex } from "./helpers";
+import { filterNoMatchReason } from "./helpers";
 import { removeFinalizer } from "./finalizer";
 import Log from "./logger";
 import { Queue } from "./queue";
@@ -99,7 +99,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[], igno
     if (phaseMatch.includes(phase)) {
       try {
         // Then, check if the object matches the filter
-        const filterMatch = filterNoMatchReasonRegex(binding, obj, capabilityNamespaces, ignoredNamespaces);
+        const filterMatch = filterNoMatchReason(binding, obj, capabilityNamespaces, ignoredNamespaces);
         if (filterMatch === "") {
           if (binding.isFinalize) {
             if (!obj.metadata?.deletionTimestamp) {


### PR DESCRIPTION
## Description

PR to refactor the filterNoMatchReasonRegex / shouldSkipRequestRegex functions & roll their contents back into the filterNoMatchReason / shouldSkipRequest functions.

## Related Issue
Relates to #1179

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc) - refactor

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
