### PR TITLE
chore: remove unused property in assets class

### DIFF
--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -33,7 +33,6 @@ export class Assets {
 
   image: string;
   buildTimestamp: string;
-  hash: string;
 
   constructor(
     readonly config: ModuleConfig,
@@ -44,17 +43,12 @@ export class Assets {
     this.buildTimestamp = `${Date.now()}`;
     this.alwaysIgnore = config.alwaysIgnore;
     this.image = `ghcr.io/defenseunicorns/pepr/controller:v${config.peprVersion}`;
-    this.hash = "";
     // Generate the ephemeral tls things
     this.tls = genTLS(this.host || `${this.name}.pepr-system.svc`);
 
     // Generate the api token for the controller / webhook
     this.apiToken = crypto.randomBytes(32).toString("hex");
   }
-
-  setHash = (hash: string): void => {
-    this.hash = hash;
-  };
 
   deploy = async (force: boolean, webhookTimeout?: number): Promise<void> => {
     this.capabilities = await loadCapabilities(this.path);
@@ -79,19 +73,18 @@ export class Assets {
 
     const code = await fs.readFile(this.path);
 
-    // Generate a hash of the code
-    this.hash = crypto.createHash("sha256").update(code).digest("hex");
+    const moduleHash = crypto.createHash("sha256").update(code).digest("hex");
 
     const deployments = {
-      default: getDeployment(this, this.hash, this.buildTimestamp, imagePullSecret),
-      watch: getWatcher(this, this.hash, this.buildTimestamp, imagePullSecret),
+      default: getDeployment(this, moduleHash, this.buildTimestamp, imagePullSecret),
+      watch: getWatcher(this, moduleHash, this.buildTimestamp, imagePullSecret),
     };
 
     const assetsInputs = {
       apiToken: this.apiToken,
       capabilities: this.capabilities,
       config: this.config,
-      hash: this.hash,
+      hash: moduleHash,
       name: this.name,
       path: this.path,
       tls: this.tls,
@@ -129,6 +122,7 @@ export class Assets {
       );
 
       const code = await fs.readFile(this.path);
+      const moduleHash = crypto.createHash("sha256").update(code).digest("hex");
 
       const pairs: [string, () => string][] = [
         [helm.files.chartYaml, (): string => dedent(chartYaml(this.config.uuid, this.config.description || ""))],
@@ -142,12 +136,12 @@ export class Assets {
         [helm.files.clusterRoleYaml, (): string => dedent(clusterRoleTemplate())],
         [helm.files.clusterRoleBindingYaml, (): string => toYaml(clusterRoleBinding(this.name))],
         [helm.files.serviceAccountYaml, (): string => toYaml(serviceAccount(this.name))],
-        [helm.files.moduleSecretYaml, (): string => toYaml(getModuleSecret(this.name, code, this.hash))],
+        [helm.files.moduleSecretYaml, (): string => toYaml(getModuleSecret(this.name, code, moduleHash))],
       ];
       await Promise.all(pairs.map(async ([file, content]) => await fs.writeFile(file, content())));
 
       const overrideData = {
-        hash: this.hash,
+        hash: moduleHash,
         name: this.name,
         image: this.image,
         config: this.config,
@@ -163,7 +157,7 @@ export class Assets {
 
       await this.writeWebhookFiles(validateWebhook, mutateWebhook, helm);
 
-      const watchDeployment = getWatcher(this, this.hash, this.buildTimestamp);
+      const watchDeployment = getWatcher(this, moduleHash, this.buildTimestamp);
       if (watchDeployment) {
         await fs.writeFile(helm.files.watcherDeploymentYaml, dedent(watcherDeployTemplate(this.buildTimestamp)));
         await fs.writeFile(helm.files.watcherServiceMonitorYaml, dedent(serviceMonitorTemplate("watcher")));


### PR DESCRIPTION
## Description

This PR removes the `Assets.hash` property and calculates the hash of a pepr module _just_ before we need to provide that value to a consuming function. This will avoid potential issues with state and removes some dead code.


End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1638 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
