### PR TITLE
feat: replace legacy fetch in WatchConfig and update docs #1423

### DIFF
--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -62,7 +62,6 @@ The Watch configuration is a part of the Pepr module that allows you to watch fo
 | `PEPR_RETRY_DELAY_SECONDS`     | The delay between retries in seconds.                                                                            | default: `"10"`                 |
 | `PEPR_LAST_SEEN_LIMIT_SECONDS` | Max seconds to go without receiving a watch event before re-establishing the watch | default: `"300"` (5 mins)       |
 | `PEPR_RELIST_INTERVAL_SECONDS` | Amount of seconds to wait before a relist of the watched resources  | default: `"600"` (10 mins)       |
-| `PEPR_USE_LEGACY_WATCH` | Configure the Kubernetes Fluent Client to use legacy node-fetch watcher  | default: `"undefined"` |
 
 ## Configuring Reconcile
 
@@ -115,7 +114,7 @@ Below are the available Helm override configurations after you have built your P
 | `affinity`                                   | Node scheduling options                                             |
 | `terminationGracePeriodSeconds`              | Optional duration in seconds the pod needs to terminate gracefully  |
 
-Note: Replace `*` with `admission` or `watcher` as needed to apply settings specifically for each part.
+Note: Replace `*` within `admission.*` or `watcher.*` to apply settings specific to the desired subparameter (e.g. `admission.failurePolicy`).
 
 ## Customizing with package.json
 

--- a/src/lib/watch-processor.ts
+++ b/src/lib/watch-processor.ts
@@ -50,7 +50,6 @@ export function getOrCreateQueue(obj: KubernetesObject) {
 
 // Watch configuration
 const watchCfg: WatchCfg = {
-  useLegacyWatch: process.env.PEPR_USE_LEGACY_WATCH === "true",
   resyncFailureMax: process.env.PEPR_RESYNC_FAILURE_MAX ? parseInt(process.env.PEPR_RESYNC_FAILURE_MAX, 10) : 5,
   resyncDelaySec: process.env.PEPR_RESYNC_DELAY_SECONDS ? parseInt(process.env.PEPR_RESYNC_DELAY_SECONDS, 10) : 5,
   lastSeenLimitSeconds: process.env.PEPR_LAST_SEEN_LIMIT_SECONDS


### PR DESCRIPTION
## Description

This stops Pepr from attempting to use the no-longer-there `WatchCfg.useLegacyWatch` config item.  Updates docs to remove example use.

## Related Issue

Fixes #1423 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
