### PR TITLE
chore(test): break up request adjudicator tests to separate file for readability

### DIFF
--- a/src/lib/filter/adjudicators.test.ts
+++ b/src/lib/filter/adjudicators.test.ts
@@ -3,7 +3,7 @@
 
 import { expect, describe, it } from "@jest/globals";
 import * as sut from "./adjudicators";
-import { GroupVersionKind, KubernetesObject } from "kubernetes-fluent-client";
+import { KubernetesObject } from "kubernetes-fluent-client";
 import { AdmissionRequest, Binding, DeepPartial } from "../types";
 import { Event, Operation } from "../enums";
 
@@ -691,37 +691,6 @@ describe("operationMatchesEvent", () => {
   });
 });
 
-describe("declaredOperation", () => {
-  const defaultAdmissionRequest = {
-    uid: "some-uid",
-    kind: { kind: "a-kind", group: "a-group" },
-    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
-    operation: undefined,
-    name: "some-name",
-    userInfo: {},
-    object: {},
-  };
-  //[ AdmissionRequest, result ]
-  it.each([
-    [{}, ""],
-    [{ operation: null }, ""],
-    [{ operation: "" }, ""],
-    [{ operation: "operation" }, "operation"],
-    [{ operation: Operation.CONNECT }, Operation.CONNECT],
-    [{ operation: Operation.CREATE }, Operation.CREATE],
-    [{ operation: Operation.UPDATE }, Operation.UPDATE],
-    [{ operation: Operation.DELETE }, Operation.DELETE],
-  ])("given %j, returns '%s'", (given, expected) => {
-    const request = {
-      ...defaultAdmissionRequest,
-      operation: ("operation" in given ? given.operation : (undefined as unknown as string)) as Operation,
-    };
-    const result = sut.declaredOperation(request);
-
-    expect(result).toEqual(expected);
-  });
-});
-
 describe("mismatchedEvent", () => {
   //[ Binding, AdmissionRequest, result ]
   it.each([
@@ -798,38 +767,6 @@ describe("definesGroup", () => {
   });
 });
 
-describe("declaredGroup", () => {
-  const defaultAdmissionRequest = {
-    uid: "some-uid",
-    kind: undefined,
-    group: "a-group",
-    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
-    operation: Operation.CONNECT,
-    name: "some-name",
-    userInfo: {},
-    object: {},
-  };
-
-  //[ AdmissionRequest, result ]
-  it.each([
-    [{}, ""],
-    [{ kind: null }, ""],
-    [{ kind: {} }, ""],
-    [{ kind: { group: null } }, ""],
-    [{ kind: { group: "" } }, ""],
-    [{ kind: { group: "group" } }, "group"],
-  ])("given %j, returns '%s'", (given, expected) => {
-    const request = {
-      ...defaultAdmissionRequest,
-      kind: ("kind" in given ? given.kind : (undefined as unknown as string)) as GroupVersionKind,
-    };
-
-    const result = sut.declaredGroup(request);
-
-    expect(result).toEqual(expected);
-  });
-});
-
 describe("mismatchedGroup", () => {
   //[ Binding, AdmissionRequest, result ]
   it.each([
@@ -884,37 +821,6 @@ describe("definesVersion", () => {
   });
 });
 
-describe("declaredVersion", () => {
-  const defaultAdmissionRequest = {
-    uid: "some-uid",
-    kind: undefined,
-    group: "a-group",
-    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
-    operation: Operation.CONNECT,
-    name: "some-name",
-    userInfo: {},
-    object: {},
-  };
-  //[ AdmissionRequest, result ]
-  it.each([
-    [{}, ""],
-    [{ kind: null }, ""],
-    [{ kind: {} }, ""],
-    [{ kind: { version: null } }, ""],
-    [{ kind: { version: "" } }, ""],
-    [{ kind: { version: "version" } }, "version"],
-  ])("given %j, returns '%s'", (given, expected) => {
-    const request = {
-      ...defaultAdmissionRequest,
-      kind: ("kind" in given ? given.kind : (undefined as unknown as string)) as GroupVersionKind,
-    };
-
-    const result = sut.declaredVersion(request);
-
-    expect(result).toEqual(expected);
-  });
-});
-
 describe("mismatchedVersion", () => {
   //[ Binding, AdmissionRequest, result ]
   it.each([
@@ -964,38 +870,6 @@ describe("definesKind", () => {
     const binding = given as DeepPartial<Binding>;
 
     const result = sut.definesKind(binding);
-
-    expect(result).toEqual(expected);
-  });
-});
-
-describe("declaredKind", () => {
-  const defaultAdmissionRequest = {
-    uid: "some-uid",
-    kind: undefined,
-    group: "a-group",
-    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
-    operation: Operation.CONNECT,
-    name: "some-name",
-    userInfo: {},
-    object: {},
-  };
-
-  //[ AdmissionRequest, result ]
-  it.each([
-    [{}, ""],
-    [{ kind: null }, ""],
-    [{ kind: {} }, ""],
-    [{ kind: { kind: null } }, ""],
-    [{ kind: { kind: "" } }, ""],
-    [{ kind: { kind: "kind" } }, "kind"],
-  ])("given %j, returns '%s'", (given, expected) => {
-    const request = {
-      ...defaultAdmissionRequest,
-      kind: ("kind" in given ? given.kind : (undefined as unknown as string)) as GroupVersionKind,
-    };
-
-    const result = sut.declaredKind(request);
 
     expect(result).toEqual(expected);
   });
@@ -1075,34 +949,6 @@ describe("definedCallbackName", () => {
     const binding = given as DeepPartial<Binding>;
 
     const result = sut.definedCallbackName(binding);
-
-    expect(result).toEqual(expected);
-  });
-});
-
-describe("declaredUid", () => {
-  const defaultAdmissionRequest = {
-    uid: undefined,
-    kind: { kind: "a-kind", group: "a-group" },
-    group: "a-group",
-    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
-    operation: Operation.CONNECT,
-    name: "some-name",
-    userInfo: {},
-    object: {},
-  };
-  //[ AdmissionRequest, result ]
-  it.each([
-    [{}, ""],
-    [{ uid: null }, ""],
-    [{ uid: "uid" }, "uid"],
-  ])("given %j, returns '%s'", (given, expected) => {
-    const request = {
-      ...defaultAdmissionRequest,
-      uid: ("uid" in given ? given.uid : (undefined as unknown as string)) as string,
-    };
-
-    const result = sut.declaredUid(request);
 
     expect(result).toEqual(expected);
   });

--- a/src/lib/filter/adjudicators/requestAdjudicators.test.ts
+++ b/src/lib/filter/adjudicators/requestAdjudicators.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { expect, describe, it } from "@jest/globals";
+import * as sut from "../adjudicators";
+import { Operation } from "../../enums";
+import { GroupVersionKind } from "kubernetes-fluent-client";
+
+describe("declaredUid", () => {
+  const defaultAdmissionRequest = {
+    uid: undefined,
+    kind: { kind: "a-kind", group: "a-group" },
+    group: "a-group",
+    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
+    operation: Operation.CONNECT,
+    name: "some-name",
+    userInfo: {},
+    object: {},
+  };
+  //[ AdmissionRequest, result ]
+  it.each([
+    [{}, ""],
+    [{ uid: null }, ""],
+    [{ uid: "uid" }, "uid"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const request = {
+      ...defaultAdmissionRequest,
+      uid: ("uid" in given ? given.uid : (undefined as unknown as string)) as string,
+    };
+
+    const result = sut.declaredUid(request);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("declaredKind", () => {
+  const defaultAdmissionRequest = {
+    uid: "some-uid",
+    kind: undefined,
+    group: "a-group",
+    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
+    operation: Operation.CONNECT,
+    name: "some-name",
+    userInfo: {},
+    object: {},
+  };
+  //[ AdmissionRequest, result ]
+  it.each([
+    [{}, ""],
+    [{ kind: null }, ""],
+    [{ kind: {} }, ""],
+    [{ kind: { kind: null } }, ""],
+    [{ kind: { kind: "" } }, ""],
+    [{ kind: { kind: "kind" } }, "kind"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const request = {
+      ...defaultAdmissionRequest,
+      kind: ("kind" in given ? given.kind : (undefined as unknown as string)) as GroupVersionKind,
+    };
+
+    const result = sut.declaredKind(request);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("declaredVersion", () => {
+  const defaultAdmissionRequest = {
+    uid: "some-uid",
+    kind: undefined,
+    group: "a-group",
+    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
+    operation: Operation.CONNECT,
+    name: "some-name",
+    userInfo: {},
+    object: {},
+  };
+  //[ AdmissionRequest, result ]
+  it.each([
+    [{}, ""],
+    [{ kind: null }, ""],
+    [{ kind: {} }, ""],
+    [{ kind: { version: null } }, ""],
+    [{ kind: { version: "" } }, ""],
+    [{ kind: { version: "version" } }, "version"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const request = {
+      ...defaultAdmissionRequest,
+      kind: ("kind" in given ? given.kind : (undefined as unknown as string)) as GroupVersionKind,
+    };
+
+    const result = sut.declaredVersion(request);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("declaredGroup", () => {
+  const defaultAdmissionRequest = {
+    uid: "some-uid",
+    kind: undefined,
+    group: "a-group",
+    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
+    operation: Operation.CONNECT,
+    name: "some-name",
+    userInfo: {},
+    object: {},
+  };
+  //[ AdmissionRequest, result ]
+  it.each([
+    [{}, ""],
+    [{ kind: null }, ""],
+    [{ kind: {} }, ""],
+    [{ kind: { group: null } }, ""],
+    [{ kind: { group: "" } }, ""],
+    [{ kind: { group: "group" } }, "group"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const request = {
+      ...defaultAdmissionRequest,
+      kind: ("kind" in given ? given.kind : (undefined as unknown as string)) as GroupVersionKind,
+    };
+
+    const result = sut.declaredGroup(request);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("declaredOperation", () => {
+  const defaultAdmissionRequest = {
+    uid: "some-uid",
+    kind: { kind: "a-kind", group: "a-group" },
+    resource: { group: "some-group", version: "some-version", resource: "some-resource" },
+    operation: undefined,
+    name: "some-name",
+    userInfo: {},
+    object: {},
+  };
+  //[ AdmissionRequest, result ]
+  it.each([
+    [{}, ""],
+    [{ operation: null }, ""],
+    [{ operation: "" }, ""],
+    [{ operation: "operation" }, "operation"],
+    [{ operation: Operation.CONNECT }, Operation.CONNECT],
+    [{ operation: Operation.CREATE }, Operation.CREATE],
+    [{ operation: Operation.UPDATE }, Operation.UPDATE],
+    [{ operation: Operation.DELETE }, Operation.DELETE],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const request = {
+      ...defaultAdmissionRequest,
+      operation: ("operation" in given ? given.operation : (undefined as unknown as string)) as Operation,
+    };
+
+    const result = sut.declaredOperation(request);
+
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Description

Break up a previously large test file in the interest of readability and future refactors around the test suite and code complexity.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Relates to #1397, #1406, #1407, #1248

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
