### PR TITLE
feat: nightly releases of pepr cli and controller image

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -44,36 +44,4 @@ jobs:
       - name: Publish to GHCR and NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          #!/bin/bash
-
-          npm install -g npm
-
-          LATEST_VERSION=$(npx pepr@latest version 2>/dev/null)
-          RAW_NIGHTLY_VERSION=$(npx pepr@nightly version 2>/dev/null || echo "none")
-
-          if [[ "$RAW_NIGHTLY_VERSION" == "none" ]]; then
-            echo "No nightly version found. Setting NIGHTLY_VERSION=0."
-            NIGHTLY_VERSION=0
-          else
-            NIGHTLY_VERSION_PART=$(echo "$RAW_NIGHTLY_VERSION" | grep -oE "nightly\.([0-9]+)" | cut -d. -f2)
-
-            BASE_NIGHTLY_VERSION=${RAW_NIGHTLY_VERSION%-nightly*}
-            if [[ "$LATEST_VERSION" > "$BASE_NIGHTLY_VERSION" ]]; then
-              echo "Nightly version is less than the latest version. Resetting NIGHTLY_VERSION to 0."
-              NIGHTLY_VERSION=0
-            else
-              NIGHTLY_VERSION=$((NIGHTLY_VERSION_PART + 1))
-              echo "Incrementing NIGHTLY_VERSION to $NIGHTLY_VERSION."
-            fi
-          fi
-
-          FULL_VERSION="${LATEST_VERSION}-nightly.${NIGHTLY_VERSION}"
-
-          echo "FULL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
-
-          npm version --no-git-tag-version $FULL_VERSION
-
-          docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:$FULL_VERSION .
-
-          npm publish --tag "nightly"
+        run: ./scripts/nightlies.sh

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,0 +1,79 @@
+name: Nightlies
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: "Pepr Controller: Login to GHCR"
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: dummy
+          password: ${{ github.token }}
+
+      - name: Publish to GHCR and NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          #!/bin/bash
+
+          npm install -g npm
+
+          LATEST_VERSION=$(npx pepr@latest version 2>/dev/null)
+          RAW_NIGHTLY_VERSION=$(npx pepr@nightly version 2>/dev/null || echo "none")
+
+          if [[ "$RAW_NIGHTLY_VERSION" == "none" ]]; then
+            echo "No nightly version found. Setting NIGHTLY_VERSION=0."
+            NIGHTLY_VERSION=0
+          else
+            NIGHTLY_VERSION_PART=$(echo "$RAW_NIGHTLY_VERSION" | grep -oE "nightly\.([0-9]+)" | cut -d. -f2)
+
+            BASE_NIGHTLY_VERSION=${RAW_NIGHTLY_VERSION%-nightly*}
+            if [[ "$LATEST_VERSION" > "$BASE_NIGHTLY_VERSION" ]]; then
+              echo "Nightly version is less than the latest version. Resetting NIGHTLY_VERSION to 0."
+              NIGHTLY_VERSION=0
+            else
+              NIGHTLY_VERSION=$((NIGHTLY_VERSION_PART + 1))
+              echo "Incrementing NIGHTLY_VERSION to $NIGHTLY_VERSION."
+            fi
+          fi
+
+          FULL_VERSION="${LATEST_VERSION}-nightly.${NIGHTLY_VERSION}"
+
+          echo "FULL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
+
+          npm version --no-git-tag-version $FULL_VERSION
+
+          docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:$FULL_VERSION .
+
+          npm publish --tag "nightly"

--- a/scripts/nightlies.sh
+++ b/scripts/nightlies.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+# Script to build and publish nightly versions of Pepr Controller and Pepr CLI.
+
+set -e
+npm install -g npm
+
+LATEST_VERSION=$(npx --yes pepr@latest --version 2>/dev/null)
+RAW_NIGHTLY_VERSION=$(npx --yes pepr@nightly --version 2>/dev/null || echo "none")
+
+if [[ "$RAW_NIGHTLY_VERSION" == "none" ]]; then
+    echo "No nightly version found. Setting NIGHTLY_VERSION=0."
+    NIGHTLY_VERSION=0
+else
+    NIGHTLY_VERSION_PART=$(echo "$RAW_NIGHTLY_VERSION" | grep -oE "nightly\.([0-9]+)" | cut -d. -f2)
+
+    BASE_NIGHTLY_VERSION=${RAW_NIGHTLY_VERSION%-nightly*}
+    if [[ "$LATEST_VERSION" > "$BASE_NIGHTLY_VERSION" ]]; then
+        echo "Nightly version is less than the latest version. Resetting NIGHTLY_VERSION to 0."
+        NIGHTLY_VERSION=0
+    else
+        NIGHTLY_VERSION=$((NIGHTLY_VERSION_PART + 1))
+        echo "Incrementing NIGHTLY_VERSION to $NIGHTLY_VERSION."
+    fi
+fi
+
+FULL_VERSION="${LATEST_VERSION}-nightly.${NIGHTLY_VERSION}"
+
+echo "FULL_VERSION=$FULL_VERSION" >> "$GITHUB_ENV"
+
+npm version --no-git-tag-version "$FULL_VERSION"
+
+docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:"$FULL_VERSION" .
+
+npm publish --tag "nightly"


### PR DESCRIPTION
## Description

As the next step in Pepr's automation journey this PR creates nightly releases of the CLI and controller image. As discussed, the nightly is version is as followings, `pepr_version`-night.[0-x]`.

The first time this is run, there will be a nightly of the current release with a prerelease version of 0 that will increment as many times as the task is run until the next release comes out, then it will start over at 0.

The tag is always set to nightly, the latest pepr code can be utilized through `npx pepr@nightly [command]`


## Related Issue

Fixes #1692 
<!-- or -->
Relates to #1096 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
