### PR TITLE
chore: choose soak branch

### DIFF
--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -3,6 +3,11 @@ name: Soak Test
 permissions: read-all
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Soak test branch'
+        required: true
+        default: 'main'
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
 


### PR DESCRIPTION
## Description

Allows us to run one off soak tests from a particular branch when we need more granular information 

## Related Issue

Fixes #1231 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
