### PR TITLE
chore: pin hash on Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # crane digest cgr.dev/chainguard/node-lts:latest-dev
 # cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a
-FROM docker.io/library/node:22-bookworm AS build
+FROM docker.io/library/node@sha256:5145c882f9e32f07dd7593962045d97f221d57a1b609f5bf7a807eb89deff9d6 AS build
 
 WORKDIR /app
 

--- a/Dockerfile.kfc
+++ b/Dockerfile.kfc
@@ -7,7 +7,7 @@
 
 # crane digest cgr.dev/chainguard/node-lts:latest-dev
 # cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a
-FROM docker.io/library/node:22-bookworm@@sha256:fa54405993eaa6bab6b6e460f5f3e945a2e2f07942ba31c0e297a7d9c2041f62 AS build
+FROM docker.io/library/node@sha256:5145c882f9e32f07dd7593962045d97f221d57a1b609f5bf7a807eb89deff9d6 AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

```bash
$ skopeo inspect docker://docker.io/library/node:22-bookworm | jq -r '.Digest'
sha256:5145c882f9e32f07dd7593962045d97f221d57a1b609f5bf7a807eb89deff9d6
$ docker pull docker.io/library/node:22-bookworm
docker inspect --format='{{index .RepoDigests 0}}' docker.io/library/node:22-bookworm
22-bookworm: Pulling from library/node
a492eee5e559: Pull complete 
32b550be6cb6: Pull complete 
35af2a7690f2: Pull complete 
7576b00d9bb1: Pull complete 
eff108ca6463: Pull complete 
07a3aea1964d: Pull complete 
495fdfe8e444: Pull complete 
8a0c646a09aa: Pull complete 
Digest: sha256:5145c882f9e32f07dd7593962045d97f221d57a1b609f5bf7a807eb89deff9d6
Status: Downloaded newer image for node:22-bookworm
docker.io/library/node:22-bookworm
node@sha256:5145c882f9e32f07dd7593962045d97f221d57a1b609f5bf7a807eb89deff9d6
```

## Related Issue

Fixes #1809 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
