### PR TITLE
chore: bump esbuild version

### DIFF
--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -51,15 +51,20 @@ describe("build", () => {
     );
 
     describe("for use as a library", () => {
-      const packageJson = resource.fromFile(`${testModule}/package.json`);
-      const uuid = packageJson.pepr.uuid;
-      const omittedConfigFiles = [
-        [`${uuid}-chart/`],
-        [`pepr-${uuid}.js.map`],
-        [`pepr-${uuid}.js`],
-        [`pepr-module-${uuid}.yaml`],
-        [`zarf.yaml`],
-      ];
+      let omittedConfigFiles;
+      let omittedLegalFiles;
+      beforeAll(() => {
+        const packageJson = resource.fromFile(`${testModule}/package.json`);
+        const uuid = packageJson.pepr.uuid;
+        omittedConfigFiles = [
+          [`${uuid}-chart/`],
+          [`pepr-${uuid}.js.map`],
+          [`pepr-${uuid}.js`],
+          [`pepr-module-${uuid}.yaml`],
+          [`zarf.yaml`],
+        ];
+        omittedLegalFiles = [[`pepr-${uuid}.js.LEGAL.txt`], [`pepr.js.LEGAL.txt`]];
+      });
 
       it.each(omittedConfigFiles)("should not create configuration file: '%s'", filename => {
         expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
@@ -72,13 +77,10 @@ describe("build", () => {
         },
       );
 
-      it.each([[`pepr-${uuid}.js.LEGAL.txt`], [`pepr.js.LEGAL.txt`]])(
-        "should not create legal file: '%s'",
-        filename => {
-          // Omitted when empty, see esbuild/#3670 https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0250
-          expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
-        },
-      );
+      it.each(omittedLegalFiles)("should not create legal file: '%s'", filename => {
+        // Omitted when empty, see esbuild/#3670 https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0250
+        expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
+      });
     });
   });
 });

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -53,22 +53,30 @@ describe("build", () => {
     describe("for use as a library", () => {
       const packageJson = resource.fromFile(`${testModule}/package.json`);
       const uuid = packageJson.pepr.uuid;
-
-      it.each([
-        [`pepr-${uuid}.js`],
+      const omittedConfigFiles = [
+        [`${uuid}-chart/`],
         [`pepr-${uuid}.js.map`],
-        [`pepr-${uuid}.js.LEGAL.txt`],
+        [`pepr-${uuid}.js`],
         [`pepr-module-${uuid}.yaml`],
         [`zarf.yaml`],
-        [`${uuid}-chart/`],
-      ])("should not create configuration file: '%s'", filename => {
+      ];
+
+      it.each(omittedConfigFiles)("should not create configuration file: '%s'", filename => {
         expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
       });
 
-      it.each([[`pepr.js`], [`pepr.js.map`], [`pepr.js.LEGAL.txt`]])(
+      it.each([[`pepr.d.ts.map`], [`pepr.d.ts`], [`pepr.js.map`], [`pepr.js`]])(
         "should create configuration file: '%s'",
         filename => {
           expect(existsSync(`${testModule}/dist/${filename}`)).toBe(true);
+        },
+      );
+
+      it.each([[`pepr-${uuid}.js.LEGAL.txt`], [`pepr.js.LEGAL.txt`]])(
+        "should not create legal file: '%s'",
+        filename => {
+          // Omitted when empty, see esbuild/#3670 https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0250
+          expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
         },
       );
     });

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -56,21 +56,21 @@ describe("build", () => {
         },
       );
 
-      const uuidPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
-
       it.each([
-        { filename: new RegExp(`^${uuidPattern}-chart/$`) },
-        { filename: new RegExp(`^pepr-${uuidPattern}\\.js\\.map$`) },
-        { filename: new RegExp(`^pepr-${uuidPattern}\\.js$`) },
-        { filename: new RegExp(`^pepr-module-${uuidPattern}\\.yaml$`) },
-        { filename: /^zarf\.yaml$/ },
+        { filename: `^UUID-chart/$` },
+        { filename: `^pepr-UUID\\.js\\.map$` },
+        { filename: `^pepr-UUID\\.js$` },
+        { filename: `^pepr-module-UUID\\.yaml$` },
+        { filename: `^zarf\\.yaml$` },
         // Legal files are omitted when empty, see esbuild/#3670 https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0250
-        { filename: new RegExp(`^pepr-${uuidPattern}\\.js\\.LEGAL\\.txt$`) },
-        { filename: /^pepr\.js\.LEGAL\.txt$/ },
+        { filename: `^pepr-UUID\\.js\\.LEGAL\\.txt$` },
+        { filename: `^pepr\\.js\\.LEGAL\\.txt$` },
       ])("should not create: '$filename'", ({ filename }) => {
+        const uuidPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+        const regex = new RegExp(filename.replace("UUID", uuidPattern));
         const files = readdirSync(`${testModule}/dist/`);
 
-        const matchingFiles = files.filter(file => filename.test(file));
+        const matchingFiles = files.filter(file => regex.test(file));
 
         expect(matchingFiles.length).toBe(0);
       });

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -51,24 +51,8 @@ describe("build", () => {
     );
 
     describe("for use as a library", () => {
-      let omittedConfigFiles;
-      let omittedLegalFiles;
-      beforeAll(() => {
-        const packageJson = resource.fromFile(`${testModule}/package.json`);
-        const uuid = packageJson.pepr.uuid;
-        omittedConfigFiles = [
-          [`${uuid}-chart/`],
-          [`pepr-${uuid}.js.map`],
-          [`pepr-${uuid}.js`],
-          [`pepr-module-${uuid}.yaml`],
-          [`zarf.yaml`],
-        ];
-        omittedLegalFiles = [[`pepr-${uuid}.js.LEGAL.txt`], [`pepr.js.LEGAL.txt`]];
-      });
-
-      it.each(omittedConfigFiles)("should not create configuration file: '%s'", filename => {
-        expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
-      });
+      const packageJson = resource.fromFile(`${testModule}/package.json`);
+      const uuid = packageJson.pepr.uuid;
 
       it.each([[`pepr.d.ts.map`], [`pepr.d.ts`], [`pepr.js.map`], [`pepr.js`]])(
         "should create configuration file: '%s'",
@@ -77,10 +61,23 @@ describe("build", () => {
         },
       );
 
-      it.each(omittedLegalFiles)("should not create legal file: '%s'", filename => {
-        // Omitted when empty, see esbuild/#3670 https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0250
-        expect(existsSync(`${testModule}/dist/${filename}`)).toBe(false);
+      it.each([
+        { filename: `${uuid}-chart/` },
+        { filename: `pepr-${uuid}.js.map` },
+        { filename: `pepr-${uuid}.js` },
+        { filename: `pepr-module-${uuid}.yaml` },
+        { filename: `zarf.yaml` },
+      ])("should not create configuration file: '$filename'", input => {
+        expect(existsSync(`${testModule}/dist/${input.filename}`)).toBe(false);
       });
+
+      it.each([{ filename: `pepr-${uuid}.js.LEGAL.txt` }, { filename: `pepr.js.LEGAL.txt` }])(
+        "should not create legal file: '$filename'",
+        input => {
+          // Omitted when empty, see esbuild/#3670 https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0250
+          expect(existsSync(`${testModule}/dist/${input.filename}`)).toBe(false);
+        },
+      );
     });
   });
 });

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -25,6 +25,9 @@ describe("build", () => {
     const id = FILE.split(".").at(1);
     const testModule = `${workdir.path()}/${id}`;
     let buildOutput: Result;
+    let packageJson;
+    let uuid: string;
+
     beforeAll(async () => {
       await fs.rm(testModule, { recursive: true, force: true });
       const initArgs = [
@@ -40,6 +43,8 @@ describe("build", () => {
 
       const buildArgs = [`--no-embed`].join(" ");
       buildOutput = await pepr.cli(testModule, { cmd: `pepr build ${buildArgs}` });
+      packageJson = resource.fromFile(`${testModule}/package.json`);
+      uuid = packageJson.pepr.uuid;
     }, time.toMs("3m"));
 
     it("should execute 'pepr build'", () => {
@@ -49,9 +54,6 @@ describe("build", () => {
     });
 
     describe("for use as a library", () => {
-      const packageJson = resource.fromFile(`${testModule}/package.json`);
-      const uuid = packageJson.pepr.uuid;
-
       it.each([[`pepr.d.ts.map`], [`pepr.d.ts`], [`pepr.js.map`], [`pepr.js`]])(
         "should create configuration file: '%s'",
         filename => {

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -26,29 +26,24 @@ describe("build", () => {
 
     beforeAll(async () => {
       await fs.rm(testModule, { recursive: true, force: true });
-      const argz = [
+      const initArgs = [
         `--name ${id}`,
         `--description ${id}`,
         `--errorBehavior reject`,
         "--confirm",
         "--skip-post-init",
       ].join(" ");
-      await pepr.cli(workdir.path(), { cmd: `pepr init ${argz}` });
+      await pepr.cli(workdir.path(), { cmd: `pepr init ${initArgs}` });
       await pepr.tgzifyModule(testModule);
       await pepr.cli(testModule, { cmd: `npm install` });
-    }, time.toMs("2m"));
 
-    it(
-      "should execute 'pepr build'",
-      async () => {
-        const argz = [`--no-embed`].join(" ");
-        const build = await pepr.cli(testModule, { cmd: `pepr build ${argz}` });
-        expect(build.exitcode).toBe(0);
-        expect(build.stderr.join("").trim()).toContain("");
-        expect(build.stdout.join("").trim()).toContain("Module built successfully at");
-      },
-      time.toMs("1m"),
-    );
+      const buildArgs = [`--no-embed`].join(" ");
+      await pepr.cli(testModule, { cmd: `pepr build ${buildArgs}` });
+    }, time.toMs("3m"));
+
+    it("should execute 'pepr build'", () => {
+      expect(true).toBe(true);
+    });
 
     describe("for use as a library", () => {
       const packageJson = resource.fromFile(`${testModule}/package.json`);

--- a/integration/cli/build.noembed.test.ts
+++ b/integration/cli/build.noembed.test.ts
@@ -9,6 +9,7 @@ import { Workdir } from "../helpers/workdir";
 import * as time from "../helpers/time";
 import * as pepr from "../helpers/pepr";
 import * as resource from "../helpers/resource";
+import { Result } from "../helpers/cmd";
 
 const FILE = path.basename(__filename);
 const HERE = __dirname;
@@ -23,7 +24,7 @@ describe("build", () => {
   describe("when building a module", () => {
     const id = FILE.split(".").at(1);
     const testModule = `${workdir.path()}/${id}`;
-
+    let buildOutput: Result;
     beforeAll(async () => {
       await fs.rm(testModule, { recursive: true, force: true });
       const initArgs = [
@@ -38,11 +39,13 @@ describe("build", () => {
       await pepr.cli(testModule, { cmd: `npm install` });
 
       const buildArgs = [`--no-embed`].join(" ");
-      await pepr.cli(testModule, { cmd: `pepr build ${buildArgs}` });
+      buildOutput = await pepr.cli(testModule, { cmd: `pepr build ${buildArgs}` });
     }, time.toMs("3m"));
 
     it("should execute 'pepr build'", () => {
-      expect(true).toBe(true);
+      expect(buildOutput.exitcode).toBe(0);
+      expect(buildOutput.stderr.join("").trim()).toContain("");
+      expect(buildOutput.stdout.join("").trim()).toContain("Module built successfully at");
     });
 
     describe("for use as a library", () => {

--- a/integration/helpers/resource.ts
+++ b/integration/helpers/resource.ts
@@ -1,6 +1,6 @@
-import { readFile } from "node:fs/promises";
 import { kind, KubernetesObject } from "kubernetes-fluent-client";
 import { parseAllDocuments } from "yaml";
+import { readFileSync } from "node:fs";
 
 /**
  * Read resources from a file and return them as JS objects.
@@ -9,11 +9,11 @@ import { parseAllDocuments } from "yaml";
  * @returns JS object or array of JS objects.
  */
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export async function fromFile(path: string): Promise<any | any[]> {
+export function fromFile(path: string): any | any[] {
   const extension = path.split(".").at(-1);
 
   let result: object | object[];
-  const content = await readFile(path, { encoding: "utf8" });
+  const content = readFileSync(path, { encoding: "utf8" });
 
   switch (extension) {
     case "json": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@typescript-eslint/eslint-plugin": "8.23.0",
         "@typescript-eslint/parser": "8.23.0",
         "commander": "13.1.0",
-        "esbuild": "0.24.2",
+        "esbuild": "0.25.0",
         "eslint": "8.57.0",
         "node-forge": "1.3.1",
         "prettier": "3.4.2",
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
       "cpu": [
         "ppc64"
       ],
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
       "cpu": [
         "arm"
       ],
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
       "cpu": [
         "arm64"
       ],
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
       "cpu": [
         "x64"
       ],
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
       "cpu": [
         "arm64"
       ],
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
       "cpu": [
         "x64"
       ],
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
       "cpu": [
         "arm64"
       ],
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
       "cpu": [
         "x64"
       ],
@@ -986,9 +986,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
       "cpu": [
         "arm"
       ],
@@ -1003,9 +1003,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
       "cpu": [
         "arm64"
       ],
@@ -1020,9 +1020,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
       "cpu": [
         "ia32"
       ],
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
       "cpu": [
         "loong64"
       ],
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
       "cpu": [
         "ppc64"
       ],
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
       "cpu": [
         "riscv64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
       "cpu": [
         "s390x"
       ],
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
       "cpu": [
         "x64"
       ],
@@ -1139,9 +1139,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
       "cpu": [
         "arm64"
       ],
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
       "cpu": [
         "x64"
       ],
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
       "cpu": [
         "x64"
       ],
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
       "cpu": [
         "x64"
       ],
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
       "cpu": [
         "arm64"
       ],
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
       "cpu": [
         "ia32"
       ],
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
       "cpu": [
         "x64"
       ],
@@ -4588,9 +4588,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -4601,31 +4601,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@typescript-eslint/eslint-plugin": "8.23.0",
     "@typescript-eslint/parser": "8.23.0",
     "commander": "13.1.0",
-    "esbuild": "0.24.2",
+    "esbuild": "0.25.0",
     "eslint": "8.57.0",
     "node-forge": "1.3.1",
     "prettier": "3.4.2",


### PR DESCRIPTION
## Description

This PR mitigates [GHSA-67mh-4wv8-2f99](https://vat.dso.mil/vat/finding?name=GHSA-67mh-4wv8-2f99). We use `esbuild` to bundle the Pepr module, which is during the build process in the CLI. This code is not accessible during runtime. There is no attack vector in Pepr vulnerable to this.

Doing this upgrade will avoid us flagging on security scans so that we do not need to justify a security finding that does not impact us.

This PR also uses parameterized tests to assert on the presence of expected files after `pepr build --no-embed`.

### Update Consideration

`esbuild:0.25.0` omits legal comment output files when empty, see [esbuild/#3670](https://github.com/evanw/esbuild/issues/3670).

As a result, pepr now mirrors this behavior with output to `dist/`. It is unlikely that this will cause issues but is something users should be aware of, depending upon what they care about in build artifacts.

## Related Issue

Security hotfix.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
