### PR TITLE
chore: test cleanup of unneeded folders

### DIFF
--- a/journey/entrypoint-wasm.test.ts
+++ b/journey/entrypoint-wasm.test.ts
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { describe, jest } from "@jest/globals";
+import { describe, jest, afterAll } from "@jest/globals";
 import { peprBuild } from "./pepr-build-wasm";
-
+import { removeFolder } from "./utils";
+import { outputDir } from "./pepr-build-wasm";
 // Unmock unit test things
 jest.deepUnmock("pino");
 
 // Allow 5 minutes for the tests to run
 jest.setTimeout(1000 * 60 * 5);
+
+afterAll(async () => {
+  await removeFolder(outputDir);
+});
 
 describe(
   "Journey: `npx pepr build -r gchr.io/defenseunicorns -o dist/pepr-test-module/child/folder`",

--- a/journey/entrypoint.test.ts
+++ b/journey/entrypoint.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { beforeAll, describe, jest } from "@jest/globals";
+import { beforeAll, afterAll, describe, jest } from "@jest/globals";
 
 import { before } from "./before";
 import { peprBuild } from "./pepr-build";
@@ -9,7 +9,8 @@ import { peprDeploy } from "./pepr-deploy";
 import { peprDev } from "./pepr-dev";
 import { peprFormat } from "./pepr-format";
 import { peprInit } from "./pepr-init";
-
+import { removeFolder } from "./utils";
+import { outputDir } from "./pepr-build-wasm";
 // Unmock unit test things
 jest.deepUnmock("pino");
 
@@ -20,7 +21,9 @@ jest.setTimeout(1000 * 60 * 5);
 
 // Configure the test environment before running the tests
 beforeAll(before);
-
+afterAll(async () => {
+  await removeFolder(outputDir);
+});
 describe("Journey: `npx pepr init`", peprInit);
 
 describe("Journey: `npx pepr format`", peprFormat);

--- a/journey/utils.ts
+++ b/journey/utils.ts
@@ -11,20 +11,8 @@ export async function removeFolder(folderPath: string): Promise<void> {
   const dir = resolve(folderPath);
 
   try {
-    const stats = await fs.lstat(folderPath);
-
-    if (stats.isDirectory()) {
-      const files = await fs.readdir(folderPath);
-
-      for (const file of files) {
-        const fullPath = join(folderPath, file);
-        await removeFolder(fullPath);
-      }
-
-      await fs.rmdir(folderPath);
-    } else {
-      await fs.unlink(folderPath);
-    }
+    await fs.access(dir);
+    await fs.rm(dir, { recursive: true, force: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       // Folder is not there, do nothing

--- a/journey/utils.ts
+++ b/journey/utils.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+import { promises as fs } from "fs";
+import { resolve, join } from "path";
+
+/**
+ * Removes a folder and all its contents recursively.
+ * @param folderPath - The path to the folder to remove.
+ */
+export async function removeFolder(folderPath: string): Promise<void> {
+  const dir = resolve(folderPath);
+
+  try {
+    const stats = await fs.lstat(folderPath);
+
+    if (stats.isDirectory()) {
+      const files = await fs.readdir(folderPath);
+
+      for (const file of files) {
+        const fullPath = join(folderPath, file);
+        await removeFolder(fullPath);
+      }
+
+      await fs.rmdir(folderPath);
+    } else {
+      await fs.unlink(folderPath);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      // Folder is not there, do nothing
+    } else {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Description

When running `npm test` the `pepr-test-module` is created with journey tests are run on module. This is a common place to test new features in the controller. However, there was legacy folders being left in the `dist` folder after the test ended. This PR cleans up the legacy folders that are no longer needed after the test ends and not relevant for controller testing. 

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1361 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
