### PR TITLE
test: http2-enable watcher and iso format logs in soak test

### DIFF
--- a/hack/soak.ci.yaml
+++ b/hack/soak.ci.yaml
@@ -314,10 +314,14 @@ spec:
               value: '60'
             - name: PEPR_WATCH_MODE
               value: 'true'
+            - name: PEPR_HTTP2_WATCH
+              value: 'true'
             - name: PEPR_PRETTY_LOG
               value: 'false'
             - name: LOG_LEVEL
               value: debug
+            - name: PINO_TIME_STAMP
+              value: iso
       volumes:
         - name: tls-certs
           secret:


### PR DESCRIPTION
## Description

Configures soaked watch controller to use `http2` watch mode.

Enables "ISO"-style logging to make comparison of cluster logs & watcher logs simpler.

## Related Issue
Relates to #1276 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
