### PR TITLE
chore(ci): increase concurrency limit for faster E2E tests

### DIFF
--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -191,6 +191,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
+          timeout_minutes: 6
           command: |
             cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
             npm run --workspace=${{ matrix.name }} test:e2e -- \

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 18
+      max-parallel: 12
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 18
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 24
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 24
+      max-parallel: 12
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 24
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -187,11 +187,15 @@ jobs:
           npm ci
 
       - name: run e2e tests
-        run: |
-          cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
-          npm run --workspace=${{ matrix.name }} test:e2e -- \
-            --image pepr:dev \
-            --custom-package ../pepr-0.0.0-development.tgz
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
+            npm run --workspace=${{ matrix.name }} test:e2e -- \
+              --image pepr:dev \
+              --custom-package ../pepr-0.0.0-development.tgz
 
       - name: upload artifacts (troubleshooting)
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 12
+      max-parallel: 18
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 12
+      max-parallel: 24
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 32 # Roughly matches the number of E2E tests and below GitHub concurrency limit
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -142,7 +142,7 @@ jobs:
     if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 18
       matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Description

Changes the concurrency limit to run more E2E tests at once.

## Related Issue

Fixes #1207 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging
- [X] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [X] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
