### PR TITLE
chore: chainguard node23 is a no, so... distroless?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@
 # Any other changes to Dockerfile should be reflected in Publish
 
 # crane digest cgr.dev/chainguard/node-lts:latest-dev
-FROM cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a AS build
+# cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a
+FROM docker.io/library/node:22-bookworm AS build
 
 WORKDIR /app
 
@@ -38,7 +39,9 @@ RUN npm run build && \
 ##### DELIVER #####
 
 # crane digest cgr.dev/chainguard/node-lts:latest
-FROM cgr.dev/chainguard/node:latest@sha256:f771505c29d1f766c1dc4d3b2ed0f8660a76553685b9d886728bc55d6f430ce8
+# cgr.dev/chainguard/node:latest@sha256:f771505c29d1f766c1dc4d3b2ed0f8660a76553685b9d886728bc55d6f430ce8
+# gcr.io/distroless/nodejs22-debian12@sha256:d00edbf864c5b989f1b69951a13c5c902bf369cca572de59b5ec972552848e33
+FROM gcr.io/distroless/nodejs22-debian12:nonroot@sha256:06298f87531dfff6dd2bc6b573095162d25f7e5583abbc865bfcdf45a4fbee16
 
 WORKDIR /app
 

--- a/Dockerfile.kfc
+++ b/Dockerfile.kfc
@@ -6,7 +6,8 @@
 # Any other changes to Dockerfile should be reflected in Publish
 
 # crane digest cgr.dev/chainguard/node-lts:latest-dev
-FROM cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a AS build
+# cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a
+FROM docker.io/library/node:22-bookworm@@sha256:fa54405993eaa6bab6b6e460f5f3e945a2e2f07942ba31c0e297a7d9c2041f62 AS build
 
 WORKDIR /app
 
@@ -46,8 +47,10 @@ RUN cp -r kubernetes-fluent-client/src node_modules/kubernetes-fluent-client/src
 ##### DELIVER #####
 
 # crane digest cgr.dev/chainguard/node-lts:latest
-FROM cgr.dev/chainguard/node:latest@sha256:f771505c29d1f766c1dc4d3b2ed0f8660a76553685b9d886728bc55d6f430ce8
+# cgr.dev/chainguard/node:latest@sha256:f771505c29d1f766c1dc4d3b2ed0f8660a76553685b9d886728bc55d6f430ce8
+# gcr.io/distroless/nodejs22-debian12@sha256:d00edbf864c5b989f1b69951a13c5c902bf369cca572de59b5ec972552848e33
+FROM gcr.io/distroless/nodejs22-debian12:nonroot@sha256:06298f87531dfff6dd2bc6b573095162d25f7e5583abbc865bfcdf45a4fbee16
 
 WORKDIR /app
 
-COPY --from=build --chown=node:node /app/node_modules/ ./node_modules/
+COPY --from=build --chown=nonroot:nonroot /app/node_modules/ ./node_modules/

--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -105,8 +105,7 @@ export function watcherDeployTemplate(buildTimestamp: string): string {
                   - name: {{ . }}
                   {{- end }}
                 {{- end }}
-                command:
-                  - node
+                args:
                   - /app/node_modules/pepr/dist/controller.js
                   - {{ .Values.hash }}
                 readinessProbe:
@@ -195,8 +194,7 @@ export function admissionDeployTemplate(buildTimestamp: string): string {
                   - name: {{ . }}
                   {{- end }}
                 {{- end }}
-                command:
-                  - node
+                args:
                   - /app/node_modules/pepr/dist/controller.js
                   - {{ .Values.hash }}
                 readinessProbe:

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -109,7 +109,7 @@ export function getWatcher(
               name: "watcher",
               image,
               imagePullPolicy: "IfNotPresent",
-              command: ["node", "/app/node_modules/pepr/dist/controller.js", hash],
+              args: ["/app/node_modules/pepr/dist/controller.js", hash],
               readinessProbe: {
                 httpGet: {
                   path: "/healthz",
@@ -248,7 +248,7 @@ export function getDeployment(
               name: "server",
               image,
               imagePullPolicy: "IfNotPresent",
-              command: ["node", "/app/node_modules/pepr/dist/controller.js", hash],
+              args: ["/app/node_modules/pepr/dist/controller.js", hash],
               readinessProbe: {
                 httpGet: {
                   path: "/healthz",


### PR DESCRIPTION
## Description

If we can't use chainguard free because it's only node:23+ then what about building on upstream node:22 & running with distroless?

## Related Issue

Relates to # 1676

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
