### PR TITLE
chore: statements in format

### DIFF
--- a/src/cli/format.helpers.ts
+++ b/src/cli/format.helpers.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { ESLint } from "eslint";
+import { promises as fs } from "fs";
+import { format, resolveConfig } from "prettier";
+
+export async function formatWithPrettier(
+  results: ESLint.LintResult[],
+  validateOnly: boolean,
+): Promise<boolean> {
+  let hasFailure = false;
+  for (const { filePath } of results) {
+    const content = await fs.readFile(filePath, "utf8");
+    const cfg = await resolveConfig(filePath);
+    const formatted = await format(content, { filepath: filePath, ...cfg });
+
+    // If in validate-only mode, check if the file is formatted correctly
+    if (validateOnly && formatted !== content) {
+      hasFailure = true;
+      console.error(`File ${filePath} is not formatted correctly`);
+    } else {
+      await fs.writeFile(filePath, formatted);
+    }
+  }
+  return hasFailure;
+}

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { formatWithPrettier } from "./format.helpers";
+import { promises as fs } from "fs";
+import { resolveConfig, format } from "prettier";
+import { ESLint } from "eslint";
+
+jest.mock("fs", () => ({
+  promises: {
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+  },
+}));
+
+jest.mock("prettier", () => ({
+  resolveConfig: jest.fn(),
+  format: jest.fn(),
+}));
+
+describe("formatWithPrettier", () => {
+  const mockReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+  const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>;
+  const mockResolveConfig = resolveConfig as jest.MockedFunction<typeof resolveConfig>;
+  const mockFormat = format as jest.MockedFunction<typeof format>;
+
+  const mockResults: ESLint.LintResult[] = [
+    { filePath: "package.json" } as ESLint.LintResult,
+    { filePath: "hello-pepr.ts" } as ESLint.LintResult,
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should format files and write back to the file system", async () => {
+    mockReadFile.mockResolvedValue("const x =1;");
+    mockResolveConfig.mockResolvedValue({ semi: true });
+    mockFormat.mockResolvedValue("const x = 1;");
+
+    const validateOnly = false;
+
+    const result = await formatWithPrettier(mockResults, validateOnly);
+
+    expect(result).toBe(false);
+    expect(mockReadFile).toHaveBeenCalledTimes(2);
+    expect(mockWriteFile).toHaveBeenCalledTimes(2);
+    expect(mockFormat).toHaveBeenCalledTimes(2);
+
+    expect(mockWriteFile).toHaveBeenCalledWith("package.json", "const x = 1;");
+    expect(mockWriteFile).toHaveBeenCalledWith("hello-pepr.ts", "const x = 1;");
+  });
+
+  it("should report failures in validate-only mode if files are not formatted", async () => {
+    mockReadFile.mockResolvedValue("const x =1;");
+    mockResolveConfig.mockResolvedValue({ semi: true });
+    mockFormat.mockResolvedValue("const x = 1;");
+
+    const validateOnly = true;
+
+    const mockError = jest.spyOn(console, "error").mockImplementation(() => {
+      return undefined as never;
+    });
+    const result = await formatWithPrettier(mockResults, validateOnly);
+
+    expect(result).toBe(true);
+    expect(mockReadFile).toHaveBeenCalledTimes(2);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith("File package.json is not formatted correctly");
+    expect(mockError).toHaveBeenCalledWith("File hello-pepr.ts is not formatted correctly");
+
+    mockError.mockRestore();
+  });
+});

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -2,8 +2,7 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { ESLint } from "eslint";
-import { promises as fs } from "fs";
-import { format, resolveConfig } from "prettier";
+import { formatWithPrettier } from "./format.helpers";
 
 import { RootCmd } from "./root";
 
@@ -56,20 +55,7 @@ export async function peprFormat(validateOnly: boolean) {
         await ESLint.outputFixes(results);
       }
 
-      // Format with Prettier
-      for (const { filePath } of results) {
-        const content = await fs.readFile(filePath, "utf8");
-        const cfg = await resolveConfig(filePath);
-        const formatted = await format(content, { filepath: filePath, ...cfg });
-
-        // If in validate-only mode, check if the file is formatted correctly
-        if (validateOnly && formatted !== content) {
-          hasFailure = true;
-          console.error(`File ${filePath} is not formatted correctly`);
-        } else {
-          await fs.writeFile(filePath, formatted);
-        }
-      }
+      hasFailure = await formatWithPrettier(results, validateOnly);
 
       return !hasFailure;
     } catch (e) {


### PR DESCRIPTION
## Description

Too many statements in format.ts

## Related Issue

Fixes #1596 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
