### PR TITLE
chore: get pods each reporting interval

### DIFF
--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -179,6 +179,7 @@ jobs:
 
               kubectl get pods -n pepr-demo 
               kubectl top po -n pepr-system
+              kubectl get po -n pepr-system
               
               # Verify that no pod's count exceeds 1
               for pod in "${!pod_map[@]}"; do


### PR DESCRIPTION
## Description

The memory on the http2 watcher is running very high, we need to get the ages of the pods in pepr system so we know how frequently they are restarting during the soak test. 

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1278 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
