### PR TITLE
chore: reduce verbosity of logs by eliminating for metric and health

### DIFF
--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -263,6 +263,11 @@ export class Controller {
     const startTime = Date.now();
 
     res.on("finish", () => {
+      const excludedRoutes = ["/healthz", "/metrics"];
+      if (excludedRoutes.includes(req.originalUrl)) {
+        return;
+      }
+
       const elapsedTime = Date.now() - startTime;
       const message = {
         uid: req.body?.request?.uid,


### PR DESCRIPTION
…heck logs

## Description

Anytime I am looking through the Pepr logs to try and find relevant information i find they are polluted with thousands of healthcheck and metric logs. It makes it extremely difficult to find the relevant pieces of information without using specific greps or jq. With that being said, the healthcheck log does not provide any information that is helpful for debugging, neither does the metric log


## Related Issue

Fixes #1518 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
