### PR TITLE
Revert "chore: remove deprecated types from k8s.ts" - slated for v0.38.0

### DIFF
--- a/src/fixtures/loader.ts
+++ b/src/fixtures/loader.ts
@@ -1,6 +1,6 @@
 import { kind } from "kubernetes-fluent-client";
 
-import { AdmissionRequest } from "../lib/types";
+import { AdmissionRequest } from "../lib/k8s";
 import createPod from "./data/create-pod.json";
 import deletePod from "./data/delete-pod.json";
 

--- a/src/lib/capability.test.ts
+++ b/src/lib/capability.test.ts
@@ -6,7 +6,7 @@ import { V1Pod } from "@kubernetes/client-node";
 import { expect, describe, jest, beforeEach, it } from "@jest/globals";
 import { PeprMutateRequest } from "./mutate-request";
 import { PeprValidateRequest } from "./validate-request";
-import { Operation, AdmissionRequest } from "./types";
+import { Operation, AdmissionRequest } from "./k8s";
 import { WatchPhase } from "kubernetes-fluent-client/dist/fluent/types";
 import { Event } from "./types";
 import { GenericClass } from "kubernetes-fluent-client";

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -6,14 +6,14 @@ import fs from "fs";
 import https from "https";
 
 import { Capability } from "../capability";
-import { MutateResponse, ValidateResponse } from "../k8s";
+import { MutateResponse, AdmissionRequest, ValidateResponse } from "../k8s";
 import Log from "../logger";
 import { metricsCollector, MetricsCollector } from "../metrics";
 import { ModuleConfig, isWatchMode } from "../module";
 import { mutateProcessor } from "../mutate-processor";
 import { validateProcessor } from "../validate-processor";
 import { PeprControllerStore } from "./store";
-import { ResponseItem, AdmissionRequest } from "../types";
+import { ResponseItem } from "../types";
 
 if (!process.env.PEPR_NODE_WARNINGS) {
   process.removeAllListeners("warning");

--- a/src/lib/k8s.ts
+++ b/src/lib/k8s.ts
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { GenericKind, RegisterKind } from "kubernetes-fluent-client";
+import { GenericKind, GroupVersionKind, KubernetesObject, RegisterKind } from "kubernetes-fluent-client";
+
+// DEPRECATED: Use Operation in types.ts instead
+export enum Operation {
+  CREATE = "CREATE",
+  UPDATE = "UPDATE",
+  DELETE = "DELETE",
+  CONNECT = "CONNECT",
+}
 
 /**
  * PeprStore for internal use by Pepr. This is used to store arbitrary data in the cluster.
@@ -19,6 +27,99 @@ export const peprStoreGVK = {
 };
 
 RegisterKind(PeprStore, peprStoreGVK);
+
+// DEPRECATED: Use Operation in types.ts instead
+/**
+ * GroupVersionResource unambiguously identifies a resource. It doesn't anonymously include GroupVersion
+ * to avoid automatic coercion. It doesn't use a GroupVersion to avoid custom marshalling
+ */
+export interface GroupVersionResource {
+  readonly group: string;
+  readonly version: string;
+  readonly resource: string;
+}
+
+// DEPRECATED: Use Operation in types.ts instead
+
+/**
+ * A Kubernetes admission request to be processed by a capability.
+ */
+export interface AdmissionRequest<T = KubernetesObject> {
+  /** UID is an identifier for the individual request/response. */
+  readonly uid: string;
+
+  /** Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale) */
+  readonly kind: GroupVersionKind;
+
+  /** Resource is the fully-qualified resource being requested (for example, v1.pods) */
+  readonly resource: GroupVersionResource;
+
+  /** SubResource is the sub-resource being requested, if any (for example, "status" or "scale") */
+  readonly subResource?: string;
+
+  /** RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale). */
+  readonly requestKind?: GroupVersionKind;
+
+  /** RequestResource is the fully-qualified resource of the original API request (for example, v1.pods). */
+  readonly requestResource?: GroupVersionResource;
+
+  /** RequestSubResource is the sub-resource of the original API request, if any (for example, "status" or "scale"). */
+  readonly requestSubResource?: string;
+
+  /**
+   * Name is the name of the object as presented in the request. On a CREATE operation, the client may omit name and
+   * rely on the server to generate the name. If that is the case, this method will return the empty string.
+   */
+  readonly name: string;
+
+  /** Namespace is the namespace associated with the request (if any). */
+  readonly namespace?: string;
+
+  /**
+   * Operation is the operation being performed. This may be different than the operation
+   * requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+   */
+  readonly operation: Operation;
+
+  /** UserInfo is information about the requesting user */
+  readonly userInfo: {
+    /** The name that uniquely identifies this user among all active users. */
+    username?: string;
+
+    /**
+     * A unique value that identifies this user across time. If this user is deleted
+     * and another user by the same name is added, they will have different UIDs.
+     */
+    uid?: string;
+
+    /** The names of groups this user is a part of. */
+    groups?: string[];
+
+    /** Any additional information provided by the authenticator. */
+    extra?: {
+      [key: string]: string[];
+    };
+  };
+
+  /** Object is the object from the incoming request prior to default values being applied */
+  readonly object: T;
+
+  /** OldObject is the existing object. Only populated for UPDATE or DELETE requests. */
+  readonly oldObject?: T;
+
+  /** DryRun indicates that modifications will definitely not be persisted for this request. Defaults to false. */
+  readonly dryRun?: boolean;
+
+  /**
+   * Options contains the options for the operation being performed.
+   * e.g. `meta.k8s.io/v1.DeleteOptions` or `meta.k8s.io/v1.CreateOptions`. This may be
+   * different than the options the caller provided. e.g. for a patch request the performed
+   * Operation might be a CREATE, in which case the Options will a
+   * `meta.k8s.io/v1.CreateOptions` even though the caller provided `meta.k8s.io/v1.PatchOptions`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly options?: any;
+}
 
 export interface MutateResponse {
   /** UID is an identifier for the individual request/response. This must be copied over from the corresponding AdmissionRequest. */


### PR DESCRIPTION
Reverts defenseunicorns/pepr#1194

We need to do a patch today, PR is necessary before `v0.38.0` but we do not want to create any potential breaking changes due to deprecations before