### PR TITLE
chore: error on max-params

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
     "eqeqeq": "error",
     "max-depth": ["warn", { "max": 3 }],
     "max-nested-callbacks": ["warn", { "max": 4 }],
-    "max-params": ["warn", { "max": 4 }],
+    "max-params": ["error", { "max": 4 }],
     "max-statements": ["warn", { "max": 20 }, { "ignoreTopLevelFunctions": true }],
     "no-invalid-this": "warn"
   },


### PR DESCRIPTION
## Description

There is currently only one maxParams error, should we go ahead and enforce this with an error and then get this #1728 ready to merge with deprecation warnings? 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
