### PR TITLE
feat: provides a way to override ignored namespaces at deployment time

### DIFF
--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -66,9 +66,9 @@ In scenarios where build-time configuration is not feasible, you can set the nam
 ```
 
 ```bash
-kubectl set env deployment/pepr-admission PEPR_IGNORED_NAMESPACES=zarf,istio-system -n pepr-system
+kubectl set env deployment/pepr-admission PEPR_IGNORED_NAMESPACES="zarf,istio-system" -n pepr-system
 
-kubectl set env deployment/pepr-watcher PEPR_IGNORED_NAMESPACES=zarf,istio-system -n pepr-system
+kubectl set env deployment/pepr-watcher PEPR_IGNORED_NAMESPACES="zarf,istio-system" -n pepr-system
 ```
 
 ## Customizing Watch Configuration

--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -57,18 +57,18 @@ Pepr, by default, ignores the `kube-system` and `pepr-system` namespaces. These 
 
 The safest and recommended way to define the namespaces your Pepr module should ignore is at build time. This approach leverages a function that validates namespaces based on the Capability configuration, ensuring that your bindings operate only on approved namespaces. Refer to the [`package.json` configurations table](#packagejson-configurations-table) for detailed guidance.
 
-In scenarios where build-time configuration is not feasible, you can set the namespaces to ignore at deploy time by using the `PEPR_IGNORE_NAMESPACES` environment variable in your deployments. However, this method bypasses the build-time safety checks and is not recommended except as a last resort. If you choose this approach, ensure that both controllers (Watch and Admission) are configured with the same value to maintain consistency.
+In scenarios where build-time configuration is not feasible, you can set the namespaces to ignore at deploy time by using the `PEPR_IGNORED_NAMESPACES` environment variable in your deployments. However, this method bypasses the build-time safety checks and is not recommended except as a last resort. If you choose this approach, ensure that both controllers (Watch and Admission) are configured with the same value to maintain consistency.
 
 ```yaml
           env:
-            - name: PEPR_IGNORE_NAMESPACES
+            - name: PEPR_IGNORED_NAMESPACES
               value: 'zarf,istio-system'
 ```
 
 ```bash
-kubectl set env deployment/pepr-admission PEPR_IGNORE_NAMESPACES=zarf,istio-system -n pepr-system
+kubectl set env deployment/pepr-admission PEPR_IGNORED_NAMESPACES=zarf,istio-system -n pepr-system
 
-kubectl set env deployment/pepr-watcher PEPR_IGNORE_NAMESPACES=zarf,istio-system -n pepr-system
+kubectl set env deployment/pepr-watcher PEPR_IGNORED_NAMESPACES=zarf,istio-system -n pepr-system
 ```
 
 ## Customizing Watch Configuration

--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -51,6 +51,25 @@ Default (without):
 ```json
 {"level":30,"time":"1715696764106","pid":16,"hostname":"pepr-static-test-watcher-559d94447f-xkq2h","method":"GET","url":"/healthz","status":200,"duration":"1 ms"}
 ```
+## Overriding Ignored Namespaces At Deploy Time
+
+Pepr, by default, ignores the `kube-system` and `pepr-system` namespaces. These namespaces are non-overridable to maintain system integrity.
+
+The safest and recommended way to define the namespaces your Pepr module should ignore is at build time. This approach leverages a function that validates namespaces based on the Capability configuration, ensuring that your bindings operate only on approved namespaces. Refer to the [`package.json` configurations table](#packagejson-configurations-table) for detailed guidance.
+
+In scenarios where build-time configuration is not feasible, you can set the namespaces to ignore at deploy time by using the `PEPR_IGNORE_NAMESPACES` environment variable in your deployments. However, this method bypasses the build-time safety checks and is not recommended except as a last resort. If you choose this approach, ensure that both controllers (Watch and Admission) are configured with the same value to maintain consistency.
+
+```yaml
+          env:
+            - name: PEPR_IGNORE_NAMESPACES
+              value: 'zarf,istio-system'
+```
+
+```bash
+kubectl set env deployment/pepr-admission PEPR_IGNORE_NAMESPACES=zarf,istio-system -n pepr-system
+
+kubectl set env deployment/pepr-watcher PEPR_IGNORE_NAMESPACES=zarf,istio-system -n pepr-system
+```
 
 ## Customizing Watch Configuration
 

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+import { it, describe, expect } from "@jest/globals";
+import { resolveIgnoreNamespaces } from "./webhooks";
+
+describe("resolveIgnoreNamespaces", () => {
+  it("should default to empty array ig config is empty", () => {
+    const result = resolveIgnoreNamespaces();
+    expect(result).toEqual([]);
+  });
+
+  it("should return the config ignore namespaces if not provided PEPR_IGNORED_NAMESPACES is not provided", () => {
+    const result = resolveIgnoreNamespaces(["payments", "istio-system"]);
+    expect(result).toEqual(["payments", "istio-system"]);
+  });
+
+  it("should be able to override config ignored namespaces if PEPR_IGNORED_NAMESPACES is provided", () => {
+    process.env.PEPR_IGNORED_NAMESPACES = "override-zarf,override-lula";
+    const result = resolveIgnoreNamespaces(["zarf", "lula"]);
+    expect(result).toEqual(["override-zarf", "override-lula"]);
+  });
+});

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -9,7 +9,7 @@ import { CapabilityExport, AdmissionRequest } from "../types";
 import { setupWatch } from "../processors/watch-processor";
 import { Log } from "../../lib";
 import { V1PolicyRule as PolicyRule } from "@kubernetes/client-node";
-
+import { resolveIgnoreNamespaces } from "../assets/webhooks";
 /** Custom Labels Type for package.json */
 export interface CustomLabels {
   namespace?: Record<string, string>;
@@ -113,7 +113,7 @@ export class PeprModule {
       // Wait for the controller to be ready before setting up watches
       if (isWatchMode() || isDevMode()) {
         try {
-          setupWatch(capabilities, pepr?.alwaysIgnore?.namespaces);
+          setupWatch(capabilities, resolveIgnoreNamespaces(pepr?.alwaysIgnore?.namespaces));
         } catch (e) {
           Log.error(e, "Error setting up watch");
           process.exit(1);

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -14,7 +14,7 @@ import Log from "../telemetry/logger";
 import { ModuleConfig } from "../core/module";
 import { PeprMutateRequest } from "../mutate-request";
 import { base64Encode, convertFromBase64Map, convertToBase64Map } from "../utils";
-
+import { resolveIgnoreNamespaces } from "../assets/webhooks";
 export interface Bindable {
   req: AdmissionRequest;
   config: ModuleConfig;
@@ -169,7 +169,7 @@ export async function mutateProcessor(
       bind.binding,
       bind.req,
       bind.namespaces,
-      bind.config?.alwaysIgnore?.namespaces,
+      resolveIgnoreNamespaces(bind.config?.alwaysIgnore?.namespaces),
     );
     if (shouldSkip !== "") {
       Log.debug(shouldSkip);

--- a/src/lib/processors/validate-processor.ts
+++ b/src/lib/processors/validate-processor.ts
@@ -10,7 +10,7 @@ import Log from "../telemetry/logger";
 import { convertFromBase64Map } from "../utils";
 import { PeprValidateRequest } from "../validate-request";
 import { ModuleConfig } from "../core/module";
-
+import { resolveIgnoreNamespaces } from "../assets/webhooks";
 export async function processRequest(
   binding: Binding,
   actionMetadata: Record<string, string>,
@@ -78,7 +78,12 @@ export async function validateProcessor(
       }
 
       // Continue to the next action without doing anything if this one should be skipped
-      const shouldSkip = shouldSkipRequest(binding, req, namespaces, config?.alwaysIgnore?.namespaces);
+      const shouldSkip = shouldSkipRequest(
+        binding,
+        req,
+        namespaces,
+        resolveIgnoreNamespaces(config?.alwaysIgnore?.namespaces),
+      );
       if (shouldSkip !== "") {
         Log.debug(shouldSkip);
         continue;


### PR DESCRIPTION
## Description

In scenarios where build-time configuration is not feasible, you can set the namespaces to ignore at deploy time by using the `PEPR_IGNORED_NAMESPACES` environment variable in your deployments. However, this method bypasses the build-time safety checks and is not recommended except as a last resort. 

Needs: 1618
## Related Issue

Fixes #1610 
<!-- or -->
Relates to #1618 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
