### PR TITLE
test: http2-enable watcher in smoke test

### DIFF
--- a/.github/workflows/uds-http2-watcher.js
+++ b/.github/workflows/uds-http2-watcher.js
@@ -1,0 +1,36 @@
+const { resolve } = require("node:path");
+const { access, copyFile, readFile, writeFile } = require("node:fs/promises");
+
+async function run(args) {
+  // args[0] = <path to node bin>
+  // args[1] = <path to this script>
+  // args[2] = <path to package.json>
+
+  const pathArg = args[2];
+  if (!pathArg) {
+    throw "arg error: must pass path to package.json";
+  }
+
+  if (!pathArg.endsWith("package.json")) {
+    throw `arg error: path (${pathArg}) must end in 'package.json'`;
+  }
+
+  let path = resolve(pathArg);
+  access(path).catch(e => {
+    throw e;
+  });
+
+  await copyFile(path, `${path}.bak`);
+
+  const pkg = JSON.parse(await readFile(path, "utf8"));
+  let env = pkg?.pepr?.env || {};
+  env = { ...env, PEPR_HTTP2_WATCH: "true" };
+  pkg.pepr.env = env;
+
+  await writeFile(path, JSON.stringify(pkg, null, 2));
+}
+
+run(process.argv).catch(err => {
+  console.error(err);
+  process.exit(-1);
+});

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -112,16 +112,26 @@ jobs:
       - name: "set env: PEPR_IMG"
         run: echo "PEPR_IMG=${GITHUB_WORKSPACE}/pepr-img.tar" >> "$GITHUB_ENV"
 
+      - name: clone pepr
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          repository: defenseunicorns/pepr
+          path: pepr
+
+      - name: "set env: PEPR"
+        run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
+
       - name: import docker image from pepr tar
         run: |
           docker image load --input "$PEPR_IMG"
 
-      - name: uds HTTP2-based watcher
+      - name: swap-in HTTP2-based watcher
         run: |
-          jq --version
-          node --version
+          cd "$UDS_CORE"
+          node "$PEPR/.github/workflows/uds-http2-watcher.js" ./package.json
+          cat ./package.json
 
-      # - name: uds run
-      #   run: |
-      #     cd "$UDS_CORE"
-      #     PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev
+      - name: uds run
+        run: |
+          cd "$UDS_CORE"
+          PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -116,7 +116,12 @@ jobs:
         run: |
           docker image load --input "$PEPR_IMG"
 
-      - name: uds run
+      - name: uds HTTP2-based watcher
         run: |
-          cd "$UDS_CORE"
-          PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev
+          jq --version
+          node --version
+
+      # - name: uds run
+      #   run: |
+      #     cd "$UDS_CORE"
+      #     PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev


### PR DESCRIPTION
## Description

Configures smoke watch controller to use http2 watch mode.

Relates to #1280 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
