### PR TITLE
feat: add timeout metrics and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,14 @@
         "@types/json-pointer": "^1.0.34",
         "@types/node": "22.x.x",
         "@types/node-forge": "1.3.11",
+        "@types/supertest": "^6.0.2",
         "@types/uuid": "10.0.0",
         "fast-check": "^3.19.0",
         "husky": "^9.1.6",
         "jest": "29.7.0",
         "js-yaml": "^4.1.0",
         "nock": "^13.5.4",
+        "supertest": "^7.0.0",
         "ts-jest": "29.2.5"
       },
       "engines": {
@@ -2444,6 +2446,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -2539,6 +2547,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -2638,6 +2652,28 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/tar": {
@@ -3015,6 +3051,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3583,6 +3625,15 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3667,6 +3718,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -3916,6 +3973,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -4829,6 +4896,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5126,6 +5207,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -8719,6 +8809,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -60,15 +60,18 @@
     "@types/json-pointer": "^1.0.34",
     "@types/node": "22.x.x",
     "@types/node-forge": "1.3.11",
+    "@types/supertest": "^6.0.2",
     "@types/uuid": "10.0.0",
     "fast-check": "^3.19.0",
+    "husky": "^9.1.6",
     "jest": "29.7.0",
     "js-yaml": "^4.1.0",
     "nock": "^13.5.4",
-    "ts-jest": "29.2.5",
-    "husky": "^9.1.6"
+    "supertest": "^7.0.0",
+    "ts-jest": "29.2.5"
   },
   "peerDependencies": {
+    "@types/prompts": "2.4.9",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "commander": "12.1.0",
@@ -76,7 +79,6 @@
     "eslint": "8.57.0",
     "node-forge": "1.3.1",
     "prettier": "3.3.3",
-    "@types/prompts": "2.4.9",
     "prompts": "2.4.2",
     "typescript": "5.3.3",
     "uuid": "10.0.0"

--- a/src/lib/controller/index.test.ts
+++ b/src/lib/controller/index.test.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import request from "supertest";
+import express from "express";
+import { Socket } from "net";
+//import https from 'https';
+import { Controller } from "./index";
+import { Capability } from "../capability";
+import { ModuleConfig } from "../module";
+import { jest, it, describe, expect, beforeEach } from "@jest/globals";
+import { metricsCollector } from "../metrics";
+import Log from "../logger";
+//import { mutateProcessor } from '../mutate-processor';
+//import { validateProcessor } from '../validate-processor';
+
+jest.mock("../mutate-processor", () => ({
+  mutateProcessor: jest.fn(),
+}));
+
+jest.mock("../validate-processor", () => ({
+  validateProcessor: jest.fn(),
+}));
+
+jest.mock("https", () => ({
+  createServer: jest.fn().mockReturnValue({
+    listen: jest.fn().mockImplementation((...args: unknown[]) => {
+      const callback = args.find(arg => typeof arg === "function") as () => void;
+      if (callback) callback();
+      return {
+        on: jest.fn((event: string, handler: (socket: Socket) => void) => {
+          if (event === "timeout") {
+            const mockSocket = new Socket(); // Simulate a socket
+            handler(mockSocket); // Trigger the timeout event
+          }
+        }),
+      };
+    }),
+  }),
+}));
+
+jest.mock("fs", () => ({
+  ...(jest.requireActual("fs") as object),
+  readFileSync: jest.fn().mockReturnValue("mocked-file-content"),
+}));
+
+jest.mock("../module", () => ({
+  isBuildMode: jest.fn(() => false),
+  isWatchMode: jest.fn(() => false),
+  isDevMode: jest.fn(() => true),
+}));
+
+jest.mock("../logger", () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+jest.mock("../metrics", () => ({
+  metricsCollector: {
+    timeout: jest.fn(),
+    alert: jest.fn(),
+    getMetrics: jest.fn().mockResolvedValue("mocked-metrics" as never),
+    observeStart: jest.fn(() => Date.now()),
+    observeEnd: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("Controller", () => {
+  let app: express.Application;
+  let controller: Controller;
+
+  beforeEach(() => {
+    const config: ModuleConfig = { uuid: "test-uuid" } as ModuleConfig;
+    const capabilities: Capability[] = [];
+    controller = new Controller(config, capabilities);
+    controller["bindEndpoints"]();
+    app = controller.app;
+  });
+
+  it("should respond to health check", async () => {
+    const response = await request(app).get("/healthz");
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("OK");
+  });
+
+  it("should respond with metrics", async () => {
+    const response = await request(app).get("/metrics");
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("mocked-metrics");
+  });
+
+  it("should validate token", async () => {
+    controller.token = "valid-token";
+    const response = await request(app).post("/mutate/invalid-token");
+    expect(response.status).toBe(401);
+    expect(response.text).toContain("Unauthorized");
+  });
+
+  it("should respond with 500 if an error occurs", async () => {
+    app.get("/error", () => {
+      throw new Error("test-error");
+    });
+
+    const response = await request(app).get("/error");
+    expect(response.status).toBe(500);
+    expect(response.text).toContain("test-error");
+  });
+
+  it("should log a timeout warning and increment the timeout metric when a timeout occurs", () => {
+    const port = 3000;
+    expect(() => controller.startServer(port)).not.toThrow();
+
+    // Assert that the warning log and timeout metric were called
+    expect(Log.warn).toHaveBeenCalledWith("Admission webhook request timed out.");
+    expect(metricsCollector.timeout).toHaveBeenCalled();
+  });
+
+  it("should prevent starting the server when it is already running", () => {
+    const port = 3000;
+    controller.startServer(port); // Start the server initially
+    expect(() => controller.startServer(port)).toThrow(
+      "Cannot start Pepr module: Pepr module was not instantiated with deferStart=true",
+    );
+  });
+
+  /* it('should gracefully handle SIGTERM and close the server', () => {
+    const port = 3000;
+    const mockClose = jest.fn((callback: () => void) => callback());
+
+    // Mock the server close function
+    (https.createServer().listen as jest.Mock).mockReturnValueOnce({
+      on: jest.fn(),
+      close: mockClose,
+    });
+
+    controller.startServer(port);
+
+    // Simulate SIGTERM
+    process.emit('SIGTERM');
+
+    // Assert the server close and log behavior
+    expect(Log.info).toHaveBeenCalledWith("Received SIGTERM, closing server");
+    expect(mockClose).toHaveBeenCalled();
+    expect(Log.info).toHaveBeenCalledWith("Server closed");
+  }); */
+
+  /* it("should retry when the port is in use (EADDRINUSE)", () => {
+    const port = 3000;
+    const mockClose = jest.fn();
+    const mockListen = jest.fn().mockImplementation((p, callback) => {
+      const error = { code: "EADDRINUSE" };
+      https.createServer().listen().emit("error", error); // Simulate the error
+      setTimeout(callback as () => void, 2000); // Simulate retry
+    });
+
+    (https.createServer().listen as jest.Mock).mockReturnValueOnce({
+      on: jest.fn(),
+      close: mockClose,
+      listen: mockListen,
+    });
+
+    controller.startServer(port);
+
+    // Add this line to debug all Log.info calls
+    console.log((Log.info as jest.Mock).mock.calls);
+
+    expect(Log.info).toHaveBeenCalledWith(expect.stringContaining("Address in use, retrying in 2 seconds"));
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 2000);
+    expect(mockClose).toHaveBeenCalled();
+  });
+ */
+
+  it("should allow valid token and proceed to the next middleware", async () => {
+    controller.token = "valid-token";
+
+    const app = express();
+    app.use("/mutate/:token", controller["validateToken"], ((req: express.Request, res: express.Response): void => {
+      res.send("OK");
+    }) as express.RequestHandler);
+
+    const response = await request(app).post("/mutate/valid-token");
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("OK");
+  });
+
+  it("should reject invalid token and increment alert metrics", async () => {
+    controller.token = "valid-token";
+
+    const app = express();
+    app.use("/mutate/:token", controller["validateToken"]);
+
+    const response = await request(app).post("/mutate/invalid-token");
+
+    expect(response.status).toBe(401);
+    expect(response.text).toContain("Unauthorized: invalid token");
+    expect(metricsCollector.alert).toHaveBeenCalled();
+  });
+
+  /*   it("should return 500 when an error occurs during admission processing", async () => {
+    const admissionKind = "Mutate";
+    const mockError = new Error("Test admission error");
+
+    // Set a valid token to bypass the token validation
+    controller.token = "valid-token";
+
+    // Mock mutateProcessor to throw an error
+    (mutateProcessor as jest.Mock).mockRejectedValue(mockError as never);
+
+    const response = await request(app).post("/mutate/valid-token").send({ request: {} });
+
+    expect(response.status).toBe(500);
+    expect(response.text).toContain("Internal Server Error");
+    expect(Log.error).toHaveBeenCalledWith(mockError, `Error processing ${admissionKind} request`);
+  }, 10000);  // Increased timeout to 10 seconds */
+
+  it("should return 500 if an error occurs in the metrics endpoint", async () => {
+    (metricsCollector.getMetrics as jest.Mock).mockRejectedValueOnce(new Error("Metrics error") as never);
+
+    const response = await request(app).get("/metrics");
+
+    expect(response.status).toBe(500);
+    expect(response.text).toBe("Internal Server Error");
+    expect(Log.error).toHaveBeenCalledWith(expect.any(Error), "Error getting metrics");
+  });
+});


### PR DESCRIPTION
## Description
Timeouts for admission webhooks default to 10 seconds. Create analytics to inform the user when a timeout has occurred.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #358 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
