### PR TITLE
chore: reduce duplication between pepr-build and pepr-build-wasm in journey tests

### DIFF
--- a/journey/entrypoint-wasm.test.ts
+++ b/journey/entrypoint-wasm.test.ts
@@ -4,7 +4,7 @@
 import { describe, jest, afterAll } from "@jest/globals";
 import { peprBuild } from "./pepr-build-wasm";
 import { removeFolder } from "./utils";
-import { outputDir } from "./pepr-build-wasm";
+import { outputDir } from "./pepr-build.helpers";
 // Unmock unit test things
 jest.deepUnmock("pino");
 

--- a/journey/entrypoint.test.ts
+++ b/journey/entrypoint.test.ts
@@ -10,7 +10,7 @@ import { peprDev } from "./pepr-dev";
 import { peprFormat } from "./pepr-format";
 import { peprInit } from "./pepr-init";
 import { removeFolder } from "./utils";
-import { outputDir } from "./pepr-build-wasm";
+import { outputDir } from "./pepr-build.helpers";
 // Unmock unit test things
 jest.deepUnmock("pino");
 

--- a/journey/pepr-build-wasm.ts
+++ b/journey/pepr-build-wasm.ts
@@ -11,13 +11,12 @@ import { validateZarfYaml, outputDir, validateOverridesYamlRbac } from "./pepr-b
 
 export function peprBuild() {
   beforeAll(async () => {
-    const dir = resolve(cwd);
     await fs.mkdir(outputDir, { recursive: true });
     await addScopedRbacMode();
   });
-  it("should successfully build the Pepr project with arguments and rbacMode scoped", async () => {
+  it("should successfully build the Pepr project with specific output directory and rbacMode scoped", async () => {
     execSync(`npx pepr build -r gchr.io/defenseunicorns -o ${outputDir}`, {
-      cwd: cwd,
+      cwd,
       stdio: "inherit",
     });
   });
@@ -26,15 +25,17 @@ export function peprBuild() {
     await fs.access(resolve(cwd, outputDir, "pepr-module-static-test.yaml"));
   });
 
-  it("should generate a custom image in zarf.yaml", async () => {
-    await fs.access(resolve(cwd, outputDir, "zarf.yaml"));
+  it("should generate a custom image in zarf.yaml with correct image", async () => {
+    const zarfFilePath = resolve(cwd, outputDir, "zarf.yaml");
+    await fs.access(zarfFilePath);
     const expectedImage = `gchr.io/defenseunicorns/custom-pepr-controller:${execSync("npx pepr --version", { cwd }).toString().trim()}`;
 
-    await validateZarfYaml(expectedImage);
+    await validateZarfYaml(expectedImage, zarfFilePath);
   });
 
-  it("should generate a scoped ClusterRole", async () => {
-    await validateOverridesYamlRbac();
+  it("should generate the right values in the values file to create a scoped clusterRole", async () => {
+    const valuesFilePath = resolve(cwd, outputDir, "static-test-chart", "values.yaml");
+    await validateOverridesYamlRbac(valuesFilePath);
   });
 }
 

--- a/journey/pepr-build.helpers.ts
+++ b/journey/pepr-build.helpers.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+import { promises as fs } from "fs";
+import { resolve } from "path";
+import { cwd } from "./entrypoint.test";
+import { loadYaml } from "@kubernetes/client-node";
+import { expect } from "@jest/globals";
+import yaml from "js-yaml";
+import { V1PolicyRule as PolicyRule } from "@kubernetes/client-node";
+
+export const outputDir = "dist/pepr-test-module/child/folder";
+
+export async function validateZarfYaml(expectedImage: string) {
+  // Read the generated yaml files
+  const zarfYAML = await fs.readFile(resolve(cwd, "dist", "zarf.yaml"), "utf8");
+
+  const expectedZarfYaml = {
+    kind: "ZarfPackageConfig",
+    metadata: {
+      name: "pepr-static-test",
+      description: "Pepr Module: A test module for Pepr",
+      url: "https://github.com/defenseunicorns/pepr",
+      version: "0.0.1",
+    },
+    components: [
+      {
+        name: "module",
+        required: true,
+        manifests: [
+          {
+            name: "module",
+            namespace: "pepr-system",
+            files: ["pepr-module-static-test.yaml"],
+          },
+        ],
+        images: [`${expectedImage}`],
+      },
+    ],
+  };
+
+  const actualZarfYaml = loadYaml(zarfYAML);
+  expect(actualZarfYaml).toEqual(expectedZarfYaml);
+}
+
+export async function validateClusterRoleYaml() {
+  // Read the generated yaml files
+  const k8sYaml = await fs.readFile(
+    resolve(cwd, outputDir, "pepr-module-static-test.yaml"),
+    "utf8",
+  );
+  const cr = await fs.readFile(resolve("journey", "resources", "clusterrole.yaml"), "utf8");
+  expect(k8sYaml.includes(cr)).toEqual(true);
+}
+
+export async function validateOverridesYamlRbac() {
+  const yamlChartRBAC = await fs.readFile(resolve("journey", "resources", "values.yaml"), "utf8");
+  const expectedYamlChartRBAC = await fs.readFile(
+    resolve("journey", "resources", "values.yaml"),
+    "utf8",
+  );
+  const jsonChartRBAC = yaml.load(yamlChartRBAC) as Record<string, PolicyRule[]>;
+  const expectedJsonChartRBAC = yaml.load(expectedYamlChartRBAC) as Record<string, PolicyRule[]>;
+
+  expect(JSON.stringify(jsonChartRBAC)).toEqual(JSON.stringify(expectedJsonChartRBAC));
+}

--- a/journey/pepr-build.helpers.ts
+++ b/journey/pepr-build.helpers.ts
@@ -10,6 +10,9 @@ import { V1PolicyRule as PolicyRule } from "@kubernetes/client-node";
 
 export const outputDir = "dist/pepr-test-module/child/folder";
 
+/*
+ * Validate the generated Zarf yaml file and image
+ */
 export async function validateZarfYaml(expectedImage: string) {
   // Read the generated yaml files
   const zarfYAML = await fs.readFile(resolve(cwd, "dist", "zarf.yaml"), "utf8");
@@ -42,6 +45,9 @@ export async function validateZarfYaml(expectedImage: string) {
   expect(actualZarfYaml).toEqual(expectedZarfYaml);
 }
 
+/*
+ * Validate the ClusterRole generated in the K8s yaml file has appropriate rules
+ */
 export async function validateClusterRoleYaml() {
   // Read the generated yaml files
   const k8sYaml = await fs.readFile(
@@ -51,6 +57,10 @@ export async function validateClusterRoleYaml() {
   const cr = await fs.readFile(resolve("journey", "resources", "clusterrole.yaml"), "utf8");
   expect(k8sYaml.includes(cr)).toEqual(true);
 }
+
+/*
+ * Validate the values.yaml file in the helm chart has the appropriate RBAC rules
+ */
 
 export async function validateOverridesYamlRbac() {
   const yamlChartRBAC = await fs.readFile(resolve("journey", "resources", "values.yaml"), "utf8");

--- a/journey/pepr-build.helpers.ts
+++ b/journey/pepr-build.helpers.ts
@@ -13,9 +13,9 @@ export const outputDir = "dist/pepr-test-module/child/folder";
 /*
  * Validate the generated Zarf yaml file and image
  */
-export async function validateZarfYaml(expectedImage: string) {
-  // Read the generated yaml files
-  const zarfYAML = await fs.readFile(resolve(cwd, "dist", "zarf.yaml"), "utf8");
+export async function validateZarfYaml(expectedImage: string, filePath: string) {
+  // Read the generated yaml files from the child folder
+  const zarfYAML = await fs.readFile(filePath, "utf8");
 
   const expectedZarfYaml = {
     kind: "ZarfPackageConfig",
@@ -48,12 +48,9 @@ export async function validateZarfYaml(expectedImage: string) {
 /*
  * Validate the ClusterRole generated in the K8s yaml file has appropriate rules
  */
-export async function validateClusterRoleYaml() {
+export async function validateClusterRoleYaml(manifestsPath: string) {
   // Read the generated yaml files
-  const k8sYaml = await fs.readFile(
-    resolve(cwd, outputDir, "pepr-module-static-test.yaml"),
-    "utf8",
-  );
+  const k8sYaml = await fs.readFile(manifestsPath, "utf8");
   const cr = await fs.readFile(resolve("journey", "resources", "clusterrole.yaml"), "utf8");
   expect(k8sYaml.includes(cr)).toEqual(true);
 }
@@ -62,8 +59,8 @@ export async function validateClusterRoleYaml() {
  * Validate the values.yaml file in the helm chart has the appropriate RBAC rules
  */
 
-export async function validateOverridesYamlRbac() {
-  const yamlChartRBAC = await fs.readFile(resolve("journey", "resources", "values.yaml"), "utf8");
+export async function validateOverridesYamlRbac(valuesFilePath: string) {
+  const yamlChartRBAC = await fs.readFile(valuesFilePath, "utf8");
   const expectedYamlChartRBAC = await fs.readFile(
     resolve("journey", "resources", "values.yaml"),
     "utf8",
@@ -71,5 +68,5 @@ export async function validateOverridesYamlRbac() {
   const jsonChartRBAC = yaml.load(yamlChartRBAC) as Record<string, PolicyRule[]>;
   const expectedJsonChartRBAC = yaml.load(expectedYamlChartRBAC) as Record<string, PolicyRule[]>;
 
-  expect(JSON.stringify(jsonChartRBAC)).toEqual(JSON.stringify(expectedJsonChartRBAC));
+  expect(JSON.stringify(jsonChartRBAC.rbac)).toEqual(JSON.stringify(expectedJsonChartRBAC.rbac));
 }

--- a/journey/pepr-build.ts
+++ b/journey/pepr-build.ts
@@ -2,15 +2,13 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 import { loadAllYaml } from "@kubernetes/client-node";
 import { expect, it } from "@jest/globals";
-import { loadYaml } from "@kubernetes/client-node";
 import { execSync } from "child_process";
 import { promises as fs } from "fs";
 import { resolve } from "path";
 import { V1ObjectMeta, KubernetesObject } from "@kubernetes/client-node";
 import yaml from "js-yaml";
 import { cwd } from "./entrypoint.test";
-
-const outputDir = "dist/pepr-test-module/child/folder";
+import { validateZarfYaml, outputDir, validateClusterRoleYaml } from "./pepr-build.helpers";
 
 export function peprBuild() {
   it("should successfully build the Pepr project", async () => {
@@ -31,7 +29,8 @@ export function peprBuild() {
 
   it("should generate the zarf.yaml file", async () => {
     await fs.access(resolve(cwd, "dist", "zarf.yaml"));
-    await validateZarfYaml();
+    const expectedImage = `ghcr.io/defenseunicorns/pepr/controller:v${execSync("npx pepr --version", { cwd }).toString().trim()}`;
+    await validateZarfYaml(expectedImage);
   });
 
   it("should generate a scoped ClusterRole", async () => {
@@ -100,17 +99,6 @@ export function peprBuild() {
   });
 }
 
-async function validateClusterRoleYaml() {
-  // Read the generated yaml files
-  const k8sYaml = await fs.readFile(
-    resolve(cwd, outputDir, "pepr-module-static-test.yaml"),
-    "utf8",
-  );
-  const cr = await fs.readFile(resolve("journey", "resources", "clusterrole.yaml"), "utf8");
-
-  expect(k8sYaml.includes(cr)).toEqual(true);
-}
-
 async function validateHelmChart() {
   const k8sYaml = await fs.readFile(resolve(cwd, "dist", "pepr-module-static-test.yaml"), "utf8");
   const helmOutput = execSync("helm template .", {
@@ -129,53 +117,6 @@ async function validateHelmChart() {
 
     expect(helmJSON.toString()).toBe(expectedJSON.toString());
   }
-}
-async function validateZarfYaml() {
-  // Get the version of the pepr binary
-  const peprVer = execSync("npx pepr --version", { cwd }).toString().trim();
-
-  // Read the generated yaml files
-  const k8sYaml = await fs.readFile(resolve(cwd, "dist", "pepr-module-static-test.yaml"), "utf8");
-  const zarfYAML = await fs.readFile(resolve(cwd, "dist", "zarf.yaml"), "utf8");
-
-  // The expected image name
-  const expectedImage = `ghcr.io/defenseunicorns/pepr/controller:v${peprVer}`;
-
-  // The expected zarf yaml contents
-  const expectedZarfYaml = {
-    kind: "ZarfPackageConfig",
-    metadata: {
-      name: "pepr-static-test",
-      description: "Pepr Module: A test module for Pepr",
-      url: "https://github.com/defenseunicorns/pepr",
-      version: "0.0.1",
-    },
-    components: [
-      {
-        name: "module",
-        required: true,
-        manifests: [
-          {
-            name: "module",
-            namespace: "pepr-system",
-            files: ["pepr-module-static-test.yaml"],
-          },
-        ],
-        images: [expectedImage],
-      },
-    ],
-  };
-
-  // Check the generated zarf yaml
-  const actualZarfYaml = loadYaml(zarfYAML);
-  expect(actualZarfYaml).toEqual(expectedZarfYaml);
-
-  // Check the generated k8s yaml
-  expect(k8sYaml).toMatch(`image: ${expectedImage}`);
-  expect(k8sYaml).toMatch(`name: MY_CUSTOM_VAR`);
-  expect(k8sYaml).toMatch(`value: example-value`);
-  expect(k8sYaml).toMatch(`name: ZARF_VAR`);
-  expect(k8sYaml).toMatch(`value: '###ZARF_VAR_THING###'`);
 }
 
 function parseYAMLToJSON(yamlContent: string): KubernetesObject[] | null {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && node build.mjs && npm pack",
     "build:image": "npm run build && docker buildx build --output type=docker --tag pepr:dev .",
     "set:version": "node scripts/set-version.js",
-    "test": "npm run test:unit && npm run test:journey",
+    "test": "npm run test:unit && npm run test:journey && npm run test:journey-wasm",
     "test:unit": "npm run gen-data-json && jest src --coverage --detectOpenHandles --coverageDirectory=./coverage --testPathIgnorePatterns='cosign.e2e.test.ts'",
     "test:integration": "npm run test:integration:prep && npm run test:integration:run",
     "test:integration:prep": "./integration/prep.sh",


### PR DESCRIPTION
## Description

The Pepr build journey test had a lot of duplicate functions between `pepr-build.ts` and `pepr-build-wasm.ts`.

This PR reduces the duplication as much as possible by creating a common `validateZarfYaml`, `validateClusterRoleYaml`, and `validateOverridesYamlRbac`. The tests technically test different thing so without creeping scope this seems to satisfy the requirements.


**Note**:

- During this PR i realized that pepr-build was building twice with different argumens and operating in different directories, it was extremely hard to follow. I have cleaned up the test so that it tests one workflow through the build in the appropriate directories.
- Running the tests locally worked, I was confused, then I realized that `npm test` did not actually run the wasn't journey tests.

This PR accounts for all of that since it was inscope in order to get the journeys passing


## Related Issue

Fixes #1344 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
