### PR TITLE
chore: make test crossplatform

### DIFF
--- a/src/sdk/cosign.e2e.tezt.ts
+++ b/src/sdk/cosign.e2e.tezt.ts
@@ -58,11 +58,8 @@ const timed = async (msg: string, func: () => Promise<any>) => {
 };
 
 async function builderExists(name: string) {
-  const resultRaw = await cmdStdout(`docker buildx ls --format json`);
-  const result = resultRaw.split("\n").map(m => JSON.parse(m));
-  const found = result.filter(f => f.Name === name).length;
-
-  return !!found;
+  const resultRaw = await cmdStdout(`docker buildx ls`);
+  return resultRaw.includes(name);
 }
 
 enum OS {


### PR DESCRIPTION
## Description

There is not json format in the dockercommand on mac

```
> docker buildx ls --format json
unknown flag: --format
See 'docker buildx ls --help'.
```

We can still parse the results without using json and get the desired outcome

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1367 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
