### PR TITLE
test: squash some extra test output

### DIFF
--- a/journey/pepr-dev.ts
+++ b/journey/pepr-dev.ts
@@ -65,7 +65,6 @@ export function peprDev() {
 
       // Convert buffer to string
       const strData = data.toString();
-      console.log(strData);
 
       // Check if any expected lines are found
       expectedLines = expectedLines.filter(expectedLine => {
@@ -73,11 +72,10 @@ export function peprDev() {
         return !strData.replace(/\s+/g, " ").includes(expectedLine);
       });
 
-      console.info(`Expected lines remaining: ${expectedLines.length}`);
-      console.debug(`Remaining expected lines: ${expectedLines}`);
-
       // If all expected lines are found, resolve the promise
-      if (expectedLines.length < 1) {
+      if (expectedLines.length > 0) {
+        console.log(`still waiting on ${expectedLines.length} lines...`);
+      } else {
         // Abort all further processing
         success = true;
 

--- a/src/cli/init/walkthrough.test.ts
+++ b/src/cli/init/walkthrough.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { describe, expect, it } from "@jest/globals";
+import { afterAll, beforeAll, describe, expect, jest, it } from "@jest/globals";
 import prompts from "prompts";
 import {
   walkthrough,
@@ -12,7 +12,20 @@ import {
   setErrorBehavior,
 } from "./walkthrough";
 
+let consoleLog: jest.Spied<typeof console.log>;
+let consoleError: jest.Spied<typeof console.error>;
+
 describe("when processing input", () => {
+  beforeAll(() => {
+    consoleLog = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    consoleLog.mockRestore();
+    consoleError.mockRestore();
+  });
+
   describe("walkthough() returns expected results", () => {
     it.each([
       //Test flag combinations with [["$FLAG", ...]]


### PR DESCRIPTION
## Description

Cut / reduce some (_extra_) lengthy test output in order to make the output more manageable / scannable.

## Related Issue

Fixes to #1358 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
