### PR TITLE
refactor: resolve eslint warnings (max-depth, complexity) - src/lib/mutate-processor.ts

### DIFF
--- a/src/lib/mutate-processor.test.ts
+++ b/src/lib/mutate-processor.test.ts
@@ -6,9 +6,12 @@ import { clone } from "ramda";
 import { ModuleConfig } from "./module";
 import { PeprMutateRequest } from "./mutate-request";
 import * as sut from "./mutate-processor";
-import { AdmissionRequest } from "./types";
-import { Operation } from "./enums";
+import { AdmissionRequest, Binding, MutateAction } from "./types";
+import { Event, Operation } from "./enums";
 import { convertFromBase64Map, convertToBase64Map } from "./utils";
+import { GenericClass, KubernetesObject } from "kubernetes-fluent-client";
+import { MutateResponse } from "./k8s";
+import { Errors } from "./errors";
 
 jest.mock("./utils");
 const mockConvertFromBase64Map = jest.mocked(convertFromBase64Map);
@@ -194,5 +197,114 @@ describe("unskipRecode", () => {
     expect(mockConvertToBase64Map.mock.calls[0].at(0)).toEqual(testPeprMutateRequest.Raw);
     expect(mockConvertToBase64Map.mock.calls[0].at(1)).toBe(skipped);
     expect(transformed).toEqual(testPeprMutateRequest.Raw);
+  });
+});
+
+const defaultBinding: Binding = {
+  event: Event.CREATE,
+  model: {} as GenericClass,
+  kind: {
+    kind: "kind",
+    group: "group",
+    version: "version",
+  },
+  filters: {
+    annotations: {},
+    deletionTimestamp: false,
+    labels: {},
+    name: "",
+    namespaces: [],
+    regexName: "",
+    regexNamespaces: [],
+  },
+  mutateCallback: jest.fn() as jest.Mocked<MutateAction<GenericClass, KubernetesObject>>,
+};
+
+const defaultBindable: sut.Bindable = {
+  req: defaultAdmissionRequest,
+  config: defaultModuleConfig,
+  name: "test-name",
+  namespaces: [],
+  binding: defaultBinding,
+  actMeta: {},
+};
+
+const defaultMutateResponse: MutateResponse = {
+  uid: "default-uid",
+  allowed: true,
+};
+
+describe("processRequest", () => {
+  it("adds a status annotation on success", async () => {
+    const testPeprMutateRequest = defaultPeprMutateRequest();
+    const testMutateResponse = clone(defaultMutateResponse);
+    const annote = `${defaultModuleConfig.uuid}.pepr.dev/${defaultBindable.name}`;
+
+    const result = await sut.processRequest(defaultBindable, testPeprMutateRequest, testMutateResponse);
+
+    expect(result).toEqual({ wrapped: testPeprMutateRequest, response: testMutateResponse });
+    expect(result.wrapped.Raw.metadata?.annotations).toBeDefined();
+    expect(result.wrapped.Raw.metadata!.annotations![annote]).toBe("succeeded");
+
+    expect(result.response.warnings).toBeUndefined();
+    expect(result.response.result).toBeUndefined();
+    expect(result.response.auditAnnotations).toBeUndefined();
+  });
+
+  it("adds a status annotation, warning, and result on failure when Errors.reject", async () => {
+    const mutateCallback = (jest.fn() as jest.Mocked<MutateAction<GenericClass, KubernetesObject>>).mockImplementation(
+      () => {
+        throw "oof";
+      },
+    );
+    const testBinding = { ...clone(defaultBinding), mutateCallback };
+    const testBindable = { ...clone(defaultBindable), binding: testBinding };
+    testBindable.config.onError = Errors.reject;
+    const testPeprMutateRequest = defaultPeprMutateRequest();
+    const testMutateResponse = clone(defaultMutateResponse);
+    const annote = `${defaultModuleConfig.uuid}.pepr.dev/${defaultBindable.name}`;
+
+    const result = await sut.processRequest(testBindable, testPeprMutateRequest, testMutateResponse);
+
+    expect(result).toEqual({ wrapped: testPeprMutateRequest, response: testMutateResponse });
+    expect(result.wrapped.Raw.metadata?.annotations).toBeDefined();
+    expect(result.wrapped.Raw.metadata!.annotations![annote]).toBe("warning");
+
+    expect(result.response.warnings).toHaveLength(1);
+    expect(result.response.warnings![0]).toBe("Action failed: An error occurred with the mutate action.");
+    expect(result.response.result).toBe("Pepr module configured to reject on error");
+    expect(result.response.auditAnnotations).toBeUndefined();
+  });
+
+  it("adds a status annotation, warning, and auditAnnotation on failure when Errors.audit", async () => {
+    const mutateCallback = (jest.fn() as jest.Mocked<MutateAction<GenericClass, KubernetesObject>>).mockImplementation(
+      () => {
+        throw "oof";
+      },
+    );
+    const testBinding = { ...clone(defaultBinding), mutateCallback };
+    const testBindable = { ...clone(defaultBindable), binding: testBinding };
+    testBindable.config.onError = Errors.audit;
+    const testPeprMutateRequest = defaultPeprMutateRequest();
+    const testMutateResponse = clone(defaultMutateResponse);
+    const annote = `${defaultModuleConfig.uuid}.pepr.dev/${defaultBindable.name}`;
+
+    const result = await sut.processRequest(testBindable, testPeprMutateRequest, testMutateResponse);
+
+    expect(result).toEqual({ wrapped: testPeprMutateRequest, response: testMutateResponse });
+    expect(result.wrapped.Raw.metadata?.annotations).toBeDefined();
+    expect(result.wrapped.Raw.metadata!.annotations![annote]).toBe("warning");
+
+    expect(result.response.warnings).toHaveLength(1);
+    expect(result.response.warnings![0]).toBe("Action failed: An error occurred with the mutate action.");
+    expect(result.response.result).toBeUndefined();
+    expect(result.response.auditAnnotations).toBeDefined();
+
+    const auditAnnotes = Object.entries(result.response.auditAnnotations!);
+    expect(auditAnnotes).toHaveLength(1);
+
+    const [key, val] = auditAnnotes[0];
+    expect(Date.now() - parseInt(key)).toBeLessThan(5);
+    expect(val).toBe("Action failed: An error occurred with the mutate action.");
   });
 });

--- a/src/lib/mutate-processor.test.ts
+++ b/src/lib/mutate-processor.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-// import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 // import { GroupVersionKind, kind, KubernetesObject } from "kubernetes-fluent-client";
 // import { AdmissionRequest, Binding, Filters } from "./types";
 // import { Event, Operation } from "./enums";
@@ -50,6 +50,18 @@
 
 // export const testPeprValidateRequest = (admissionRequest: AdmissionRequest) =>
 //   new PeprValidateRequest<KubernetesObject>(admissionRequest);
+
+describe("updateStatus", () => {
+  it("does...", () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe("logMutateErrorMessage", () => {
+  it("does...", () => {
+    expect(true).toBe(true);
+  });
+});
 
 // describe("processRequest", () => {
 //   let binding: Binding;

--- a/src/lib/mutate-processor.test.ts
+++ b/src/lib/mutate-processor.test.ts
@@ -2,114 +2,70 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { describe, expect, it } from "@jest/globals";
-// import { GroupVersionKind, kind, KubernetesObject } from "kubernetes-fluent-client";
-// import { AdmissionRequest, Binding, Filters } from "./types";
-// import { Event, Operation } from "./enums";
-// import { PeprValidateRequest } from "./validate-request";
-// import { clone } from "ramda";
-// import * as sut from "./mutate-processor";
+import { clone } from "ramda";
+import { ModuleConfig } from "./module";
+import { PeprMutateRequest } from "./mutate-request";
+import * as sut from "./mutate-processor";
+import { AdmissionRequest } from "./types";
+import { Operation } from "./enums";
 
-// const testFilters: Filters = {
-//   annotations: {},
-//   deletionTimestamp: false,
-//   labels: {},
-//   name: "",
-//   namespaces: [],
-//   regexName: "^default$",
-//   regexNamespaces: [] as string[],
-// };
+const defaultModuleConfig: ModuleConfig = {
+  uuid: "test-uuid",
+  alwaysIgnore: {},
+};
 
-// const testGroupVersionKind: GroupVersionKind = {
-//   kind: "some-kind",
-//   group: "some-group",
-// };
+const defaultAdmissionRequest: AdmissionRequest = {
+  uid: "uid",
+  kind: {
+    kind: "kind",
+    group: "group",
+  },
+  resource: {
+    group: "group",
+    version: "version",
+    resource: "resource",
+  },
+  name: "",
+  object: {},
+  operation: Operation.CREATE,
+  userInfo: {},
+};
 
-// const testBinding: Binding = {
-//   event: Event.ANY,
-//   filters: testFilters,
-//   kind: testGroupVersionKind,
-//   model: kind.Pod,
-//   isFinalize: false,
-//   isMutate: false,
-//   isQueue: false,
-//   isValidate: false,
-//   isWatch: false,
-// };
-
-// export const testAdmissionRequest: AdmissionRequest = {
-//   uid: "some-uid",
-//   kind: { kind: "a-kind", group: "a-group" },
-//   resource: { group: "some-group", version: "some-version", resource: "some-resource" },
-//   operation: Operation.CONNECT,
-//   name: "some-name",
-//   userInfo: {},
-//   object: {},
-// };
-
-// export const testActionMetadata: Record<string, string> = {};
-
-// export const testPeprValidateRequest = (admissionRequest: AdmissionRequest) =>
-//   new PeprValidateRequest<KubernetesObject>(admissionRequest);
+const defaultPeprMutateRequest = (admissionRequest = defaultAdmissionRequest) =>
+  new PeprMutateRequest(admissionRequest);
 
 describe("updateStatus", () => {
-  it("does...", () => {
-    expect(true).toBe(true);
+  describe("when given non-delete request", () => {
+    it("adds status annotation to to-be-admitted resource", () => {
+      const name = "capa";
+      const status = "test-status";
+      const annote = `${defaultModuleConfig.uuid}.pepr.dev/${name}`;
+
+      const result = sut.updateStatus(defaultModuleConfig, name, defaultPeprMutateRequest(), status);
+
+      expect(result.HasAnnotation(annote)).toBe(true);
+      expect(result.Raw.metadata?.annotations?.[annote]).toBe(status);
+    });
+  });
+
+  describe("when given delete request", () => {
+    it("does not add status annotation to to-be-admitted resource", () => {
+      const testAdmissionRequest = {
+        ...clone(defaultAdmissionRequest),
+        operation: Operation.DELETE,
+        oldObject: {},
+      };
+      const name = "capa";
+      const annote = `${defaultModuleConfig.uuid}.pepr.dev/${name}`;
+
+      const result = sut.updateStatus(
+        defaultModuleConfig,
+        name,
+        defaultPeprMutateRequest(testAdmissionRequest),
+        "test-status",
+      );
+
+      expect(result.HasAnnotation(annote)).toBe(false);
+    });
   });
 });
-
-describe("logMutateErrorMessage", () => {
-  it("does...", () => {
-    expect(true).toBe(true);
-  });
-});
-
-// describe("processRequest", () => {
-//   let binding: Binding;
-//   let actionMetadata: Record<string, string>;
-//   let peprValidateRequest: PeprValidateRequest<KubernetesObject>;
-
-//   beforeEach(() => {
-//     binding = clone(testBinding);
-//     actionMetadata = clone(testActionMetadata);
-//     peprValidateRequest = testPeprValidateRequest(testAdmissionRequest);
-//   });
-
-//   it("responds on successful validation action", async () => {
-//     const cbResult = {
-//       allowed: true,
-//       statusCode: 200,
-//       statusMessage: "yay",
-//     };
-//     const callback = jest.fn().mockImplementation(() => cbResult) as Binding["validateCallback"];
-//     binding = { ...clone(testBinding), validateCallback: callback };
-
-//     const result = await sut.processRequest(binding, actionMetadata, peprValidateRequest);
-
-//     expect(result).toEqual({
-//       uid: peprValidateRequest.Request.uid,
-//       allowed: cbResult.allowed,
-//       status: {
-//         code: cbResult.statusCode,
-//         message: cbResult.statusMessage,
-//       },
-//     });
-//   });
-
-//   it("responds on unsuccessful validation action", async () => {
-//     const callback = jest.fn().mockImplementation(() => {
-//       throw "oof";
-//     }) as Binding["validateCallback"];
-//     binding = { ...clone(testBinding), validateCallback: callback };
-
-//     const result = await sut.processRequest(binding, actionMetadata, peprValidateRequest);
-
-//     expect(result).toEqual({
-//       uid: peprValidateRequest.Request.uid,
-//       allowed: false,
-//       status: {
-//         code: 500,
-//         message: `Action failed with error: "oof"`,
-//       },
-//     });
-//   });
-// });

--- a/src/lib/mutate-processor.test.ts
+++ b/src/lib/mutate-processor.test.ts
@@ -69,3 +69,15 @@ describe("updateStatus", () => {
     });
   });
 });
+
+describe("logMutateErrorMessage", () => {
+  it.each([
+    // error msg, result string
+    ["oof", "oof"],
+    ["", "An error occurred with the mutate action."],
+    ["[object Object]", "An error occurred with the mutate action."],
+  ])("given error '%s', returns '%s'", (err, res) => {
+    const result = sut.logMutateErrorMessage(new Error(err));
+    expect(result).toBe(res);
+  });
+});

--- a/src/lib/mutate-processor.test.ts
+++ b/src/lib/mutate-processor.test.ts
@@ -117,7 +117,7 @@ describe("decodeData", () => {
     };
     const testPeprMutateRequest = defaultPeprMutateRequest(testAdmissionRequest);
 
-    const [skipped, wrapped] = sut.decodeData(testPeprMutateRequest);
+    const { skipped, wrapped } = sut.decodeData(testPeprMutateRequest);
 
     expect(mockConvertFromBase64Map.mock.calls.length).toBe(1);
     expect(mockConvertFromBase64Map.mock.calls[0].at(0)).toBe(testPeprMutateRequest.Raw);
@@ -136,7 +136,7 @@ describe("decodeData", () => {
     };
     const testPeprMutateRequest = defaultPeprMutateRequest(testAdmissionRequest);
 
-    const [skipped, wrapped] = sut.decodeData(testPeprMutateRequest);
+    const { skipped, wrapped } = sut.decodeData(testPeprMutateRequest);
 
     expect(mockConvertFromBase64Map.mock.calls.length).toBe(0);
     expect(skipped).toEqual([]);

--- a/src/lib/mutate-processor.test.ts
+++ b/src/lib/mutate-processor.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+// import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+// import { GroupVersionKind, kind, KubernetesObject } from "kubernetes-fluent-client";
+// import { AdmissionRequest, Binding, Filters } from "./types";
+// import { Event, Operation } from "./enums";
+// import { PeprValidateRequest } from "./validate-request";
+// import { clone } from "ramda";
+// import * as sut from "./mutate-processor";
+
+// const testFilters: Filters = {
+//   annotations: {},
+//   deletionTimestamp: false,
+//   labels: {},
+//   name: "",
+//   namespaces: [],
+//   regexName: "^default$",
+//   regexNamespaces: [] as string[],
+// };
+
+// const testGroupVersionKind: GroupVersionKind = {
+//   kind: "some-kind",
+//   group: "some-group",
+// };
+
+// const testBinding: Binding = {
+//   event: Event.ANY,
+//   filters: testFilters,
+//   kind: testGroupVersionKind,
+//   model: kind.Pod,
+//   isFinalize: false,
+//   isMutate: false,
+//   isQueue: false,
+//   isValidate: false,
+//   isWatch: false,
+// };
+
+// export const testAdmissionRequest: AdmissionRequest = {
+//   uid: "some-uid",
+//   kind: { kind: "a-kind", group: "a-group" },
+//   resource: { group: "some-group", version: "some-version", resource: "some-resource" },
+//   operation: Operation.CONNECT,
+//   name: "some-name",
+//   userInfo: {},
+//   object: {},
+// };
+
+// export const testActionMetadata: Record<string, string> = {};
+
+// export const testPeprValidateRequest = (admissionRequest: AdmissionRequest) =>
+//   new PeprValidateRequest<KubernetesObject>(admissionRequest);
+
+// describe("processRequest", () => {
+//   let binding: Binding;
+//   let actionMetadata: Record<string, string>;
+//   let peprValidateRequest: PeprValidateRequest<KubernetesObject>;
+
+//   beforeEach(() => {
+//     binding = clone(testBinding);
+//     actionMetadata = clone(testActionMetadata);
+//     peprValidateRequest = testPeprValidateRequest(testAdmissionRequest);
+//   });
+
+//   it("responds on successful validation action", async () => {
+//     const cbResult = {
+//       allowed: true,
+//       statusCode: 200,
+//       statusMessage: "yay",
+//     };
+//     const callback = jest.fn().mockImplementation(() => cbResult) as Binding["validateCallback"];
+//     binding = { ...clone(testBinding), validateCallback: callback };
+
+//     const result = await sut.processRequest(binding, actionMetadata, peprValidateRequest);
+
+//     expect(result).toEqual({
+//       uid: peprValidateRequest.Request.uid,
+//       allowed: cbResult.allowed,
+//       status: {
+//         code: cbResult.statusCode,
+//         message: cbResult.statusMessage,
+//       },
+//     });
+//   });
+
+//   it("responds on unsuccessful validation action", async () => {
+//     const callback = jest.fn().mockImplementation(() => {
+//       throw "oof";
+//     }) as Binding["validateCallback"];
+//     binding = { ...clone(testBinding), validateCallback: callback };
+
+//     const result = await sut.processRequest(binding, actionMetadata, peprValidateRequest);
+
+//     expect(result).toEqual({
+//       uid: peprValidateRequest.Request.uid,
+//       allowed: false,
+//       status: {
+//         code: 500,
+//         message: `Action failed with error: "oof"`,
+//       },
+//     });
+//   });
+// });

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -14,6 +14,7 @@ import { ModuleConfig } from "./module";
 import { PeprMutateRequest } from "./mutate-request";
 import { base64Encode, convertFromBase64Map, convertToBase64Map } from "./utils";
 
+//TODO
 export async function mutateProcessor(
   config: ModuleConfig,
   capabilities: Capability[],

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -137,16 +137,14 @@ export async function mutateProcessor(
   req: AdmissionRequest,
   reqMetadata: Record<string, string>,
 ): Promise<MutateResponse> {
-  let wrapped = new PeprMutateRequest(req);
   let response: MutateResponse = {
     uid: req.uid,
     warnings: [],
     allowed: false,
   };
 
-  // track base64-encoded data fields that should be decoded before / reencoded after processing
-  let skipped: string[] = [];
-  [skipped, wrapped] = decodeData(wrapped);
+  let wrapped = new PeprMutateRequest(req);
+  const skipped = decodeData(wrapped);
 
   Log.info(reqMetadata, `Processing request`);
 

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -15,7 +15,7 @@ import { ModuleConfig } from "./module";
 import { PeprMutateRequest } from "./mutate-request";
 import { base64Encode, convertFromBase64Map, convertToBase64Map } from "./utils";
 
-interface Bindable {
+export interface Bindable {
   req: AdmissionRequest;
   config: ModuleConfig;
   name: string;
@@ -24,7 +24,7 @@ interface Bindable {
   actMeta: Record<string, string>;
 }
 
-interface Result {
+export interface Result {
   wrapped: PeprMutateRequest<KubernetesObject>;
   response: MutateResponse;
 }

--- a/src/lib/mutate-processor.ts
+++ b/src/lib/mutate-processor.ts
@@ -27,14 +27,7 @@ export function updateStatus(
   if (req.operation === "DELETE") {
     return wrapped;
   }
-
-  //
-  // Can this block be substituted for a call to wrapped.SetAnnotation()..?
-  //
-  const identifier = `${config.uuid}.pepr.dev/${name}`;
-  wrapped.Raw.metadata = wrapped.Raw.metadata || {};
-  wrapped.Raw.metadata.annotations = wrapped.Raw.metadata.annotations || {};
-  wrapped.Raw.metadata.annotations[identifier] = status;
+  wrapped.SetAnnotation(`${config.uuid}.pepr.dev/${name}`, status);
 
   return wrapped;
 }


### PR DESCRIPTION
### Describe what should be investigated or refactored

Refactor of `src/lib/mutate-processor.ts` to reduce complexity warnings:
```
/pepr/src/lib/mutate-processor.ts
  18:8  warning  Async function 'mutateProcessor' has a complexity of 18. Maximum allowed is 10        complexity
  18:8  warning  Async function 'mutateProcessor' has too many statements (49). Maximum allowed is 20  max-statements
  99:9  warning  Blocks are nested too deeply (4). Maximum allowed is 3                                max-depth
```

### Additional context
Fixes #1532 
In support of #1248 
