### PR TITLE
fix(CI): grant write permission to CI job

### DIFF
--- a/.github/workflows/digestabot.yml
+++ b/.github/workflows/digestabot.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: write # to commit changes
       pull-requests: write # to open Pull requests
       id-token: write # used to sign the commits using gitsign
 


### PR DESCRIPTION
## Description

A CI job fails due to what may be a permissions issue. This PR adds permissions.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #1657 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
