### PR TITLE
refactor: shouldSkipRequest should give reason for skipping request instead of boolean

### DIFF
--- a/src/fixtures/data/create-pod.json
+++ b/src/fixtures/data/create-pod.json
@@ -39,7 +39,8 @@
       "labels": {
         "app.kubernetes.io/name": "cool-name-podinfo",
         "pod-template-hash": "66bbff7cf4",
-        "zarf-agent": "patched"
+        "zarf-agent": "patched",
+        "test-op": "create"
       },
       "name": "cool-name-podinfo-66bbff7cf4-fwhl2",
       "namespace": "helm-releasename",

--- a/src/fixtures/data/delete-pod.json
+++ b/src/fixtures/data/delete-pod.json
@@ -36,7 +36,8 @@
       "labels": {
         "app.kubernetes.io/name": "cool-name-podinfo",
         "pod-template-hash": "66bbff7cf4",
-        "zarf-agent": "patched"
+        "zarf-agent": "patched",
+        "test-op": "delete"
       },
       "name": "cool-name-podinfo-66bbff7cf4-fwhl2",
       "namespace": "helm-releasename",

--- a/src/lib/adjudicators.test.ts
+++ b/src/lib/adjudicators.test.ts
@@ -550,11 +550,13 @@ describe("metasMismatch", () => {
     [{ anno: "tate" }, {}, true],
     [{ anno: "tate" }, { anno: "" }, true],
     [{ anno: "tate" }, { anno: "tate" }, false],
+    [{ anno: "tate" }, { anno: "tato" }, true],
 
     [{ an: "no", ta: "te" }, { an: "" }, true],
     [{ an: "no", ta: "te" }, { an: "no" }, true],
     [{ an: "no", ta: "te" }, { an: "no", ta: "" }, true],
     [{ an: "no", ta: "te" }, { an: "no", ta: "te" }, false],
+    [{ an: "no", ta: "te" }, { an: "no", ta: "to" }, true],
   ])("given left %j and right %j, returns %s", (bnd, obj, expected) => {
     const result = sut.metasMismatch(bnd, obj);
 
@@ -575,10 +577,12 @@ describe("mismatchedAnnotations", () => {
     [{ filters: { annotations: { anno: "tate" } } }, {}, true],
     [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "" } } }, true],
     [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "tate" } } }, false],
+    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "tato" } } }, true],
 
     [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "" } } }, true],
     [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no" } } }, true],
     [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no", ta: "" } } }, true],
+    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no", ta: "to" } } }, true],
     [
       { filters: { annotations: { an: "no", ta: "te" } } },
       { metadata: { annotations: { an: "no", ta: "te" } } },

--- a/src/lib/adjudicators.ts
+++ b/src/lib/adjudicators.ts
@@ -162,12 +162,14 @@ export const metasMismatch = pipe(
         const keyMissing = !Object.hasOwn(result.carried, key);
         const noValue = !val;
         const valMissing = !result.carried[key];
+        const valDiffers = result.carried[key] !== result.defined[key];
 
         // prettier-ignore
         return (
           keyMissing ? { [key]: val } :
           noValue ? {} :
           valMissing ? { [key]: val } :
+          valDiffers ? { [key]: val } :
           {}
         )
       })

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -4,6 +4,24 @@
 import { AdmissionRequest, Binding, Operation } from "./types";
 import {
   carriesIgnoredNamespace,
+  carriedName,
+  definedEvent,
+  declaredOperation,
+  definedName,
+  definedGroup,
+  declaredGroup,
+  definedVersion,
+  declaredVersion,
+  definedKind,
+  declaredKind,
+  definedNamespaces,
+  carriedNamespace,
+  definedLabels,
+  carriedLabels,
+  definedAnnotations,
+  carriedAnnotations,
+  definedNamespaceRegexes,
+  definedNameRegex,
   misboundDeleteWithDeletionTimestamp,
   mismatchedDeletionTimestamp,
   mismatchedAnnotations,
@@ -32,27 +50,94 @@ export function shouldSkipRequest(
   req: AdmissionRequest,
   capabilityNamespaces: string[],
   ignoredNamespaces?: string[],
-): boolean {
+): string {
+  const prefix = "Ignoring Admission Callback:";
   const obj = req.operation === Operation.DELETE ? req.oldObject : req.object;
 
   // prettier-ignore
   return (
-    misboundDeleteWithDeletionTimestamp(binding) ? true :
-    mismatchedDeletionTimestamp(binding, obj) ? true :
-    mismatchedEvent(binding, req) ? true :
-    mismatchedName(binding, obj) ? true :
-    mismatchedGroup(binding, req) ? true :
-    mismatchedVersion(binding, req) ? true :
-    mismatchedKind(binding, req) ? true :
-    unbindableNamespaces(capabilityNamespaces, binding) ? true :
-    uncarryableNamespace(capabilityNamespaces, obj) ? true :
-    mismatchedNamespace(binding, obj) ? true :
-    mismatchedLabels(binding, obj) ? true :
-    mismatchedAnnotations(binding, obj) ? true :
-    mismatchedNamespaceRegex(binding, obj) ? true :
-    mismatchedNameRegex(binding, obj) ? true :
-    carriesIgnoredNamespace(ignoredNamespaces, obj) ? true :
+    misboundDeleteWithDeletionTimestamp(binding) ? 
+      `${prefix} Cannot use deletionTimestamp filter on a DELETE operation.` :
 
-    false
+    mismatchedDeletionTimestamp(binding, obj) ?
+      `${prefix} Binding defines deletionTimestamp but Object does not carry it.` :
+
+    mismatchedEvent(binding, req) ?
+      (
+        `${prefix} Binding defines event '${definedEvent(binding)}' but ` +
+        `Request declares '${declaredOperation(req)}'.`
+      ) :
+
+    mismatchedName(binding, obj) ?
+      `${prefix} Binding defines name '${definedName(binding)}' but Object carries '${carriedName(obj)}'.` :
+
+    mismatchedGroup(binding, req) ?
+      (
+        `${prefix} Binding defines group '${definedGroup(binding)}' but ` +
+        `Request declares '${declaredGroup(req)}'.`
+      ) :
+
+    mismatchedVersion(binding, req) ?
+      (
+        `${prefix} Binding defines version '${definedVersion(binding)}' but ` +
+        `Request declares '${declaredVersion(req)}'.`
+      ) :
+
+    mismatchedKind(binding, req) ?
+      (
+        `${prefix} Binding defines kind '${definedKind(binding)}' but ` +
+        `Request declares '${declaredKind(req)}'.`
+      ) :
+
+    unbindableNamespaces(capabilityNamespaces, binding) ?
+      (
+        `${prefix} Binding defines namespaces ${JSON.stringify(definedNamespaces(binding))} ` +
+        `but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'.`
+      ) :
+
+    uncarryableNamespace(capabilityNamespaces, obj) ?
+      (
+        `${prefix} Object carries namespace '${carriedNamespace(obj)}' ` +
+        `but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'.`
+      ) :
+
+    mismatchedNamespace(binding, obj) ?
+      (
+        `${prefix} Binding defines namespaces '${JSON.stringify(definedNamespaces(binding))}' ` +
+        `but Object carries '${carriedNamespace(obj)}'.`
+      ) :
+
+    mismatchedLabels(binding, obj) ?
+      (
+        `${prefix} Binding defines labels '${JSON.stringify(definedLabels(binding))}' ` +
+        `but Object carries '${JSON.stringify(carriedLabels(obj))}'.`
+      ) :
+
+    mismatchedAnnotations(binding, obj) ?
+      (
+        `${prefix} Binding defines annotations '${JSON.stringify(definedAnnotations(binding))}' ` +
+        `but Object carries '${JSON.stringify(carriedAnnotations(obj))}'.`
+      ) :
+
+    mismatchedNamespaceRegex(binding, obj) ?
+      (
+        `${prefix} Binding defines namespace regexes ` +
+        `'${JSON.stringify(definedNamespaceRegexes(binding))}' ` +
+        `but Object carries '${carriedNamespace(obj)}'.`
+      ) :
+
+    mismatchedNameRegex(binding, obj) ?
+      (
+        `${prefix} Binding defines name regex '${definedNameRegex(binding)}' ` +
+        `but Object carries '${carriedName(obj)}'.`
+      ) :
+
+    carriesIgnoredNamespace(ignoredNamespaces, obj) ?
+      (
+        `${prefix} Object carries namespace '${carriedNamespace(obj)}' ` +
+        `but ignored namespaces include '${JSON.stringify(ignoredNamespaces)}'.`
+      ) :
+
+    ""
   );
 }

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -49,8 +49,13 @@ export async function mutateProcessor(
         continue;
       }
 
+      // if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
+      //   continue;
+      // }
       // Continue to the next action without doing anything if this one should be skipped
-      if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
+      const shouldSkip = shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces);
+      if (shouldSkip === "") {
+        Log.debug(shouldSkip);
         continue;
       }
 

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -49,12 +49,9 @@ export async function mutateProcessor(
         continue;
       }
 
-      // if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
-      //   continue;
-      // }
       // Continue to the next action without doing anything if this one should be skipped
       const shouldSkip = shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces);
-      if (shouldSkip === "") {
+      if (shouldSkip !== "") {
         Log.debug(shouldSkip);
         continue;
       }

--- a/src/lib/validate-processor.ts
+++ b/src/lib/validate-processor.ts
@@ -43,12 +43,9 @@ export async function validateProcessor(
         allowed: true, // Assume it's allowed until a validation check fails
       };
 
-      // if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
-      //   continue;
-      // }
       // Continue to the next action without doing anything if this one should be skipped
       const shouldSkip = shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces);
-      if (shouldSkip === "") {
+      if (shouldSkip !== "") {
         Log.debug(shouldSkip);
         continue;
       }

--- a/src/lib/validate-processor.ts
+++ b/src/lib/validate-processor.ts
@@ -43,8 +43,13 @@ export async function validateProcessor(
         allowed: true, // Assume it's allowed until a validation check fails
       };
 
+      // if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
+      //   continue;
+      // }
       // Continue to the next action without doing anything if this one should be skipped
-      if (shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces)) {
+      const shouldSkip = shouldSkipRequest(action, req, namespaces, config?.alwaysIgnore?.namespaces);
+      if (shouldSkip === "") {
+        Log.debug(shouldSkip);
         continue;
       }
 


### PR DESCRIPTION
## Description

PR to make shouldSkipRequest function more like filterNoMatchReason.

Relates to #1186 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
