### PR TITLE
chore: make load tests more resilient to slow metrics-server startup in GH CI

### DIFF
--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -736,8 +736,15 @@ program
           .concat("\n");
         await fs.appendFile(audFile, outlines);
       };
-      audience(); // run immediately, then on schedule
-      const ticket = setInterval(audience, opts.audInterval);
+      await audience(); // run immediately, then on schedule
+      const ticket = setInterval(async () => {
+        try {
+          await audience();
+        } catch (e) {
+          console.error(e);
+          process.exit(1);
+        }
+      }, opts.audInterval);
 
       await nap(opts.stagger); // stagger interval starts
 
@@ -763,9 +770,15 @@ program
           await fs.appendFile(actFile, Date.now().toString() + "\n");
         }
       };
-      actress(); // run immediately, then on schedule
-      const backstagePass = setInterval(() => actress(abort), opts.actInterval);
-
+      await actress(); // run immediately, then on schedule
+      const backstagePass = setInterval(async () => {
+        try {
+          await actress(abort);
+        } catch (e) {
+          console.error(e);
+          process.exit(1);
+        }
+      }, opts.actInterval);
       // wait until total duration has elapsed
       const startWait = Date.now();
       await nap(opts.duration - (startWait - alpha));


### PR DESCRIPTION
## Description

Adds some add'l try/catches+output to allow us to see what's actually blowing up in CI.

## Related Issue

Fixes #1622 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
