### PR TITLE
chore: update resource limits/requests on controllers

### DIFF
--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -132,7 +132,7 @@ export function watcher(assets: Assets, hash: string, buildTimestamp: string, im
                   cpu: "200m",
                 },
                 limits: {
-                  memory: "1Gi",
+                  memory: "512Mi",
                   cpu: "500m",
                 },
               },
@@ -271,7 +271,7 @@ export function deployment(
                   cpu: "200m",
                 },
                 limits: {
-                  memory: "1Gi",
+                  memory: "512Mi",
                   cpu: "500m",
                 },
               },

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -128,11 +128,11 @@ export function watcher(assets: Assets, hash: string, buildTimestamp: string, im
               ],
               resources: {
                 requests: {
-                  memory: "64Mi",
-                  cpu: "100m",
+                  memory: "256Mi",
+                  cpu: "200m",
                 },
                 limits: {
-                  memory: "256Mi",
+                  memory: "1Gi",
                   cpu: "500m",
                 },
               },
@@ -267,11 +267,11 @@ export function deployment(
               ],
               resources: {
                 requests: {
-                  memory: "64Mi",
-                  cpu: "100m",
+                  memory: "256Mi",
+                  cpu: "200m",
                 },
                 limits: {
-                  memory: "256Mi",
+                  memory: "1Gi",
                   cpu: "500m",
                 },
               },

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -63,11 +63,11 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       },
       resources: {
         requests: {
-          memory: "64Mi",
-          cpu: "100m",
+          memory: "256Mi",
+          cpu: "200m",
         },
         limits: {
-          memory: "256Mi",
+          memory: "1Gi",
           cpu: "500m",
         },
       },
@@ -129,11 +129,11 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
       },
       resources: {
         requests: {
-          memory: "64Mi",
-          cpu: "100m",
+          memory: "256Mi",
+          cpu: "200m",
         },
         limits: {
-          memory: "256Mi",
+          memory: "1Gi",
           cpu: "500m",
         },
       },

--- a/src/lib/assets/yaml.ts
+++ b/src/lib/assets/yaml.ts
@@ -67,7 +67,7 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
           cpu: "200m",
         },
         limits: {
-          memory: "1Gi",
+          memory: "512Mi",
           cpu: "500m",
         },
       },
@@ -133,7 +133,7 @@ export async function overridesFile({ hash, name, image, config, apiToken }: Ass
           cpu: "200m",
         },
         limits: {
-          memory: "1Gi",
+          memory: "512Mi",
           cpu: "500m",
         },
       },


### PR DESCRIPTION
## Description

The default memory limits for Pepr are very low. We need to update to more sane defaults



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
