### PR TITLE
chore: add watch logs to soak test to determine reasons for failure

### DIFF
--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -184,12 +184,14 @@ jobs:
           }
           touch logs/auditor-log.txt
           touch logs/informer-log.txt
+          touch logs/watch-logs.txt
 
           update_pod_map
 
           collect_metrics() {
             kubectl exec metrics-collector -n watch-auditor -- curl watch-auditor:8080/metrics | grep watch_controller_failures_total > logs/auditor-log.txt
             kubectl exec metrics-collector -n watch-auditor -- curl -k https://pepr-soak-ci-watcher.pepr-system.svc.cluster.local/metrics | egrep -E "pepr_cache_miss|pepr_resync_failure_count" > logs/informer-log.txt
+            kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system > logs/watch-logs.txt
           }
 
           # Start collecting metrics every 5 minutes and checking pod counts every 30 minutes
@@ -208,6 +210,7 @@ jobs:
                 echo "$pod: ${pod_map[$pod]}"
                 if [ "${pod_map[$pod]}" -gt 1 ]; then
                   echo "Test failed: Pod $pod has count ${pod_map[$pod]}"
+                  kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system
                   exit 1
                 fi
               done

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -26,9 +26,6 @@ jest.mock("./metrics", () => ({
     incRetryCount: jest.fn(),
   },
 }));
-it("something", () => {
-  expect(1).toBe(1);
-});
 describe("WatchProcessor", () => {
   const mockStart = jest.fn();
   const mockK8s = jest.mocked(K8s);

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -26,7 +26,9 @@ jest.mock("./metrics", () => ({
     incRetryCount: jest.fn(),
   },
 }));
-
+it("something", () => {
+  expect(1).toBe(1);
+});
 describe("WatchProcessor", () => {
   const mockStart = jest.fn();
   const mockK8s = jest.mocked(K8s);

--- a/src/lib/watch-processor.test.ts
+++ b/src/lib/watch-processor.test.ts
@@ -26,6 +26,7 @@ jest.mock("./metrics", () => ({
     incRetryCount: jest.fn(),
   },
 }));
+
 describe("WatchProcessor", () => {
   const mockStart = jest.fn();
   const mockK8s = jest.mocked(K8s);


### PR DESCRIPTION
## Description

Our soak test has a blind spot as to what goes wrong in a failure scenario. Adding logs should help us determine the reason. 


## Related Issue

Fixes #1213 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
