### PR TITLE
chore: complexity of monitor

### DIFF
--- a/src/cli/monitor.test.ts
+++ b/src/cli/monitor.test.ts
@@ -1,9 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, describe, it, jest } from "@jest/globals";
-import { getLabelsAndErrorMessage, getK8sLogFromKubeConfig } from "./monitor";
+import { expect, describe, it, jest, beforeEach, afterEach } from "@jest/globals";
+import {
+  getLabelsAndErrorMessage,
+  getK8sLogFromKubeConfig,
+  processMutateLog,
+  processValidateLog,
+} from "./monitor";
 import { KubeConfig, Log as K8sLog } from "@kubernetes/client-node";
+import { SpiedFunction } from "jest-mock";
+
+const payload = {
+  level: 30,
+  time: 1733751945893,
+  pid: 1,
+  hostname: "test-host",
+  uid: "test-uid",
+  namespace: "test-namespace",
+  name: "test-name",
+  res: {
+    allowed: true,
+    uid: "test-uid",
+    patch: btoa(JSON.stringify({ key: "value" })),
+    patchType: "test-patch-type",
+    warning: "test-warning",
+    status: { message: "test-message" },
+  },
+  msg: "Check response",
+};
 
 jest.mock("@kubernetes/client-node", () => {
   const mockKubeConfig = jest.fn();
@@ -45,5 +70,98 @@ describe("getLabelsAndErrorMessage", () => {
   ])("should return labels and error message", (uuid, expected) => {
     const result = getLabelsAndErrorMessage(uuid);
     expect(result).toEqual(expected);
+  });
+});
+
+describe("processMutateLog", () => {
+  let consoleLogSpy: SpiedFunction<{
+    (...data: unknown[]): void;
+    (message?: unknown, ...optionalParams: unknown[]): void;
+  }>;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should log a mutation approval with patch details", () => {
+    processMutateLog(
+      {
+        ...payload,
+        res: {
+          ...payload.res,
+          patch: btoa(JSON.stringify({ key: "value" })),
+          patchType: "JSONPatch",
+        },
+      },
+      "test-name",
+      "test-uid",
+    );
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("\n🔀  MUTATE     test-name (test-uid)");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining(JSON.stringify({ key: "value" }, null, 2)),
+    );
+  });
+
+  it("should log a mutation denial without patch details", () => {
+    processMutateLog(
+      {
+        ...payload,
+        res: {
+          ...payload.res,
+          allowed: false,
+          patch: btoa(JSON.stringify("something")),
+        },
+      },
+      "test-name",
+      "test-uid",
+    );
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("\n🚫  MUTATE     test-name (test-uid)");
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringContaining("{"));
+  });
+});
+
+describe("processValidateLog", () => {
+  let consoleLogSpy: SpiedFunction<{
+    (...data: unknown[]): void;
+    (message?: unknown, ...optionalParams: unknown[]): void;
+  }>;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should log a successful validation", () => {
+    processValidateLog(payload, "test-name", "test-uid");
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("\n✅  VALIDATE   test-name (test-uid)");
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringContaining("❌"));
+  });
+
+  it("should log a validation failure with error messages", () => {
+    processValidateLog(
+      {
+        ...payload,
+        res: {
+          ...payload.res,
+          allowed: false,
+          status: { message: "Failure message 1" },
+        },
+      },
+      "test-name",
+      "test-uid",
+    );
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("\n❌  VALIDATE   test-name (test-uid)");
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Failure message 1"));
   });
 });

--- a/src/cli/monitor.test.ts
+++ b/src/cli/monitor.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { expect, describe, it, jest } from "@jest/globals";
+import { getLabelsAndErrorMessage, getK8sLogFromKubeConfig } from "./monitor";
+import { KubeConfig, Log as K8sLog } from "@kubernetes/client-node";
+
+jest.mock("@kubernetes/client-node", () => {
+  const mockKubeConfig = jest.fn();
+  mockKubeConfig.prototype.loadFromDefault = jest.fn();
+  const mockK8sLog = jest.fn();
+
+  return {
+    KubeConfig: mockKubeConfig,
+    Log: mockK8sLog,
+  };
+});
+
+describe("getK8sLogFromKubeConfig", () => {
+  it("should create a K8sLog instance from the default KubeConfig", () => {
+    const result = getK8sLogFromKubeConfig();
+    expect(KubeConfig).toHaveBeenCalledTimes(1);
+    expect(KubeConfig.prototype.loadFromDefault).toHaveBeenCalledTimes(1);
+
+    const kubeConfigInstance = new KubeConfig();
+    expect(K8sLog).toHaveBeenCalledWith(kubeConfigInstance);
+
+    expect(result).toBeInstanceOf(K8sLog);
+  });
+});
+
+describe("getLabelsAndErrorMessage", () => {
+  it.each([
+    [
+      undefined,
+      {
+        labels: ["pepr.dev/controller", "admission"],
+        errorMessage: "No pods found with admission labels",
+      },
+    ],
+    ["test", { labels: ["app", "pepr-test"], errorMessage: "No pods found for module test" }],
+    ["test2", { labels: ["app", "pepr-test2"], errorMessage: "No pods found for module test2" }],
+    ["test3", { labels: ["app", "pepr-test3"], errorMessage: "No pods found for module test3" }],
+    ["test4", { labels: ["app", "pepr-test4"], errorMessage: "No pods found for module test4" }],
+  ])("should return labels and error message", (uuid, expected) => {
+    const result = getLabelsAndErrorMessage(uuid);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -1,92 +1,51 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { Log as K8sLog, KubeConfig } from "@kubernetes/client-node";
+import { Log as K8sLog, KubeConfig, KubernetesListObject } from "@kubernetes/client-node";
 import { K8s, kind } from "kubernetes-fluent-client";
 import stream from "stream";
 import { ResponseItem } from "../lib/types";
 import { RootCmd } from "./root";
 
-export default function (program: RootCmd) {
+interface LogPayload {
+  namespace: string;
+  name: string;
+  res: {
+    uid: string;
+    allowed?: boolean;
+    patch?: string;
+    patchType?: string;
+    warnings?: string;
+    status?: {
+      message: string;
+    };
+  };
+}
+
+export default function (program: RootCmd): void {
   program
     .command("monitor [module-uuid]")
     .description("Monitor a Pepr Module")
     .action(async uuid => {
-      let labels: string[];
-      let errorMessage: string;
-
-      if (!uuid) {
-        labels = ["pepr.dev/controller", "admission"];
-        errorMessage = `No pods found with admission labels`;
-      } else {
-        labels = ["app", `pepr-${uuid}`];
-        errorMessage = `No pods found for module ${uuid}`;
-      }
+      const { labels, errorMessage } = getLabelsAndErrorMessage(uuid);
 
       // Get the logs for the `app=pepr-${module}` or `pepr.dev/controller=admission` pod selector
-      const pods = await K8s(kind.Pod)
+      const pods: KubernetesListObject<kind.Pod> = await K8s(kind.Pod)
         .InNamespace("pepr-system")
         .WithLabel(labels[0], labels[1])
         .Get();
 
-      const podNames = pods.items.flatMap(pod => pod.metadata!.name) as string[];
+      // Pods will ways have a metadata and name fields
+      const podNames: string[] = pods.items.flatMap(pod => pod.metadata!.name || "");
 
       if (podNames.length < 1) {
         console.error(errorMessage);
         process.exit(1);
       }
 
-      const kc = new KubeConfig();
-      kc.loadFromDefault();
+      const log = getK8sLogFromKubeConfig();
 
-      const log = new K8sLog(kc);
-
-      const logStream = new stream.PassThrough();
-      logStream.on("data", async chunk => {
-        const respMsg = `"msg":"Check response"`;
-        // Split the chunk into lines
-        const lines = await chunk.toString().split("\n");
-
-        for (const line of lines) {
-          // Check for `"msg":"Hello Pepr"`
-          if (!line.includes(respMsg)) continue;
-          try {
-            const payload = JSON.parse(line.trim());
-            const isMutate = payload.res.patchType || payload.res.warnings;
-
-            const name = `${payload.namespace}${payload.name}`;
-            const uid = payload.res.uid;
-
-            if (isMutate) {
-              const plainPatch =
-                payload.res?.patch !== undefined && payload.res?.patch !== null
-                  ? atob(payload.res.patch)
-                  : "";
-
-              const patch = plainPatch !== "" && JSON.stringify(JSON.parse(plainPatch), null, 2);
-              const patchType = payload.res.patchType || payload.res.warnings || "";
-              const allowOrDeny = payload.res.allowed ? "🔀" : "🚫";
-              console.log(`\n${allowOrDeny}  MUTATE     ${name} (${uid})`);
-              patchType.length > 0 && console.log(`\n\u001b[1;34m${patch}\u001b[0m`);
-            } else {
-              const failures = Array.isArray(payload.res) ? payload.res : [payload.res];
-
-              const filteredFailures = failures
-                .filter((r: ResponseItem) => !r.allowed)
-                .map((r: ResponseItem) => r.status.message);
-
-              console.log(
-                `\n${filteredFailures.length > 0 ? "❌" : "✅"}  VALIDATE   ${name} (${uid})`,
-              );
-              console.log(
-                filteredFailures.length > 0 ? `\u001b[1;31m${filteredFailures}\u001b[0m` : "",
-              );
-            }
-          } catch {
-            // Do nothing
-          }
-        }
-      });
+      const logStream = createLogStream();
 
       for (const podName of podNames) {
         await log.log("pepr-system", podName, "server", logStream, {
@@ -96,4 +55,88 @@ export default function (program: RootCmd) {
         });
       }
     });
+}
+
+export function getLabelsAndErrorMessage(uuid?: string): {
+  labels: string[];
+  errorMessage: string;
+} {
+  let labels: string[];
+  let errorMessage: string;
+
+  if (!uuid) {
+    labels = ["pepr.dev/controller", "admission"];
+    errorMessage = `No pods found with admission labels`;
+  } else {
+    labels = ["app", `pepr-${uuid}`];
+    errorMessage = `No pods found for module ${uuid}`;
+  }
+
+  return { labels, errorMessage };
+}
+
+export function getK8sLogFromKubeConfig(): K8sLog {
+  const kc = new KubeConfig();
+  kc.loadFromDefault();
+  return new K8sLog(kc);
+}
+
+export function createLogStream(): stream.PassThrough {
+  const logStream = new stream.PassThrough();
+
+  logStream.on("data", async chunk => {
+    const lines = chunk.toString().split("\n");
+    const respMsg = `"msg":"Check response"`;
+
+    for (const line of lines) {
+      if (!line.includes(respMsg)) continue;
+      processLogLine(line);
+    }
+  });
+
+  return logStream;
+}
+
+export function processLogLine(line: string): void {
+  try {
+    const payload: LogPayload = JSON.parse(line.trim());
+    const isMutate = payload.res.patchType || payload.res.warnings;
+    const name = `${payload.namespace}${payload.name}`;
+    const uid = payload.res.uid;
+
+    if (isMutate) {
+      processMutateLog(payload, name, uid);
+    } else {
+      processValidateLog(payload, name, uid);
+    }
+  } catch {
+    // Do nothing
+  }
+}
+
+export function processMutateLog(payload: LogPayload, name: string, uid: string): void {
+  const plainPatch =
+    payload.res.patch !== undefined && payload.res.patch !== null ? atob(payload.res.patch) : "";
+
+  const patch = plainPatch !== "" && JSON.stringify(JSON.parse(plainPatch), null, 2);
+  const patchType = payload.res.patchType || payload.res.warnings || "";
+  const allowOrDeny = payload.res.allowed ? "🔀" : "🚫";
+
+  console.log(`\n${allowOrDeny}  MUTATE     ${name} (${uid})`);
+  if (patchType.length > 0) {
+    console.log(`\n\u001b[1;34m${patch}\u001b[0m`);
+  }
+}
+
+export function processValidateLog(payload: LogPayload, name: string, uid: string): void {
+  const failures = Array.isArray(payload.res) ? payload.res : [payload.res];
+
+  const filteredFailures = failures
+    .filter((r: ResponseItem) => !r.allowed)
+    .map((r: ResponseItem) => r.status?.message || "");
+
+  console.log(`\n${filteredFailures.length > 0 ? "❌" : "✅"}  VALIDATE   ${name} (${uid})`);
+  if (filteredFailures.length > 0) {
+    console.log(`\u001b[1;31m${filteredFailures}\u001b[0m`);
+  }
 }

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -81,7 +81,7 @@ export function getK8sLogFromKubeConfig(): K8sLog {
   return new K8sLog(kc);
 }
 
-export function createLogStream(): stream.PassThrough {
+function createLogStream(): stream.PassThrough {
   const logStream = new stream.PassThrough();
 
   logStream.on("data", async chunk => {
@@ -97,7 +97,7 @@ export function createLogStream(): stream.PassThrough {
   return logStream;
 }
 
-export function processLogLine(line: string): void {
+function processLogLine(line: string): void {
   try {
     const payload: LogPayload = JSON.parse(line.trim());
     const isMutate = payload.res.patchType || payload.res.warnings;


### PR DESCRIPTION
## Description

Reduces the complexity of `npx pepr monitor`, adds _some_ unit tests, got as much coverage as I could, other than that it works the same 

```bash
> npx ts-node src/cli.ts monitor 

🔀  MUTATE     pepr-demo/pepr-demo (2df33bcb-dcc8-4579-9239-5046f748173b)

[
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  },
  {
    "op": "remove",
    "path": "/metadata/labels/remove-me"
  }
]

🔀  MUTATE     pepr-demo/kube-root-ca.crt (ce9bcbe1-b2aa-4b6d-bc50-0b8c711c512b)

🔀  MUTATE     pepr-demo-2/pepr-demo-2 (ad47c30d-b4e3-49fd-ae6c-d931358e3b32)

[
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  }
]

🔀  MUTATE     pepr-demo/secret-1 (52f20119-13cd-473b-b28d-46ac61113ca2)

[
  {
    "op": "replace",
    "path": "/data/example",
    "value": "dW5pY29ybiBtYWdpYyAtIG1vZGlmaWVkIGJ5IFBlcHI="
  },
  {
    "op": "add",
    "path": "/data/magic",
    "value": "Y2hhbmdlLXdpdGhvdXQtZW5jb2Rpbmc="
  },
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  }
]

🔀  MUTATE     pepr-demo-2/pepr-ssa-demo (6cd0af90-d77f-4859-b141-605dc36a3375)

🔀  MUTATE     pepr-demo-2/kube-root-ca.crt (e3add4bb-c028-474d-91df-607b92d52971)

🔀  MUTATE     pepr-demo/example-1 (0771353d-969f-4868-bdaf-5f2d32b48190)

[
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  },
  {
    "op": "add",
    "path": "/metadata/annotations/pepr.dev",
    "value": "annotations-work-too"
  },
  {
    "op": "add",
    "path": "/metadata/labels",
    "value": {
      "pepr": "was-here"
    }
  }
]

🔀  MUTATE     pepr-demo/example-2 (2ad5718d-3693-412c-91c8-98288c9e5e2d)

[
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  },
  {
    "op": "add",
    "path": "/metadata/annotations/pepr.dev",
    "value": "annotations-work-too"
  },
  {
    "op": "add",
    "path": "/metadata/labels",
    "value": {
      "pepr": "was-here"
    }
  }
]

🔀  MUTATE     pepr-demo/example-evil-cm (13e5b5c2-a411-4f6c-9698-ae3251676aef)

🔀  MUTATE     pepr-demo/example-3 (02ec1498-2449-4844-9ed0-7f1b400baef7)

[
  {
    "op": "add",
    "path": "/data/username",
    "value": "system:admin"
  },
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  },
  {
    "op": "add",
    "path": "/metadata/annotations/pepr.dev",
    "value": "making-waves"
  }
]

🔀  MUTATE     pepr-demo/example-4 (bc436d1c-86b2-408b-9ff4-ffcdf4528f7b)

[
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  },
  {
    "op": "add",
    "path": "/metadata/labels",
    "value": {
      "pepr.dev/first": "true",
      "pepr.dev/second": "true",
      "pepr.dev/third": "true"
    }
  }
]

🔀  MUTATE     pepr-demo-2/example-4a (4811a195-73e0-4c2d-a4c6-c0a50bce1af1)

[
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  },
  {
    "op": "add",
    "path": "/metadata/labels",
    "value": {
      "pepr.dev/first": "true",
      "pepr.dev/second": "true",
      "pepr.dev/third": "true"
    }
  }
]

🔀  MUTATE     pepr-demo/example-5 (46d0657c-9a5a-47c3-9c3e-49d6d81cb141)

[
  {
    "op": "add",
    "path": "/data/chuck-says",
    "value": "No one has ever spoken during review of Chuck Norris' code and lived to tell about it."
  },
  {
    "op": "add",
    "path": "/metadata/annotations/3b1b7ed6-88f6-54ec-9ae0-0dcc8a432456.pepr.dev~1upgrade-test",
    "value": "succeeded"
  }
]

✅  VALIDATE   pepr-demo/kube-root-ca.crt (742c156f-6d1a-459c-9dbe-40defb9a4b18)

✅  VALIDATE   pepr-demo-2/pepr-ssa-demo (d3ab073f-2789-4324-abd9-2fc7bb9aa552)

✅  VALIDATE   pepr-demo-2/kube-root-ca.crt (6d21adab-cafd-4a85-8c1f-827f5adb1049)

✅  VALIDATE   pepr-demo/example-1 (37926781-6c5c-4641-98cf-eb855fc19e9d)

✅  VALIDATE   pepr-demo/example-2 (34dd49fb-dbfe-4130-a8ba-45d10cb4223b)

✅  VALIDATE   pepr-demo/example-2 (34dd49fb-dbfe-4130-a8ba-45d10cb4223b)

❌  VALIDATE   pepr-demo/example-evil-cm (fb63c6ed-822d-418b-acb7-9a43f1ec9b59)
No evil CM annotations allowed.

✅  VALIDATE   pepr-demo/example-3 (ca76fd37-1548-41a6-968e-463ca759c8e9)

✅  VALIDATE   pepr-demo/example-4 (814d9145-f499-441b-9fa7-b36db3069e83)

✅  VALIDATE   pepr-demo-2/example-4a (583882a3-fb0b-4185-beca-fa1c8bd8ccc7)

✅  VALIDATE   pepr-demo/example-5 (900e65d8-530e-47a1-8f06-79fb448eedde)
```

## Related Issue

Fixes #1537 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
