### PR TITLE
chore: carriedNamespace/carriesIgnoredNamespace account for Namespace object

### DIFF
--- a/src/lib/filter/adjudicators/adjudicators.test.ts
+++ b/src/lib/filter/adjudicators/adjudicators.test.ts
@@ -268,6 +268,9 @@ describe("uncarryableNamespace", () => {
     [[], {}, false],
     [[], { metadata: { namespace: "namespace" } }, false],
 
+    [["namespace"], { kind: "Namespace", metadata: { name: "namespace" } }, false],
+    [["namespace"], { kind: "Namespace", metadata: { name: "monitoring" } }, true],
+
     [["namespace"], {}, false],
     [["namespace"], { metadata: {} }, false],
     [["namespace"], { metadata: { namespace: null } }, false],
@@ -296,6 +299,9 @@ describe("carriesIgnoredNamespace", () => {
   it.each([
     [[], {}, false],
     [[], { metadata: { namespace: "whatever" } }, false],
+
+    [["ignored"], { kind: "Namespace", metadata: { name: "ignored" } }, true],
+    [["ignored"], { kind: "Namespace", metadata: { name: "monitoring" } }, false],
 
     [["ignored"], {}, false],
     [["ignored"], { metadata: {} }, false],

--- a/src/lib/filter/adjudicators/adjudicators.ts
+++ b/src/lib/filter/adjudicators/adjudicators.ts
@@ -73,10 +73,14 @@ export const carriedName = pipe(
 export const carriesName = pipe(carriedName, equals(""), not);
 export const missingName = complement(carriesName);
 
-export const carriedNamespace = pipe(
-  (kubernetesObject: KubernetesObject): string | undefined => kubernetesObject?.metadata?.namespace,
-  defaultTo(""),
-);
+export const carriedNamespace = pipe((kubernetesObject: KubernetesObject): string | undefined => {
+  if (kubernetesObject?.kind === "Namespace") {
+    return kubernetesObject?.metadata?.name;
+  } else {
+    return kubernetesObject?.metadata?.namespace;
+  }
+}, defaultTo(""));
+
 export const carriesNamespace = pipe(carriedNamespace, equals(""), not);
 
 export const carriedAnnotations = pipe(

--- a/src/lib/filter/adjudicators/adjudicators.ts
+++ b/src/lib/filter/adjudicators/adjudicators.ts
@@ -73,12 +73,10 @@ export const carriedName = pipe(
 export const carriesName = pipe(carriedName, equals(""), not);
 export const missingName = complement(carriesName);
 
-export const carriedNamespace = pipe((kubernetesObject: KubernetesObject): string | undefined => {
-  if (kubernetesObject?.kind === "Namespace") {
-    return kubernetesObject?.metadata?.name;
-  }
-  return kubernetesObject?.metadata?.namespace;
-}, defaultTo(""));
+export const carriedNamespace = pipe(
+  (kubernetesObject: KubernetesObject): string | undefined => kubernetesObject?.metadata?.namespace,
+  defaultTo(""),
+);
 
 export const carriesNamespace = pipe(carriedNamespace, equals(""), not);
 

--- a/src/lib/filter/filter.test.ts
+++ b/src/lib/filter/filter.test.ts
@@ -1218,6 +1218,10 @@ describe("adjudicateUnbindableNamespaces", () => {
 });
 
 describe("adjudicateUncarryableNamespace", () => {
+  it("should return uncarryableNamespace reason when the object is a namespace that is not allowed by the capability", () => {
+    const result = adjudicateUncarryableNamespace(["default"], { kind: "Namespace", metadata: { name: "pepr-demo" } });
+    expect(result).toBe(`Object carries namespace 'pepr-demo' but namespaces allowed by Capability are '["default"]'.`);
+  });
   it("should return uncarryableNamespace reason when the object carries a namespace that is not allowed by the capability", () => {
     const result = adjudicateUncarryableNamespace(["default"], { metadata: { namespace: "kube-system" } });
     expect(result).toBe(

--- a/src/lib/filter/filter.test.ts
+++ b/src/lib/filter/filter.test.ts
@@ -1321,6 +1321,10 @@ describe("adjudicateMismatchedNameRegex", () => {
 });
 
 describe("adjudicateCarriesIgnoredNamespace", () => {
+  it("should return carriesIgnoredNamespace reason when the object is a namespace that is in the ignoredNamespaces", () => {
+    const result = adjudicateCarriesIgnoredNamespace(["default"], { kind: "Namespace", metadata: { name: "default" } });
+    expect(result).toBe(`Object carries namespace 'default' but ignored namespaces include '["default"]'.`);
+  });
   it("should return carriesIgnoredNamespace reason when the object carries a namespace that is in the ignoredNamespaces", () => {
     const result = adjudicateCarriesIgnoredNamespace(["default"], { metadata: { namespace: "default" } });
     expect(result).toBe(`Object carries namespace 'default' but ignored namespaces include '["default"]'.`);

--- a/src/lib/filter/filter.ts
+++ b/src/lib/filter/filter.ts
@@ -191,7 +191,7 @@ export function adjudicateUncarryableNamespace(
   obj: KubernetesObject,
 ): AdjudicationResult {
   return uncarryableNamespace(capabilityNamespaces, obj)
-    ? `Object carries namespace '${carriedNamespace(obj)}' but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'.`
+    ? `Object carries namespace '${obj.kind && obj.kind === "Namespace" ? obj.metadata?.name : carriedNamespace(obj)}' but namespaces allowed by Capability are '${JSON.stringify(capabilityNamespaces)}'.`
     : null;
 }
 
@@ -230,7 +230,7 @@ export function adjudicateCarriesIgnoredNamespace(
   obj: KubernetesObject,
 ): AdjudicationResult {
   return carriesIgnoredNamespace(ignoredNamespaces, obj)
-    ? `Object carries namespace '${carriedNamespace(obj)}' but ignored namespaces include '${JSON.stringify(ignoredNamespaces)}'.`
+    ? `Object carries namespace '${obj.kind && obj.kind === "Namespace" ? obj.metadata?.name : carriedNamespace(obj)}' but ignored namespaces include '${JSON.stringify(ignoredNamespaces)}'.`
     : null;
 }
 


### PR DESCRIPTION
## Description

CarriedNamespace did not account for Namespace objects which caused some strange behaviors in #1610 

After Fix:

```bash
[14:20:13.943] DEBUG (44989): Ignoring Watch Callback: Object carries namespace 'pepr-demo-2' but ignored namespaces include '["pepr-demo-2"]'.
```

## Related Issue

Fixes #1618 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
