### PR TITLE
chore: sync work - add types to cli with prompts and init options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@types/json-pointer": "^1.0.34",
         "@types/node": "22.x.x",
         "@types/node-forge": "1.3.11",
-        "@types/prompts": "2.4.9",
         "@types/uuid": "10.0.0",
         "fast-check": "^3.19.0",
         "husky": "^9.1.6",
@@ -45,6 +44,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
+        "@types/prompts": "2.4.9",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "commander": "12.1.0",
@@ -2574,7 +2574,7 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
       "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "kleur": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/json-pointer": "^1.0.34",
     "@types/node": "22.x.x",
     "@types/node-forge": "1.3.11",
-    "@types/prompts": "2.4.9",
     "@types/uuid": "10.0.0",
     "fast-check": "^3.19.0",
     "jest": "29.7.0",
@@ -75,6 +74,7 @@
     "eslint": "8.57.0",
     "node-forge": "1.3.1",
     "prettier": "3.3.3",
+    "@types/prompts": "2.4.9",
     "prompts": "2.4.2",
     "typescript": "5.3.3",
     "uuid": "10.0.0"

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -13,7 +13,7 @@ import peprSnippetsJSON from "../../templates/pepr.code-snippets.json";
 import settingsJSON from "../../templates/settings.json";
 import tsConfigJSON from "../../templates/tsconfig.module.json";
 import { sanitizeName } from "./utils";
-import { InitOptions } from "../../lib/types";
+import { InitOptions } from "../types";
 
 export const { dependencies, devDependencies, peerDependencies, scripts, version } = packageJSON;
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,3 @@
+import { Answers } from "prompts";
+
+export type InitOptions = Answers<"name" | "description" | "errorBehavior">;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,6 @@ import { WatchPhase } from "kubernetes-fluent-client/dist/fluent/types";
 
 import { PeprMutateRequest } from "./mutate-request";
 import { PeprValidateRequest } from "./validate-request";
-import { Answers } from "prompts";
 
 import { Logger } from "pino";
 
@@ -284,8 +283,6 @@ export type FinalizeActionChain<T extends GenericClass> = {
    */
   Finalize: (action: FinalizeAction<T, InstanceType<T>>) => void;
 };
-
-export type InitOptions = Answers<"name" | "description" | "errorBehavior">;
 
 /**
  * A Kubernetes admission request to be processed by a capability.


### PR DESCRIPTION
## Description

We need to add types/prompts to the peerDependencies

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
