### PR TITLE
chore: return types on module, included-files, and helpers to standardize our typing

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -143,7 +143,7 @@ export function filterNoMatchReason(
   );
 }
 
-export function addVerbIfNotExists(verbs: string[], verb: string) {
+export function addVerbIfNotExists(verbs: string[], verb: string): void {
   if (!verbs.includes(verb)) {
     verbs.push(verb);
   }
@@ -200,11 +200,11 @@ export function hasAnyOverlap<T>(array1: T[], array2: T[]): boolean {
   return array1.some(element => array2.includes(element));
 }
 
-export function ignoredNamespaceConflict(ignoreNamespaces: string[], bindingNamespaces: string[]) {
+export function ignoredNamespaceConflict(ignoreNamespaces: string[], bindingNamespaces: string[]): boolean {
   return hasAnyOverlap(bindingNamespaces, ignoreNamespaces);
 }
 
-export function bindingAndCapabilityNSConflict(bindingNamespaces: string[], capabilityNamespaces: string[]) {
+export function bindingAndCapabilityNSConflict(bindingNamespaces: string[], capabilityNamespaces: string[]): boolean {
   if (!capabilityNamespaces) {
     return false;
   }
@@ -215,7 +215,7 @@ export function generateWatchNamespaceError(
   ignoredNamespaces: string[],
   bindingNamespaces: string[],
   capabilityNamespaces: string[],
-) {
+): string {
   let err = "";
 
   // check if binding uses an ignored namespace
@@ -237,7 +237,7 @@ export function generateWatchNamespaceError(
 }
 
 // namespaceComplianceValidator ensures that capability bindings respect ignored and capability namespaces
-export function namespaceComplianceValidator(capability: CapabilityExport, ignoredNamespaces?: string[]) {
+export function namespaceComplianceValidator(capability: CapabilityExport, ignoredNamespaces?: string[]): void {
   const { namespaces: capabilityNamespaces, bindings, name } = capability;
   const bindingNamespaces: string[] = bindings.flatMap((binding: Binding) => binding.filters.namespaces);
   const bindingRegexNamespaces: string[] = bindings.flatMap(

--- a/src/lib/included-files.ts
+++ b/src/lib/included-files.ts
@@ -3,7 +3,7 @@
 
 import { promises as fs } from "fs";
 
-export async function createDockerfile(version: string, description: string, includedFiles: string[]) {
+export async function createDockerfile(version: string, description: string, includedFiles: string[]): Promise<void> {
   const file = `
     # Use an official Node.js runtime as the base image
     FROM ghcr.io/defenseunicorns/pepr/controller:v${version}

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -58,12 +58,12 @@ export type PeprModuleOptions = {
 };
 
 // Track if this is a watch mode controller
-export const isWatchMode = () => process.env.PEPR_WATCH_MODE === "true";
+export const isWatchMode = (): boolean => process.env.PEPR_WATCH_MODE === "true";
 
 // Track if Pepr is running in build mode
-export const isBuildMode = () => process.env.PEPR_MODE === "build";
+export const isBuildMode = (): boolean => process.env.PEPR_MODE === "build";
 
-export const isDevMode = () => process.env.PEPR_MODE === "dev";
+export const isDevMode = (): boolean => process.env.PEPR_MODE === "dev";
 
 export class PeprModule {
   #controller!: Controller;
@@ -135,7 +135,7 @@ export class PeprModule {
    *
    * @param port
    */
-  start = (port = 3000) => {
+  start = (port = 3000): void => {
     this.#controller.startServer(port);
   };
 }


### PR DESCRIPTION
## Description

Return types on module, included-files, and helpers to standardize our typing

## Related Issue

Fixes #1548 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
