### PR TITLE
chore: restore early exit on build no-embed

### DIFF
--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -48,6 +48,7 @@ describe("build", () => {
           const argz = [`--no-embed`].join(" ");
           const build = await pepr.cli(testModule, { cmd: `pepr build ${argz}` });
           expect(build.exitcode).toBe(0);
+          expect(build.stderr.join("").trim()).toContain("");
           expect(build.stdout.join("").trim()).toContain("Module built successfully at");
 
           packageJson = await resource.fromFile(`${testModule}/package.json`);

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -48,8 +48,7 @@ describe("build", () => {
           const argz = [`--no-embed`].join(" ");
           const build = await pepr.cli(testModule, { cmd: `pepr build ${argz}` });
           expect(build.exitcode).toBe(0);
-          expect(build.stderr.join("").trim()).toContain("Error: Cannot find module");
-          expect(build.stdout.join("").trim()).toContain("");
+          expect(build.stdout.join("").trim()).toContain("Module built successfully at");
 
           packageJson = await resource.fromFile(`${testModule}/package.json`);
           uuid = packageJson.pepr.uuid;

--- a/src/cli/build.helpers.ts
+++ b/src/cli/build.helpers.ts
@@ -106,7 +106,6 @@ export async function handleCustomImageBuild(
   image: string,
 ): Promise<void> {
   if (includedFiles.length > 0) {
-    console.info(`Including ${includedFiles.length} files in controller image.`);
     await createDockerfile(peprVersion, description, includedFiles);
     execSync(`docker build --tag ${image} -f Dockerfile.controller .`, {
       stdio: "inherit",

--- a/src/cli/build.helpers.ts
+++ b/src/cli/build.helpers.ts
@@ -123,7 +123,7 @@ export async function handleCustomImageBuild(
 export function handleEmbedding(embed: boolean, path: string): void {
   if (!embed) {
     console.info(`✅ Module built successfully at ${path}`);
-    return;
+    process.exit(0);
   }
 }
 

--- a/src/cli/build.helpers.ts
+++ b/src/cli/build.helpers.ts
@@ -11,51 +11,18 @@ import { promises as fs } from "fs";
 import { generateAllYaml } from "../lib/assets/yaml/generateAllYaml";
 import { webhookConfigGenerator } from "../lib/assets/webhooks";
 import { generateZarfYamlGeneric } from "../lib/assets/yaml/generateZarfYaml";
-import { ModuleConfig } from "../lib/core/module";
 
-export type PeprNestedFields = Pick<
-  ModuleConfig,
-  | "uuid"
-  | "onError"
-  | "webhookTimeout"
-  | "customLabels"
-  | "alwaysIgnore"
-  | "env"
-  | "rbac"
-  | "rbacMode"
-> & {
-  peprVersion: string;
-};
-
-export type LoadModuleReturn = {
-  cfg: PeprConfig;
-  entryPointPath: string;
-  modulePath: string;
-  name: string;
-  path: string;
-  uuid: string;
-};
-
-export type PeprConfig = Omit<ModuleConfig, keyof PeprNestedFields> & {
-  pepr: PeprNestedFields & {
-    includedFiles: string[];
-  };
-  description: string;
-  version: string;
-};
-
-export type BuildModuleReturn = {
-  ctx: BuildContext<BuildOptions>;
-  path: string;
-  cfg: PeprConfig;
-  uuid: string;
-};
 interface ImageOptions {
   customImage?: string;
   registryInfo?: string;
   peprVersion?: string;
   registry?: string;
 }
+/**
+ * Assign image string
+ * @param imageOptions CLI options for image
+ * @returns image string
+ */
 export function assignImage(imageOptions: ImageOptions): string {
   const { customImage, registryInfo, peprVersion, registry } = imageOptions;
   if (customImage) {
@@ -71,12 +38,6 @@ export function assignImage(imageOptions: ImageOptions): string {
   }
 
   return "";
-}
-export function shouldExitEarly(buildModuleResult: BuildModuleReturn): boolean {
-  if (buildModuleResult?.cfg && buildModuleResult.path && buildModuleResult.uuid) {
-    return false;
-  }
-  return true;
 }
 
 export type Reloader = (opts: BuildResult<BuildOptions>) => void | Promise<void>;

--- a/src/cli/build.helpers.ts
+++ b/src/cli/build.helpers.ts
@@ -106,6 +106,7 @@ export async function handleCustomImageBuild(
   image: string,
 ): Promise<void> {
   if (includedFiles.length > 0) {
+    console.info(`Including ${includedFiles.length} files in controller image.`);
     await createDockerfile(peprVersion, description, includedFiles);
     execSync(`docker build --tag ${image} -f Dockerfile.controller .`, {
       stdio: "inherit",

--- a/src/cli/build.test.ts
+++ b/src/cli/build.test.ts
@@ -4,12 +4,16 @@
 import {
   determineRbacMode,
   handleCustomOutputDir,
-  handleEmbedding,
   handleValidCapabilityNames,
   handleCustomImageBuild,
   checkIronBankImage,
   validImagePullSecret,
+  assignImage,
+  // shouldExitEarly,
+  // BuildModuleReturn,
+  // PeprConfig
 } from "./build.helpers";
+// import { BuildOptions, BuildContext, BuildResult, ServeResult } from "esbuild";
 import { createDirectoryIfNotExists } from "../lib/filesystemService";
 import { expect, describe, it, jest, beforeEach } from "@jest/globals";
 import { createDockerfile } from "../lib/included-files";
@@ -28,6 +32,111 @@ jest.mock("../lib/included-files", () => ({
 jest.mock("../lib/filesystemService", () => ({
   createDirectoryIfNotExists: jest.fn(),
 }));
+
+// describe("shouldExitEarly", () => {
+
+//   it("should return true if buildModuleResult is missing required fields", () => {
+//     const buildModuleResult: BuildModuleReturn = {} as BuildModuleReturn;
+//     const result = shouldExitEarly(buildModuleResult);
+//     expect(result).toBe(true);
+//   });
+
+//   it("should return false if buildModuleResult has all required fields", () => {
+//     const config: PeprConfig = {
+//       pepr: {
+//         uuid: "some-uuid",
+//         onError: "ignore",
+//         webhookTimeout: 30,
+//         customLabels: {},
+//         alwaysIgnore: {
+//           namespaces: [],
+//         },
+//         env: {},
+//         rbac: [],
+//         rbacMode: "minimal",
+//         peprVersion: "1.0.0",
+//         includedFiles: [],
+//       },
+//       description: "A test module",
+//       version: "1.0.0",
+//     };
+
+//     const mockContext: BuildContext<BuildOptions> = {
+//       rebuild: jest.fn<() => Promise<BuildResult<BuildOptions>>>().mockImplementation(() =>
+//         Promise.resolve({} as BuildResult<BuildOptions>)
+//       ),
+//       dispose: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
+//       watch: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
+//       cancel: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
+//       serve: jest.fn<() => Promise<ServeResult>>().mockImplementation(() =>
+//         Promise.resolve({ host: "localhost", port: 8000 })
+//       ),
+//     };
+//     const buildModuleResult: BuildModuleReturn = {
+//       ctx: mockContext,
+//       path: "some-path",
+//       cfg: config,
+//       uuid: "some-uuid",
+//     };
+//     const result = shouldExitEarly(buildModuleResult);
+//     expect(result).toBe(false);
+//   });
+
+//   it("should return true if any field in buildModuleResult is falsy", () => {
+//     const buildModuleResult: BuildModuleReturn = {
+//       path: "some-path",
+//       uuid: "some-uuid",
+//     } as BuildModuleReturn;
+//     const result = shouldExitEarly(buildModuleResult);
+//     expect(result).toBe(true);
+//   });
+// });
+
+describe("assignImage", () => {
+  const mockPeprVersion = "1.0.0";
+
+  it("should return the customImage if provided", () => {
+    const result = assignImage({
+      customImage: "pepr:dev",
+      registryInfo: "docker.io/defenseunicorns",
+      peprVersion: mockPeprVersion,
+      registry: "my-registry",
+    });
+    expect(result).toBe("pepr:dev");
+  });
+
+  it("should return registryInfo with custom-pepr-controller and peprVersion if customImage is not provided", () => {
+    const result = assignImage({
+      customImage: "",
+      registryInfo: "docker.io/defenseunicorns",
+      peprVersion: mockPeprVersion,
+      registry: "my-registry",
+    });
+    expect(result).toBe(`docker.io/defenseunicorns/custom-pepr-controller:1.0.0`);
+  });
+
+  it("should return IronBank image if registry is provided and others are not", () => {
+    const result = assignImage({
+      customImage: "",
+      registryInfo: "",
+      peprVersion: mockPeprVersion,
+      registry: "Iron Bank",
+    });
+    expect(result).toBe(
+      `registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller:v${mockPeprVersion}`,
+    );
+  });
+
+  it("should return an empty string if none of the conditions are met", () => {
+    const result = assignImage({
+      customImage: "",
+      registryInfo: "",
+      peprVersion: "",
+      registry: "",
+    });
+    expect(result).toBe("");
+  });
+});
 
 describe("determineRbacMode", () => {
   it("should allow CLI options to overwrite module config", () => {
@@ -171,32 +280,6 @@ describe("handleCustomImageBuild", () => {
     expect(mockedExecSync).not.toHaveBeenCalled();
   });
 });
-describe("handleEmbedding", () => {
-  const consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should log success message if embed is false", () => {
-    const embed = false;
-    const path = "test/path";
-
-    handleEmbedding(embed, path);
-
-    expect(consoleInfoSpy).toHaveBeenCalledWith(`✅ Module built successfully at ${path}`);
-  });
-
-  it("should not log success message if embed is true", () => {
-    const embed = true;
-    const path = "test/path";
-
-    handleEmbedding(embed, path);
-
-    expect(consoleInfoSpy).not.toHaveBeenCalled();
-  });
-});
-
 describe("handleValidCapabilityNames", () => {
   const mockExit = jest.spyOn(process, "exit").mockImplementation(() => {
     return undefined as never;

--- a/src/cli/build.test.ts
+++ b/src/cli/build.test.ts
@@ -9,11 +9,8 @@ import {
   checkIronBankImage,
   validImagePullSecret,
   assignImage,
-  // shouldExitEarly,
-  // BuildModuleReturn,
-  // PeprConfig
 } from "./build.helpers";
-// import { BuildOptions, BuildContext, BuildResult, ServeResult } from "esbuild";
+
 import { createDirectoryIfNotExists } from "../lib/filesystemService";
 import { expect, describe, it, jest, beforeEach } from "@jest/globals";
 import { createDockerfile } from "../lib/included-files";
@@ -32,65 +29,6 @@ jest.mock("../lib/included-files", () => ({
 jest.mock("../lib/filesystemService", () => ({
   createDirectoryIfNotExists: jest.fn(),
 }));
-
-// describe("shouldExitEarly", () => {
-
-//   it("should return true if buildModuleResult is missing required fields", () => {
-//     const buildModuleResult: BuildModuleReturn = {} as BuildModuleReturn;
-//     const result = shouldExitEarly(buildModuleResult);
-//     expect(result).toBe(true);
-//   });
-
-//   it("should return false if buildModuleResult has all required fields", () => {
-//     const config: PeprConfig = {
-//       pepr: {
-//         uuid: "some-uuid",
-//         onError: "ignore",
-//         webhookTimeout: 30,
-//         customLabels: {},
-//         alwaysIgnore: {
-//           namespaces: [],
-//         },
-//         env: {},
-//         rbac: [],
-//         rbacMode: "minimal",
-//         peprVersion: "1.0.0",
-//         includedFiles: [],
-//       },
-//       description: "A test module",
-//       version: "1.0.0",
-//     };
-
-//     const mockContext: BuildContext<BuildOptions> = {
-//       rebuild: jest.fn<() => Promise<BuildResult<BuildOptions>>>().mockImplementation(() =>
-//         Promise.resolve({} as BuildResult<BuildOptions>)
-//       ),
-//       dispose: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
-//       watch: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
-//       cancel: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
-//       serve: jest.fn<() => Promise<ServeResult>>().mockImplementation(() =>
-//         Promise.resolve({ host: "localhost", port: 8000 })
-//       ),
-//     };
-//     const buildModuleResult: BuildModuleReturn = {
-//       ctx: mockContext,
-//       path: "some-path",
-//       cfg: config,
-//       uuid: "some-uuid",
-//     };
-//     const result = shouldExitEarly(buildModuleResult);
-//     expect(result).toBe(false);
-//   });
-
-//   it("should return true if any field in buildModuleResult is falsy", () => {
-//     const buildModuleResult: BuildModuleReturn = {
-//       path: "some-path",
-//       uuid: "some-uuid",
-//     } as BuildModuleReturn;
-//     const result = shouldExitEarly(buildModuleResult);
-//     expect(result).toBe(true);
-//   });
-// });
 
 describe("assignImage", () => {
   const mockPeprVersion = "1.0.0";

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -227,7 +227,7 @@ export async function buildModule(
   reloader?: Reloader,
   entryPoint = peprTS,
   embed = true,
-): Promise<BuildModuleReturn> {
+): Promise<BuildModuleReturn | void> {
   try {
     const { cfg, modulePath, path, uuid } = await loadModule(entryPoint);
 

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -136,7 +136,8 @@ export default function (program: RootCmd): void {
       const buildModuleResult = await buildModule(undefined, opts.entryPoint, opts.embed);
       if (buildModuleResult?.cfg && buildModuleResult.path && buildModuleResult.uuid) {
         const { cfg, path, uuid } = buildModuleResult;
-
+        // Files to include in controller image for WASM support
+        const { includedFiles } = cfg.pepr;
         let image = opts.customImage || "";
 
         // Check if there is a custom timeout defined
@@ -149,12 +150,7 @@ export default function (program: RootCmd): void {
           image = `${opts.registryInfo}/custom-pepr-controller:${cfg.pepr.peprVersion}`;
 
           // only actually build/push if there are files to include
-          await handleCustomImageBuild(
-            cfg.pepr.includedFiles,
-            cfg.pepr.peprVersion,
-            cfg.description,
-            image,
-          );
+          await handleCustomImageBuild(includedFiles, cfg.pepr.peprVersion, cfg.description, image);
         }
 
         // If building without embedding, exit after building

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -2,12 +2,7 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { execFileSync } from "child_process";
-import {
-  // BuildContext,
-  BuildOptions,
-  BuildResult,
-  analyzeMetafile,
-} from "esbuild";
+import { BuildOptions, BuildResult, analyzeMetafile } from "esbuild";
 import { promises as fs } from "fs";
 import { basename, dirname, extname, resolve } from "path";
 import { Assets } from "../lib/assets/assets";
@@ -23,7 +18,6 @@ import {
   handleCustomOutputDir,
   handleValidCapabilityNames,
   handleCustomImageBuild,
-  // shouldExitEarly,
   validImagePullSecret,
   generateYamlAndWriteToDisk,
   BuildModuleReturn,
@@ -103,9 +97,6 @@ export default function (program: RootCmd): void {
       // Build the module
       const buildModuleResult = await buildModule(undefined, opts.entryPoint, opts.embed);
 
-      // if (shouldExitEarly(buildModuleResult)) {
-      //   return;
-      // }
       const { cfg, path, uuid } = buildModuleResult!;
       const image = assignImage({
         customImage: opts.customImage,

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -146,6 +146,7 @@ export default function (program: RootCmd): void {
         }
 
         if (opts.registryInfo !== undefined) {
+          console.info(`Including ${includedFiles.length} files in controller image.`);
           // for journey test to make sure the image is built
           image = `${opts.registryInfo}/custom-pepr-controller:${cfg.pepr.peprVersion}`;
 

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -136,8 +136,6 @@ export default function (program: RootCmd): void {
       const buildModuleResult = await buildModule(undefined, opts.entryPoint, opts.embed);
       if (buildModuleResult?.cfg && buildModuleResult.path && buildModuleResult.uuid) {
         const { cfg, path, uuid } = buildModuleResult;
-        // Files to include in controller image for WASM support
-        const { includedFiles } = cfg.pepr;
 
         let image = opts.customImage || "";
 
@@ -147,13 +145,16 @@ export default function (program: RootCmd): void {
         }
 
         if (opts.registryInfo !== undefined) {
-          console.info(`Including ${includedFiles.length} files in controller image.`);
-
           // for journey test to make sure the image is built
           image = `${opts.registryInfo}/custom-pepr-controller:${cfg.pepr.peprVersion}`;
 
           // only actually build/push if there are files to include
-          await handleCustomImageBuild(includedFiles, cfg.pepr.peprVersion, cfg.description, image);
+          await handleCustomImageBuild(
+            cfg.pepr.includedFiles,
+            cfg.pepr.peprVersion,
+            cfg.description,
+            image,
+          );
         }
 
         // If building without embedding, exit after building

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -106,7 +106,7 @@ export default function (program: RootCmd): void {
       // if (shouldExitEarly(buildModuleResult)) {
       //   return;
       // }
-      const { cfg, path, uuid } = buildModuleResult;
+      const { cfg, path, uuid } = buildModuleResult!;
       const image = assignImage({
         customImage: opts.customImage,
         registryInfo: opts.registryInfo,

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -183,7 +183,6 @@ export default function (program: RootCmd): void {
         opts.withPullSecret === "" ? [] : [opts.withPullSecret],
       );
 
-      // if image is a custom image, use that instead of the default
       image !== "" ? (assets.image = image) : null;
 
       // Ensure imagePullSecret is valid


### PR DESCRIPTION
## Description

When running a build using `--no-embed` the build should _not_ generate the Pepr module as a secret as used during typical builds. As we were working towards reducing statements in the build file a function was created to handle the embed option and stop execution. This PR updates the function to stop execution which was causing the command to write to `stdErr`

While implementing this fix I encountered errors and needed to satisfy eslint configs
```bash
src/cli/build.ts
  131:13  warning  Async arrow function has too many statements (21). Maximum allowed is 20  max-statements
  131:13  warning  Async arrow function has a complexity of 11. Maximum allowed is 10        complexity
```


## Related Issue

Fixes #1659 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
