### PR TITLE
test: make load tests run on mac

### DIFF
--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -1025,6 +1025,7 @@ program
       `--interactive `,
       `--user ${user} `,
       `--volume ${opts.outputDir}:/workdir `,
+      `--platform linux/amd64 `,
       `gnuoctave/octave:9.2.0 `,
       `bash -c 'octave ${path.basename(octaveFile)}'`,
     ].join(" ");


### PR DESCRIPTION
## Description

Adds a new flag to allow GNU Octave graph to be generated on Mac.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
