### PR TITLE
fix: fix error in metrics.ts related to this.#cacheMissWindows.delete(firstKey)

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -173,7 +173,9 @@ export class MetricsCollector {
 
     if (maxCacheMissWindows !== undefined && this.#cacheMissWindows.size >= maxCacheMissWindows) {
       const firstKey = this.#cacheMissWindows.keys().next().value;
-      this.#cacheMissWindows.delete(firstKey);
+      if (firstKey !== undefined) {
+        this.#cacheMissWindows.delete(firstKey);
+      }
       this.#gauges.get(this.#getMetricName(this.#metricNames.cacheMiss))?.remove({ window: firstKey });
     }
   };


### PR DESCRIPTION
## Description
this.#cacheMissWindows.delete(firstKey) is generating an error related to it possibly being undefined. This should be investigated and fixed.


...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1351 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
