### PR TITLE
chore: different periods between send and receive

### DIFF
--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -166,6 +166,9 @@ export class StoreController {
         metadata: {
           name: this.#name,
           namespace,
+          labels: {
+            "pepr.dev-cacheID": `${Date.now()}`,
+          },
         },
         data: {
           // JSON Patch will die if the data is empty, so we need to add a placeholder

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -12,7 +12,8 @@ import { DataOp, DataSender, DataStore, Storage } from "../storage";
 import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
 
 const namespace = "pepr-system";
-export const debounceBackoff = 1000;
+const debounceBackoffReceive = 1000;
+const debounceBackoffSend = 4000;
 
 export class StoreController {
   #name: string;
@@ -134,7 +135,7 @@ export class StoreController {
 
     // Debounce the update to 1 second to avoid multiple rapid calls
     clearTimeout(this.#sendDebounce);
-    this.#sendDebounce = setTimeout(debounced, this.#onReady ? 0 : debounceBackoff);
+    this.#sendDebounce = setTimeout(debounced, this.#onReady ? 0 : debounceBackoffReceive);
   };
 
   #send = (capabilityName: string): DataSender => {
@@ -151,7 +152,7 @@ export class StoreController {
         Log.debug(redactedPatch(storeCache), "Sending updates to Pepr store");
         void sendUpdatesAndFlushCache(storeCache, namespace, this.#name);
       }
-    }, debounceBackoff);
+    }, debounceBackoffSend);
 
     return sender;
   };

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -69,6 +69,15 @@ export class StoreController {
 
   #migrateAndSetupWatch = async (store: Store): Promise<void> => {
     Log.debug(redactedStore(store), "Pepr Store migration");
+    // Add cacheID label to store
+    await K8s(Store, { namespace, name: this.#name }).Patch([
+      {
+        op: "add",
+        path: "/metadata/labels/pepr.dev-cacheID",
+        value: `${Date.now()}`,
+      },
+    ]);
+
     const data: DataStore = store.data || {};
     let storeCache: Record<string, Operation> = {};
 

--- a/src/lib/controller/storeCache.test.ts
+++ b/src/lib/controller/storeCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, afterEach } from "@jest/globals";
-import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
+import { fillStoreCache, sendUpdatesAndFlushCache, updateCacheID } from "./storeCache";
 import { Operation } from "fast-json-patch";
 import { GenericClass, K8s, KubernetesObject } from "kubernetes-fluent-client";
 import { K8sInit } from "kubernetes-fluent-client/dist/fluent/types";
@@ -98,5 +98,22 @@ describe("sendCache", () => {
         fillStoreCache({}, "capability", "remove", { key: [] });
       }).toThrow("Key is required for REMOVE operation");
     });
+  });
+});
+
+describe("updateCacheId", () => {
+  it("should update the metadata label of the cacheID in the payload array of patches", () => {
+    const patches: Operation[] = [
+      {
+        op: "add",
+        path: "/data/hello-pepr-v2-a",
+        value: "a",
+      },
+    ];
+
+    const updatedPatches = updateCacheID(patches);
+    expect(updatedPatches.length).toBe(2);
+    expect(updatedPatches[1].op).toBe("replace");
+    expect(updatedPatches[1].path).toBe("/metadata/labels/pepr.dev-cacheID");
   });
 });

--- a/src/lib/controller/storeCache.ts
+++ b/src/lib/controller/storeCache.ts
@@ -11,7 +11,9 @@ export const sendUpdatesAndFlushCache = async (cache: Record<string, Operation>,
 
   try {
     if (payload.length > 0) {
-      await K8s(Store, { namespace, name }).Patch(payload); // Send patch to cluster
+      // Force a change on the Watched resource for setItemAndWait and removeItemAndWait to resolve
+      const res = await K8s(Store, { namespace, name }).Patch(updateCacheID(payload)); // Send patch to cluster
+      console.log("res", JSON.stringify(res, null, 2));
       Object.keys(cache).forEach(key => delete cache[key]);
     }
   } catch (err) {
@@ -61,3 +63,12 @@ export const fillStoreCache = (
   }
   return cache;
 };
+
+export function updateCacheID(payload: Operation[]): Operation[] {
+  payload.push({
+    op: "replace",
+    path: "/metadata/labels/pepr.dev-cacheID",
+    value: `${Date.now()}`,
+  });
+  return payload;
+}

--- a/src/lib/controller/storeCache.ts
+++ b/src/lib/controller/storeCache.ts
@@ -11,9 +11,7 @@ export const sendUpdatesAndFlushCache = async (cache: Record<string, Operation>,
 
   try {
     if (payload.length > 0) {
-      // Force a change on the Watched resource for setItemAndWait and removeItemAndWait to resolve
-      const res = await K8s(Store, { namespace, name }).Patch(updateCacheID(payload)); // Send patch to cluster
-      console.log("res", JSON.stringify(res, null, 2));
+      await K8s(Store, { namespace, name }).Patch(updateCacheID(payload)); // Send patch to cluster
       Object.keys(cache).forEach(key => delete cache[key]);
     }
   } catch (err) {

--- a/src/lib/schedule.test.ts
+++ b/src/lib/schedule.test.ts
@@ -20,10 +20,10 @@ export class MockStorage {
     this.storage[key] = value;
   }
 
-  setItemAndWait(key: string, value: string): Promise<void> {
+  setItemAndWait(key: string, value: string): Promise<string> {
     return new Promise(resolve => {
       this.storage[key] = value;
-      resolve();
+      resolve("ok");
     });
   }
 
@@ -31,10 +31,10 @@ export class MockStorage {
     delete this.storage[key];
   }
 
-  removeItemAndWait(key: string): Promise<void> {
+  removeItemAndWait(key: string): Promise<string> {
     return new Promise(resolve => {
       delete this.storage[key];
-      resolve();
+      resolve("ok");
     });
   }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -141,7 +141,7 @@ export class Storage implements PeprStore {
       // If promise has not resolved before MAX_WAIT_TIME reject
       record.timeout = setTimeout(() => {
         record.unsubscribe!();
-        return reject(`MAX_WAIT_TIME elapsed: Key ${key} not seen in ${MAX_WAIT_TIME}s`);
+        return reject(`MAX_WAIT_TIME elapsed: Key ${key} not seen in ${MAX_WAIT_TIME / 1000}s`);
       }, MAX_WAIT_TIME);
 
       record.unsubscribe = this.subscribe(data => {
@@ -168,7 +168,7 @@ export class Storage implements PeprStore {
       // If promise has not resolved before MAX_WAIT_TIME reject
       record.timeout = setTimeout(() => {
         record.unsubscribe!();
-        return reject(`MAX_WAIT_TIME elapsed: Key ${key} still seen after ${MAX_WAIT_TIME}s`);
+        return reject(`MAX_WAIT_TIME elapsed: Key ${key} still seen after ${MAX_WAIT_TIME / 1000}s`);
       }, MAX_WAIT_TIME);
 
       record.unsubscribe = this.subscribe(data => {


### PR DESCRIPTION
## Description

We lowered the debounce period (to one second) in which our Store Subscribers **receive** updates from the Watch on the `PeprStore` resource, meaning they can react to changes faster.

The same debounce period was responsible for **sending** JSON patches to the `PeprStore` resource. The cache that holds these updates is updated and the items that were sent are deleted after the JSON patch succeeds. This meant that if we are sending events every second, and the kube-apiserver does not process the patch in a second, then the same events will be sent over multiple intervals. It is unclear if this would make the data incorrect as it is idempotent but it certainly introduces pressure on the network which could create a fallout of other network created problems. 

This PR:
- Creates two different debounce periods, one for send and one for receive
- Sends a reason for the reject in `SetItemAndWait/RemoveItemAndWait`
- Cleans up the timeouts in `SetItemAndWait/RemoveItemAndWait`
- Adds an array item to the JSON patch to the Store to ensure a watch event occurs to resolve promises in Set/RemoveItemAndWait


e2e: https://github.com/defenseunicorns/pepr-excellent-examples/pull/204
## Related Issue

Fixes #1561
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
