### PR TITLE
chore(lint): adopt additional code quality rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "complexity": ["warn", { "max": 5 }],
     "max-depth": ["warn", { "max": 3 }],
     "max-params": ["warn", { "max": 4 }],
+    "max-nested-callbacks": ["warn", { "max": 4 }],
     "class-methods-use-this": "warn",
     "consistent-this": "warn",
     "no-invalid-this": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,15 +10,16 @@
     "ecmaVersion": 2022
   },
   "rules": {
-    "complexity": ["off", { "max": 5 }],
-    "max-depth": ["off", { "max": 3 }],
-    "max-params": ["off", { "max": 4 }],
-    "max-nested-callbacks": ["off", { "max": 4 }],
-    "max-statements": ["warn", { "max": 20 }, { "ignoreTopLevelFunctions": true }],
+    "@typescript-eslint/no-floating-promises": "warn",
     "class-methods-use-this": "warn",
+    "complexity": ["warn", { "max": 10 }],
     "consistent-this": "warn",
-    "no-invalid-this": "warn",
-    "@typescript-eslint/no-floating-promises": "warn"
+    "eqeqeq": "error",
+    "max-depth": ["warn", { "max": 3 }],
+    "max-nested-callbacks": ["warn", { "max": 4 }],
+    "max-params": ["warn", { "max": 4 }],
+    "max-statements": ["warn", { "max": 20 }, { "ignoreTopLevelFunctions": true }],
+    "no-invalid-this": "warn"
   },
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   },
   "rules": {
     "complexity": ["warn", { "max": 5 }],
+    "max-depth": ["warn", { "max": 3 }],
     "class-methods-use-this": "warn",
     "consistent-this": "warn",
     "no-invalid-this": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,14 +10,15 @@
     "ecmaVersion": 2022
   },
   "rules": {
-    "complexity": ["warn", { "max": 5 }],
-    "max-depth": ["warn", { "max": 3 }],
-    "max-params": ["warn", { "max": 4 }],
-    "max-nested-callbacks": ["warn", { "max": 4 }],
+    "complexity": ["off", { "max": 5 }],
+    "max-depth": ["off", { "max": 3 }],
+    "max-params": ["off", { "max": 4 }],
+    "max-nested-callbacks": ["off", { "max": 4 }],
+    "max-statements": ["warn", { "max": 20 }, { "ignoreTopLevelFunctions": true }],
     "class-methods-use-this": "warn",
     "consistent-this": "warn",
     "no-invalid-this": "warn",
-    "@typescript-eslint/no-floating-promises": ["warn"]
+    "@typescript-eslint/no-floating-promises": "warn"
   },
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "ecmaVersion": 2022
   },
   "rules": {
+    "complexity": ["warn", { "max": 5 }],
     "class-methods-use-this": "warn",
     "consistent-this": "warn",
     "no-invalid-this": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   "rules": {
     "complexity": ["warn", { "max": 5 }],
     "max-depth": ["warn", { "max": 3 }],
+    "max-params": ["warn", { "max": 4 }],
     "class-methods-use-this": "warn",
     "consistent-this": "warn",
     "no-invalid-this": "warn",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npx lint-staged --verbose

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -138,7 +138,7 @@ export default function (program: RootCmd) {
       );
 
       // If registry is set to Iron Bank, use Iron Bank image
-      if (opts?.registry == "Iron Bank") {
+      if (opts?.registry === "Iron Bank") {
         console.info(
           `\n\tThis command assumes the latest release. Pepr's Iron Bank image release cycle is dictated by renovate and is typically released a few days after the GitHub release.\n\tAs an alternative you may consider custom --custom-image to target a specific image and version.`,
         );

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -34,7 +34,7 @@ export async function mutateProcessor(
   let skipDecode: string[] = [];
 
   // If the resource is a secret, decode the data
-  const isSecret = req.kind.version == "v1" && req.kind.kind == "Secret";
+  const isSecret = req.kind.version === "v1" && req.kind.kind === "Secret";
   if (isSecret) {
     skipDecode = convertFromBase64Map(wrapped.Raw as unknown as kind.Secret);
   }
@@ -62,7 +62,7 @@ export async function mutateProcessor(
       // this will allow tracking of failed mutations that were permitted to continue
       const updateStatus = (status: string) => {
         // Only update the status if the request is a CREATE or UPDATE (we don't use CONNECT)
-        if (req.operation == "DELETE") {
+        if (req.operation === "DELETE") {
           return;
         }
 
@@ -128,7 +128,7 @@ export async function mutateProcessor(
   }
 
   // delete operations can't be mutate, just return before the transformation
-  if (req.operation == "DELETE") {
+  if (req.operation === "DELETE") {
     return response;
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,7 +30,7 @@ export function convertFromBase64Map(obj: { data?: Record<string, string> }) {
 
   obj.data = obj.data ?? {};
   for (const key in obj.data) {
-    if (obj.data[key] == undefined) {
+    if (obj.data[key] === undefined) {
       obj.data[key] = "";
     } else {
       const decoded = base64Decode(obj.data[key]);

--- a/src/lib/validate-processor.ts
+++ b/src/lib/validate-processor.ts
@@ -22,7 +22,7 @@ export async function validateProcessor(
   const response: ValidateResponse[] = [];
 
   // If the resource is a secret, decode the data
-  const isSecret = req.kind.version == "v1" && req.kind.kind == "Secret";
+  const isSecret = req.kind.version === "v1" && req.kind.kind === "Secret";
   if (isSecret) {
     convertFromBase64Map(wrapped.Raw as unknown as kind.Secret);
   }


### PR DESCRIPTION
## Description

This PR sets several `.eslintrc` rules to `warn` with loose thresholds to get the team used to a new set of coding standards aimed at improving overall code quality. Eventually, we should set `warn` to `error` and use tighter tolerances by decreasing the `max` field for applicable rules.

## Related Issue

Fixes #1206

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging
- [X] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [X] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
