### PR TITLE
chore: remove matchExpression peprdev key in webhook

### DIFF
--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -13,12 +13,6 @@ import { Assets } from "./assets";
 import { Event } from "../enums";
 import { Binding } from "../types";
 
-const peprIgnoreLabel: V1LabelSelectorRequirement = {
-  key: "pepr.dev",
-  operator: "NotIn",
-  values: ["ignore"],
-};
-
 const peprIgnoreNamespaces: string[] = ["kube-system", "pepr-system"];
 
 const validateRule = (binding: Binding, isMutateWebhook: boolean): V1RuleWithOperations | undefined => {
@@ -64,7 +58,7 @@ export async function webhookConfig(
   mutateOrValidate: "mutate" | "validate",
   timeoutSeconds = 10,
 ): Promise<kind.MutatingWebhookConfiguration | kind.ValidatingWebhookConfiguration | null> {
-  const ignore = [peprIgnoreLabel];
+  const ignore: V1LabelSelectorRequirement[] = [];
 
   const { name, tls, config, apiToken, host } = assets;
   const ignoreNS = concat(peprIgnoreNamespaces, config?.alwaysIgnore?.namespaces || []);

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -114,9 +114,6 @@ export async function webhookConfig(
         namespaceSelector: {
           matchExpressions: ignore,
         },
-        objectSelector: {
-          matchExpressions: ignore,
-        },
         rules,
         // @todo: track side effects state
         sideEffects: "None",


### PR DESCRIPTION
## Description

Removing a namespaceSelector for a certain expression on WebhookConfigs

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
