### PR TITLE
chore: set default branch for new module to main

### DIFF
--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -81,7 +81,7 @@ export default function (program: RootCmd) {
             });
 
             // setup git
-            execSync("git init", {
+            execSync("git init --initial-branch=test", {
               stdio: "inherit",
             });
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -81,7 +81,7 @@ export default function (program: RootCmd) {
             });
 
             // setup git
-            execSync("git init --initial-branch=test", {
+            execSync("git init --initial-branch=main", {
               stdio: "inherit",
             });
 


### PR DESCRIPTION
## Description
When a developer runs `pepr init` a Pepr module is created with the default branch of `master`, potentially resulting in messages about the default branch name if those messages aren't suppressed on the user's computer.

By setting the default branch for new Pepr modules to `main` the warning messages should not appear.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1142
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
