### PR TITLE
chore(test): break up Binding-KubernetesObject tests to separate file for readability

### DIFF
--- a/src/lib/filter/adjudicators.test.ts
+++ b/src/lib/filter/adjudicators.test.ts
@@ -73,23 +73,6 @@ describe("missingDeletionTimestamp", () => {
   });
 });
 
-describe("mismatchedDeletionTimestamp", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { deletionTimestamp: new Date() } }, false],
-    [{ filters: { deletionTimestamp: true } }, {}, true],
-    [{ filters: { deletionTimestamp: true } }, { metadata: { deletionTimestamp: new Date() } }, false],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<KubernetesObject>;
-
-    const result = sut.mismatchedDeletionTimestamp(binding, object);
-
-    expect(result).toBe(expected);
-  });
-});
-
 describe("definedName", () => {
   //[ Binding, result ]
   it.each([
@@ -213,45 +196,6 @@ describe("missingName", () => {
     const binding = given as DeepPartial<Binding>;
 
     const result = sut.missingName(binding);
-
-    expect(result).toBe(expected);
-  });
-});
-
-describe("mismatchedName", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { name: "name" } }, false],
-    [{ filters: { name: "name" } }, {}, true],
-    [{ filters: { name: "name" } }, { metadata: { name: "name" } }, false],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<KubernetesObject>;
-
-    const result = sut.mismatchedName(binding, object);
-
-    expect(result).toBe(expected);
-  });
-});
-
-describe("mismatchedNameRegex", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { name: "name" } }, false],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, {}, true],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "name" } }, false],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "neme" } }, false],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nime" } }, false],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nome" } }, false],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nume" } }, false],
-    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "n3me" } }, true],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<KubernetesObject>;
-
-    const result = sut.mismatchedNameRegex(binding, object);
 
     expect(result).toBe(expected);
   });
@@ -402,55 +346,6 @@ describe("carriesNamespace", () => {
   });
 });
 
-describe("mismatchedNamespace", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { namespace: "namespace" } }, false],
-    [{ filters: { namespaces: ["namespace"] } }, {}, true],
-    [{ filters: { namespaces: ["namespace"] } }, { metadata: { namespace: "nopesause" } }, true],
-    [{ filters: { namespaces: ["namespace"] } }, { metadata: { namespace: "namespace" } }, false],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<Binding>;
-
-    const result = sut.mismatchedNamespace(binding, object);
-
-    expect(result).toBe(expected);
-  });
-});
-
-describe("mismatchedNamespaceRegex", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { namespace: "namespace" } }, false],
-    [{ filters: { regexNamespaces: ["^n.mespace$"] } }, {}, true],
-
-    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "namespace" } }, false],
-    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nemespace" } }, false],
-    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nimespace" } }, false],
-    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nomespace" } }, false],
-    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "numespace" } }, false],
-    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "n3mespace" } }, true],
-
-    [{ filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } }, { metadata: { namespace: "name" } }, false],
-    [{ filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } }, { metadata: { namespace: "space" } }, false],
-    [
-      { filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } },
-      { metadata: { namespace: "namespace" } },
-      true,
-    ],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<Binding>;
-
-    const result = sut.mismatchedNamespaceRegex(binding, object);
-
-    expect(result).toBe(expected);
-  });
-});
-
 describe("misboundNamespace", () => {
   //[ Binding, result ]
   it.each([
@@ -539,66 +434,6 @@ describe("carriesAnnotations", () => {
   });
 });
 
-describe("metasMismatch", () => {
-  it.each([
-    [{}, {}, false],
-    [{}, { anno: "tate" }, false],
-
-    [{ anno: "" }, {}, true],
-    [{ anno: "" }, { anno: "" }, false],
-    [{ anno: "" }, { anno: "tate" }, false],
-
-    [{ anno: "tate" }, {}, true],
-    [{ anno: "tate" }, { anno: "" }, true],
-    [{ anno: "tate" }, { anno: "tate" }, false],
-    [{ anno: "tate" }, { anno: "tato" }, true],
-
-    [{ an: "no", ta: "te" }, { an: "" }, true],
-    [{ an: "no", ta: "te" }, { an: "no" }, true],
-    [{ an: "no", ta: "te" }, { an: "no", ta: "" }, true],
-    [{ an: "no", ta: "te" }, { an: "no", ta: "te" }, false],
-    [{ an: "no", ta: "te" }, { an: "no", ta: "to" }, true],
-  ])("given left %j and right %j, returns %s", (bnd, obj, expected) => {
-    const result = sut.metasMismatch(bnd, obj);
-
-    expect(result).toBe(expected);
-  });
-});
-
-describe("mismatchedAnnotations", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { annotations: { anno: "tate" } } }, false],
-
-    [{ filters: { annotations: { anno: "" } } }, {}, true],
-    [{ filters: { annotations: { anno: "" } } }, { metadata: { annotations: { anno: "" } } }, false],
-    [{ filters: { annotations: { anno: "" } } }, { metadata: { annotations: { anno: "tate" } } }, false],
-
-    [{ filters: { annotations: { anno: "tate" } } }, {}, true],
-    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "" } } }, true],
-    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "tate" } } }, false],
-    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "tato" } } }, true],
-
-    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "" } } }, true],
-    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no" } } }, true],
-    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no", ta: "" } } }, true],
-    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no", ta: "to" } } }, true],
-    [
-      { filters: { annotations: { an: "no", ta: "te" } } },
-      { metadata: { annotations: { an: "no", ta: "te" } } },
-      false,
-    ],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<Binding>;
-
-    const result = sut.mismatchedAnnotations(binding, object);
-
-    expect(result).toBe(expected);
-  });
-});
-
 describe("definedLabels", () => {
   //[ Binding, result ]
   it.each([
@@ -666,34 +501,6 @@ describe("carriesLabels", () => {
     const binding = given as DeepPartial<KubernetesObject>;
 
     const result = sut.carriesLabels(binding);
-
-    expect(result).toBe(expected);
-  });
-});
-
-describe("mismatchedLabels", () => {
-  //[ Binding, KubernetesObject, result ]
-  it.each([
-    [{}, {}, false],
-    [{}, { metadata: { labels: { la: "ble" } } }, false],
-
-    [{ filters: { labels: { la: "" } } }, {}, true],
-    [{ filters: { labels: { la: "" } } }, { metadata: { labels: { la: "" } } }, false],
-    [{ filters: { labels: { la: "" } } }, { metadata: { labels: { la: "ble" } } }, false],
-
-    [{ filters: { labels: { la: "ble" } } }, {}, true],
-    [{ filters: { labels: { la: "ble" } } }, { metadata: { labels: { la: "" } } }, true],
-    [{ filters: { labels: { la: "ble" } } }, { metadata: { labels: { la: "ble" } } }, false],
-
-    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "" } } }, true],
-    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "a" } } }, true],
-    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "a", b: "" } } }, true],
-    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "a", b: "le" } } }, false],
-  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
-    const binding = bnd as DeepPartial<Binding>;
-    const object = obj as DeepPartial<Binding>;
-
-    const result = sut.mismatchedLabels(binding, object);
 
     expect(result).toBe(expected);
   });

--- a/src/lib/filter/adjudicators/bindingKubernetesObjectAdjudicators.test.ts
+++ b/src/lib/filter/adjudicators/bindingKubernetesObjectAdjudicators.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable max-statements */
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { expect, describe, it } from "@jest/globals";
+import * as sut from "../adjudicators";
+import { KubernetesObject } from "kubernetes-fluent-client";
+import { Binding, DeepPartial } from "../../types";
+
+describe("mismatchedName", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { name: "name" } }, false],
+    [{ filters: { name: "name" } }, {}, true],
+    [{ filters: { name: "name" } }, { metadata: { name: "name" } }, false],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<KubernetesObject>;
+
+    const result = sut.mismatchedName(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedDeletionTimestamp", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { deletionTimestamp: new Date() } }, false],
+    [{ filters: { deletionTimestamp: true } }, {}, true],
+    [{ filters: { deletionTimestamp: true } }, { metadata: { deletionTimestamp: new Date() } }, false],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<KubernetesObject>;
+
+    const result = sut.mismatchedDeletionTimestamp(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedNameRegex", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { name: "name" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, {}, true],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "name" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "neme" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nime" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nome" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "nume" } }, false],
+    [{ filters: { regexName: "^n[aeiou]me$" } }, { metadata: { name: "n3me" } }, true],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<KubernetesObject>;
+
+    const result = sut.mismatchedNameRegex(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedNamespace", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { namespace: "namespace" } }, false],
+    [{ filters: { namespaces: ["namespace"] } }, {}, true],
+    [{ filters: { namespaces: ["namespace"] } }, { metadata: { namespace: "nopesause" } }, true],
+    [{ filters: { namespaces: ["namespace"] } }, { metadata: { namespace: "namespace" } }, false],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<Binding>;
+
+    const result = sut.mismatchedNamespace(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedNamespaceRegex", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { namespace: "namespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n.mespace$"] } }, {}, true],
+
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "namespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nemespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nimespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "nomespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "numespace" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]mespace$"] } }, { metadata: { namespace: "n3mespace" } }, true],
+
+    [{ filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } }, { metadata: { namespace: "name" } }, false],
+    [{ filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } }, { metadata: { namespace: "space" } }, false],
+    [
+      { filters: { regexNamespaces: ["^n[aeiou]me$", "^sp[aeiou]ce$"] } },
+      { metadata: { namespace: "namespace" } },
+      true,
+    ],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<Binding>;
+
+    const result = sut.mismatchedNamespaceRegex(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedAnnotations", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { annotations: { anno: "tate" } } }, false],
+
+    [{ filters: { annotations: { anno: "" } } }, {}, true],
+    [{ filters: { annotations: { anno: "" } } }, { metadata: { annotations: { anno: "" } } }, false],
+    [{ filters: { annotations: { anno: "" } } }, { metadata: { annotations: { anno: "tate" } } }, false],
+
+    [{ filters: { annotations: { anno: "tate" } } }, {}, true],
+    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "" } } }, true],
+    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "tate" } } }, false],
+    [{ filters: { annotations: { anno: "tate" } } }, { metadata: { annotations: { anno: "tato" } } }, true],
+
+    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "" } } }, true],
+    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no" } } }, true],
+    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no", ta: "" } } }, true],
+    [{ filters: { annotations: { an: "no", ta: "te" } } }, { metadata: { annotations: { an: "no", ta: "to" } } }, true],
+    [
+      { filters: { annotations: { an: "no", ta: "te" } } },
+      { metadata: { annotations: { an: "no", ta: "te" } } },
+      false,
+    ],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<Binding>;
+
+    const result = sut.mismatchedAnnotations(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("mismatchedLabels", () => {
+  //[ Binding, KubernetesObject, result ]
+  it.each([
+    [{}, {}, false],
+    [{}, { metadata: { labels: { la: "ble" } } }, false],
+
+    [{ filters: { labels: { la: "" } } }, {}, true],
+    [{ filters: { labels: { la: "" } } }, { metadata: { labels: { la: "" } } }, false],
+    [{ filters: { labels: { la: "" } } }, { metadata: { labels: { la: "ble" } } }, false],
+
+    [{ filters: { labels: { la: "ble" } } }, {}, true],
+    [{ filters: { labels: { la: "ble" } } }, { metadata: { labels: { la: "" } } }, true],
+    [{ filters: { labels: { la: "ble" } } }, { metadata: { labels: { la: "ble" } } }, false],
+
+    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "" } } }, true],
+    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "a" } } }, true],
+    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "a", b: "" } } }, true],
+    [{ filters: { labels: { l: "a", b: "le" } } }, { metadata: { labels: { l: "a", b: "le" } } }, false],
+  ])("given binding %j and object %j, returns %s", (bnd, obj, expected) => {
+    const binding = bnd as DeepPartial<Binding>;
+    const object = obj as DeepPartial<Binding>;
+
+    const result = sut.mismatchedLabels(binding, object);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("metasMismatch", () => {
+  it.each([
+    [{}, {}, false],
+    [{}, { anno: "tate" }, false],
+
+    [{ anno: "" }, {}, true],
+    [{ anno: "" }, { anno: "" }, false],
+    [{ anno: "" }, { anno: "tate" }, false],
+
+    [{ anno: "tate" }, {}, true],
+    [{ anno: "tate" }, { anno: "" }, true],
+    [{ anno: "tate" }, { anno: "tate" }, false],
+    [{ anno: "tate" }, { anno: "tato" }, true],
+
+    [{ an: "no", ta: "te" }, { an: "" }, true],
+    [{ an: "no", ta: "te" }, { an: "no" }, true],
+    [{ an: "no", ta: "te" }, { an: "no", ta: "" }, true],
+    [{ an: "no", ta: "te" }, { an: "no", ta: "te" }, false],
+    [{ an: "no", ta: "te" }, { an: "no", ta: "to" }, true],
+  ])("given left %j and right %j, returns %s", (bnd, obj, expected) => {
+    const result = sut.metasMismatch(bnd, obj);
+
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Description

Part of a series of smaller steps to address #1397 without giant PRs.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Relates to #1397, #1406, #1407, #1408, #1248

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
