### PR TITLE
chore: deployments for soak for new image

### DIFF
--- a/hack/soak.ci.yaml
+++ b/hack/soak.ci.yaml
@@ -102,8 +102,7 @@ spec:
         - name: server
           image: pepr:dev
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - /app/node_modules/pepr/dist/controller.js
             - 72bd9a27f01b365525d6bd9b153743cddc39044d105345c3c2bc5de405dbcdf3
           readinessProbe:
@@ -271,8 +270,7 @@ spec:
         - name: watcher
           image: pepr:dev
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - /app/node_modules/pepr/dist/controller.js
             - 72bd9a27f01b365525d6bd9b153743cddc39044d105345c3c2bc5de405dbcdf3
           readinessProbe:


### PR DESCRIPTION
## Description

The `soak.ci.yaml` uses pre-built manifests. When this [PR](https://github.com/defenseunicorns/pepr/pull/1684) merged we went to a distroless image where `node` is not in the path on the image. We need to update the args on the deployments. 

[Job Failure](https://github.com/defenseunicorns/pepr/actions/runs/12840693540/job/35809678165)

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
