### PR TITLE
chore: remove write perms image digest workflow

### DIFF
--- a/.github/workflows/digestabot.yml
+++ b/.github/workflows/digestabot.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write # to commit changes
       pull-requests: write # to open Pull requests
       id-token: write # used to sign the commits using gitsign
 


### PR DESCRIPTION
## Description

Remove excess perms from Image Digest Workflow 
## Related Issue

Fixes #1675 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
