### PR TITLE
chore: kfc release-candidate for http2 watch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "express": "4.21.0",
         "fast-json-patch": "3.1.1",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "3.0.4",
+        "kubernetes-fluent-client": "4.0.0-rc-http2-watch",
         "pino": "9.4.0",
         "pino-pretty": "11.2.2",
         "prom-client": "15.1.3",
@@ -7011,9 +7011,10 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.0.4.tgz",
-      "integrity": "sha512-mkLpT2Wjm8zUO3fgIy5d+UqFWoe4DG/soJA5wwrCTrsis+JHBnuLfTtI8bU/y2ie4EOfW0uSs8c0oXmveMImZQ==",
+      "version": "4.0.0-rc-http2-watch",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-4.0.0-rc-http2-watch.tgz",
+      "integrity": "sha512-Nyvc6XFThLPiY0tzgFxrYQ8mqNvZyST9BfMY4I6LAkAaucCScsqmk5niFjgZnBYsENeGGqYy2mNzMO8mr0j5BQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.0.0-rc6",
         "byline": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express": "4.21.0",
     "fast-json-patch": "3.1.1",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "3.0.4",
+    "kubernetes-fluent-client": "4.0.0-rc-http2-watch",
     "pino": "9.4.0",
     "pino-pretty": "11.2.2",
     "prom-client": "15.1.3",

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -49,6 +49,7 @@ export function getOrCreateQueue(obj: KubernetesObject) {
 
 // Watch configuration
 const watchCfg: WatchCfg = {
+  useHTTP2: process.env.PEPR_HTTP2_WATCH === "true",
   resyncFailureMax: process.env.PEPR_RESYNC_FAILURE_MAX ? parseInt(process.env.PEPR_RESYNC_FAILURE_MAX, 10) : 5,
   resyncDelaySec: process.env.PEPR_RESYNC_DELAY_SECONDS ? parseInt(process.env.PEPR_RESYNC_DELAY_SECONDS, 10) : 5,
   lastSeenLimitSeconds: process.env.PEPR_LAST_SEEN_LIMIT_SECONDS


### PR DESCRIPTION
## Description

This is an RC for testing in UDS Core staging env. It adds the KFC dependency update and updates the `WatchCfg`


## Related Issue

Fixes #1229 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
