### PR TITLE
chore: add typing to untyped functions

### DIFF
--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -14,7 +14,7 @@ import { peprStoreCRD } from "../lib/assets/store";
 import { validateHash } from "../lib/helpers";
 const { version } = packageJSON;
 
-function runModule(expectedHash: string) {
+function runModule(expectedHash: string): void {
   const gzPath = `/app/load/module-${expectedHash}.js.gz`;
   const jsPath = `/app/module-${expectedHash}.js`;
 
@@ -59,7 +59,7 @@ Log.info(`Pepr Controller (v${version})`);
 
 const hash = process.argv[2];
 
-const startup = async () => {
+const startup = async (): Promise<void> => {
   try {
     Log.info("Applying the Pepr Store CRD if it doesn't exist");
     await K8s(kind.CustomResourceDefinition).Apply(peprStoreCRD, { force: true });

--- a/src/sdk/heredoc.ts
+++ b/src/sdk/heredoc.ts
@@ -1,7 +1,7 @@
 // Refs:
 // - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
 
-export function heredoc(strings: TemplateStringsArray, ...values: string[]) {
+export function heredoc(strings: TemplateStringsArray, ...values: string[]): string {
   // shuffle strings & expression values back together
   const zipped = strings
     .reduce((acc: string[], cur, idx) => {


### PR DESCRIPTION
## Description

This PR adds typing to the return types of some untyped functions. #1545 mentions `sdk.ts` and `cosign.ts`, but those files are already fully-typed with their returns.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1545 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
