### PR TITLE
feat: add ability to exit Finalize() callback WITHOUT removing the finalizer

### DIFF
--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -337,7 +337,7 @@ export class Capability implements CapabilityExport {
           event: Event.Update,
           finalizeCallback: async (update: InstanceType<T>, logger = aliasLogger) => {
             Log.info(`Executing finalize action with alias: ${binding.alias || "no alias provided"}`);
-            await finalizeCallback(update, logger);
+            return await finalizeCallback(update, logger);
           },
         };
         bindings.push(watchBinding);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -267,7 +267,7 @@ export type ValidateActionResponse = {
 export type FinalizeAction<T extends GenericClass, K extends KubernetesObject = InstanceType<T>> = (
   update: K,
   logger?: Logger,
-) => Promise<void> | void;
+) => Promise<boolean | void> | boolean | void;
 
 export type FinalizeActionChain<T extends GenericClass> = {
   /**

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -120,7 +120,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[], igno
               // [ true, void, undefined ] SHOULD remove finalizer
               // [ false ] should NOT remove finalizer
               shouldRemoveFinalizer === false
-                ? Log.debug({ obj }, `Skip removal of finalizer '${peprFinal}' from '${resource}'`)
+                ? Log.debug({ obj }, `Skipping removal of finalizer '${peprFinal}' from '${resource}'`)
                 : await removeFinalizer(binding, obj);
             }
           } else {

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -107,6 +107,7 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[], igno
               return;
             }
             try {
+              // TODO
               await binding.finalizeCallback?.(obj);
 
               // irrespective of callback success / failure, remove pepr finalizer

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -106,13 +106,22 @@ async function runBinding(binding: Binding, capabilityNamespaces: string[], igno
             if (!obj.metadata?.deletionTimestamp) {
               return;
             }
-            try {
-              // TODO
-              await binding.finalizeCallback?.(obj);
 
-              // irrespective of callback success / failure, remove pepr finalizer
+            let shouldRemoveFinalizer: boolean | void | undefined = true;
+            try {
+              shouldRemoveFinalizer = await binding.finalizeCallback?.(obj);
+
+              // if not opt'ed out of / if in error state, remove pepr finalizer
             } finally {
-              await removeFinalizer(binding, obj);
+              const peprFinal = "pepr.dev/finalizer";
+              const meta = obj.metadata!;
+              const resource = `${meta.namespace || "ClusterScoped"}/${meta.name}`;
+
+              // [ true, void, undefined ] SHOULD remove finalizer
+              // [ false ] should NOT remove finalizer
+              shouldRemoveFinalizer === false
+                ? Log.debug({ obj }, `Skip removal of finalizer '${peprFinal}' from '${resource}'`)
+                : await removeFinalizer(binding, obj);
             }
           } else {
             await binding.watchCallback?.(obj, phase);


### PR DESCRIPTION
## Description

Adds ability for Module Author to "opt out" of removing Pepr's metadata.finalizers entry.

End to End Test:  <!-- if applicable -->  
[pepr-excellent-examples #172](https://github.com/defenseunicorns/pepr-excellent-examples/pull/172)

## Related Issue

Fixes #1316 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
