### PR TITLE
chore: update soak-interrupts test

### DIFF
--- a/.github/workflows/soak-interrupts.yaml
+++ b/.github/workflows/soak-interrupts.yaml
@@ -180,13 +180,13 @@ jobs:
                 fi
               done
 
-              # Every 20 minutes, scale up or down the `watch-auditor` deployment
+              # Every 20 minutes, scale up or down the watcher deployment
               if [ $((i % 4)) -eq 0 ]; then
                 echo "Scaling down the watch-auditor deployment to 0 replicas"
-                kubectl scale deploy/watch-auditor -n watch-auditor --replicas=0
+                kubectl scale deploy/pepr-soak-ci-watcher -n pepr-system --replicas=0
               else
                 echo "Scaling up the watch-auditor deployment to 1 replica"
-                kubectl scale deploy/watch-auditor -n watch-auditor --replicas=1
+                kubectl scale deploy/pepr-soak-ci-watcher -n pepr-system --replicas=1
               fi
             fi
             sleep 300s  # Sleep for 5 minutes before the next iteration


### PR DESCRIPTION
## Description

Soak interrupts test is not scaling down the Pepr deployment, this fixes that. 

## Related Issue

Fixes #1701
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
