### PR TITLE
chore: remove write to repo access for sbom and container scan

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -2,7 +2,6 @@ name: Container Scans
 
 permissions:
   actions: read
-  contents: write # for sbom-action artifact uploads
 
 on:
   push:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -4,8 +4,6 @@ permissions:
   actions: read
 
 on:
-  workflow_dispatch:
-    
   push:
     branches:
       - main

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -4,6 +4,8 @@ permissions:
   actions: read
 
 on:
+  workflow_dispatch:
+    
   push:
     branches:
       - main


### PR DESCRIPTION
## Description

Since we are not writing to the repo, the workflow does not need write privilege. [Workflow run](https://github.com/defenseunicorns/pepr/actions/runs/13268452165)

## Related Issue

Fixes #1375 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
