### PR TITLE
chore: store adjudicator code in adjudicators/

### DIFF
--- a/src/lib/filter/adjudicators/adjudicators.test.ts
+++ b/src/lib/filter/adjudicators/adjudicators.test.ts
@@ -22,14 +22,9 @@ import {
   uncarryableNamespace,
 } from "./adjudicators";
 import { KubernetesObject } from "kubernetes-fluent-client";
-import { AdmissionRequest, Binding, DeepPartial } from "../types";
-import { Event, Operation } from "../enums";
-import {
-  defaultAdmissionRequest,
-  defaultBinding,
-  defaultFilters,
-  defaultKubernetesObject,
-} from "./adjudicators/defaultTestObjects";
+import { AdmissionRequest, Binding, DeepPartial } from "../../types";
+import { Event, Operation } from "../../enums";
+import { defaultAdmissionRequest, defaultBinding, defaultFilters, defaultKubernetesObject } from "./defaultTestObjects";
 
 describe("mismatchedName", () => {
   //[ Binding, KubernetesObject, result ]

--- a/src/lib/filter/adjudicators/adjudicators.ts
+++ b/src/lib/filter/adjudicators/adjudicators.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { Event, Operation } from "../enums";
-import { AdmissionRequest, Binding } from "../../lib/types";
+import { Event, Operation } from "../../enums";
+import { AdmissionRequest, Binding } from "../../types";
 import {
   __,
   allPass,

--- a/src/lib/filter/adjudicators/bindingAdjudicators.test.ts
+++ b/src/lib/filter/adjudicators/bindingAdjudicators.test.ts
@@ -44,7 +44,7 @@ import {
   misboundDeleteWithDeletionTimestamp,
   misboundNamespace,
   missingName,
-} from "../adjudicators";
+} from "./adjudicators";
 import { defaultBinding, defaultFilters, defaultKubernetesObject } from "./defaultTestObjects";
 
 describe("definesDeletionTimestamp", () => {

--- a/src/lib/filter/adjudicators/bindingKubernetesObjectAdjudicators.test.ts
+++ b/src/lib/filter/adjudicators/bindingKubernetesObjectAdjudicators.test.ts
@@ -13,7 +13,7 @@ import {
   mismatchedAnnotations,
   mismatchedLabels,
   metasMismatch,
-} from "../adjudicators";
+} from "./adjudicators";
 import { defaultBinding, defaultFilters, defaultKubernetesObject } from "./defaultTestObjects";
 
 describe("mismatchedName", () => {

--- a/src/lib/filter/adjudicators/requestAdjudicators.test.ts
+++ b/src/lib/filter/adjudicators/requestAdjudicators.test.ts
@@ -5,7 +5,7 @@ import { expect, describe, it } from "@jest/globals";
 import { Operation } from "../../enums";
 import { AdmissionRequest } from "../../types";
 import { defaultAdmissionRequest } from "./defaultTestObjects";
-import { declaredUid, declaredKind, declaredVersion, declaredGroup, declaredOperation } from "../adjudicators";
+import { declaredUid, declaredKind, declaredVersion, declaredGroup, declaredOperation } from "./adjudicators";
 
 describe("declaredUid", () => {
   //[ AdmissionRequest, result ]

--- a/src/lib/filter/filter.ts
+++ b/src/lib/filter/filter.ts
@@ -38,7 +38,7 @@ import {
   missingCarriableNamespace,
   unbindableNamespaces,
   uncarryableNamespace,
-} from "./adjudicators";
+} from "./adjudicators/adjudicators";
 
 /**
  * shouldSkipRequest determines if a request should be skipped based on the binding filters.

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -28,7 +28,7 @@ import {
   missingCarriableNamespace,
   unbindableNamespaces,
   uncarryableNamespace,
-} from "./filter/adjudicators";
+} from "./filter/adjudicators/adjudicators";
 
 export function matchesRegex(pattern: string, testString: string): boolean {
   return new RegExp(pattern).test(testString);


### PR DESCRIPTION
## Description

This PR moves adjudicator files to the `adjudicators/` directory.

## Related Issue

None, this is a one-off PR to relocate files.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
