### PR TITLE
chore: update subscribers every second

### DIFF
--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -12,7 +12,7 @@ import { DataOp, DataSender, DataStore, Storage } from "../storage";
 import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
 
 const namespace = "pepr-system";
-export const debounceBackoff = 5000;
+export const debounceBackoff = 1000;
 
 export class StoreController {
   #name: string;


### PR DESCRIPTION
## Description

Pepr watches `PeprStore` resources for updates around keys/values and consumes them through the `Store`. This update send updates to the store subscribers every second after the watch event. 

## Related Issue

Fixes #1480 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
