### PR TITLE
chore: prefer it() over test() for BDD-style test names

### DIFF
--- a/src/lib/assets/helm.test.ts
+++ b/src/lib/assets/helm.test.ts
@@ -8,10 +8,10 @@ import {
   admissionDeployTemplate,
   serviceMonitorTemplate,
 } from "./helm";
-import { expect, describe, test } from "@jest/globals";
+import { expect, describe, it } from "@jest/globals";
 describe("Kubernetes Template Generators", () => {
   describe("nsTemplate", () => {
-    test("should generate a Namespace template correctly", () => {
+    it("should generate a Namespace template correctly", () => {
       const result = namespaceTemplate();
       expect(result).toContain("apiVersion: v1");
       expect(result).toContain("kind: Namespace");
@@ -20,7 +20,7 @@ describe("Kubernetes Template Generators", () => {
   });
 
   describe("chartYaml", () => {
-    test("should generate a Chart.yaml content correctly", () => {
+    it("should generate a Chart.yaml content correctly", () => {
       const name = "test-app";
       const description = "A test application";
       const result = chartYaml(name, description);
@@ -31,7 +31,7 @@ describe("Kubernetes Template Generators", () => {
   });
 
   describe("watcherDeployTemplate", () => {
-    test("should generate a Deployment template for the watcher correctly", () => {
+    it("should generate a Deployment template for the watcher correctly", () => {
       const result = watcherDeployTemplate(`${Date.now()}`);
       expect(result).toContain("apiVersion: apps/v1");
       expect(result).toContain("kind: Deployment");
@@ -40,7 +40,7 @@ describe("Kubernetes Template Generators", () => {
   });
 
   describe("admissionDeployTemplate", () => {
-    test("should generate a Deployment template for the admission controller correctly", () => {
+    it("should generate a Deployment template for the admission controller correctly", () => {
       const result = admissionDeployTemplate(`${Date.now()}`);
       expect(result).toContain("apiVersion: apps/v1");
       expect(result).toContain("kind: Deployment");
@@ -49,7 +49,7 @@ describe("Kubernetes Template Generators", () => {
   });
 
   describe("admissionServiceMonitor", () => {
-    test("should generate a Service Monitor template for the admission controller correctly", () => {
+    it("should generate a Service Monitor template for the admission controller correctly", () => {
       const result = serviceMonitorTemplate("admission");
       expect(result).toContain("apiVersion: monitoring.coreos.com/v1");
       expect(result).toContain("kind: ServiceMonitor");
@@ -59,7 +59,7 @@ describe("Kubernetes Template Generators", () => {
   });
 
   describe("watcherServiceMonitor", () => {
-    test("should generate a Service Monitor template for the watcher controller correctly", () => {
+    it("should generate a Service Monitor template for the watcher controller correctly", () => {
       const result = serviceMonitorTemplate("watcher");
       expect(result).toContain("apiVersion: monitoring.coreos.com/v1");
       expect(result).toContain("kind: ServiceMonitor");

--- a/src/lib/assets/pods.test.ts
+++ b/src/lib/assets/pods.test.ts
@@ -1,5 +1,5 @@
 import { getNamespace, getWatcher, getDeployment, getModuleSecret, genEnv } from "./pods";
-import { expect, describe, test, jest, afterEach } from "@jest/globals";
+import { expect, describe, it, jest, afterEach } from "@jest/globals";
 import { Assets } from "./assets";
 import { ModuleConfig } from "../types";
 import { gzipSync } from "zlib";
@@ -296,7 +296,7 @@ const assets: Assets = JSON.parse(`{
   "hash": "e303205079a4445946f6eacde9ec4800534653f85aca6f84539d0f7158a22569"
 }`);
 describe("namespace function", () => {
-  test("should create a namespace object without labels if none are provided", () => {
+  it("should create a namespace object without labels if none are provided", () => {
     const result = getNamespace();
     expect(result).toEqual({
       apiVersion: "v1",
@@ -318,12 +318,12 @@ describe("namespace function", () => {
     });
   });
 
-  test("should create a namespace object with empty labels if an empty object is provided", () => {
+  it("should create a namespace object with empty labels if an empty object is provided", () => {
     const result = getNamespace({});
     expect(result.metadata?.labels).toEqual({});
   });
 
-  test("should create a namespace object with provided labels", () => {
+  it("should create a namespace object with provided labels", () => {
     const labels = { "pepr.dev/controller": "admission", "istio-injection": "enabled" };
     const result = getNamespace(labels);
     expect(result.metadata?.labels).toEqual(labels);
@@ -331,14 +331,14 @@ describe("namespace function", () => {
 });
 
 describe("watcher function", () => {
-  test("watcher with bindings", () => {
+  it("watcher with bindings", () => {
     const result = getWatcher(assets, "test-hash", "test-timestamp");
 
     expect(result).toBeTruthy();
     expect(result!.metadata!.name).toBe("pepr-static-test-watcher");
   });
 
-  test("watcher without bindings", () => {
+  it("watcher without bindings", () => {
     assets.capabilities = [];
     const result = getWatcher(assets, "test-hash", "test-timestamp");
 
@@ -346,7 +346,7 @@ describe("watcher function", () => {
   });
 });
 describe("deployment function", () => {
-  test("deployment", () => {
+  it("deployment", () => {
     const result = getDeployment(assets, "test-hash", "test-timestamp");
 
     expect(result).toBeTruthy();
@@ -358,7 +358,7 @@ describe("moduleSecret function", () => {
     jest.resetAllMocks();
   });
 
-  test("moduleSecret within limit", () => {
+  it("moduleSecret within limit", () => {
     const name = "test";
     const data = Buffer.from("test data");
     const hash = "test-hash";
@@ -384,7 +384,7 @@ describe("moduleSecret function", () => {
     });
   });
 
-  test("moduleSecret over limit", () => {
+  it("moduleSecret over limit", () => {
     const name = "test";
     const data = Buffer.from("test data");
     const hash = "test-hash";
@@ -411,7 +411,7 @@ describe("moduleSecret function", () => {
 });
 
 describe("genEnv", () => {
-  test("generates default environment variables without watch mode", () => {
+  it("generates default environment variables without watch mode", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       alwaysIgnore: {
@@ -430,7 +430,7 @@ describe("genEnv", () => {
     expect(result).toEqual(expectedEnv);
   });
 
-  test("generates default environment variables with watch mode", () => {
+  it("generates default environment variables with watch mode", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       alwaysIgnore: {
@@ -449,7 +449,7 @@ describe("genEnv", () => {
     expect(result).toEqual(expectedEnv);
   });
 
-  test("overrides default environment variables with config.env", () => {
+  it("overrides default environment variables with config.env", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       logLevel: "debug",
@@ -473,7 +473,7 @@ describe("genEnv", () => {
     expect(result).toEqual(expectedEnv);
   });
 
-  test("handles empty config.env correctly", () => {
+  it("handles empty config.env correctly", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       logLevel: "error",
@@ -494,7 +494,7 @@ describe("genEnv", () => {
     expect(result).toEqual(expectedEnv);
   });
 
-  test("should not be able to override PEPR_WATCH_MODE in package.json pepr env", () => {
+  it("should not be able to override PEPR_WATCH_MODE in package.json pepr env", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       logLevel: "error",
@@ -511,7 +511,7 @@ describe("genEnv", () => {
     expect(watchMode.value).toEqual("true");
   });
 
-  test("handles no config.env correctly", () => {
+  it("handles no config.env correctly", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       logLevel: "error",
@@ -531,7 +531,7 @@ describe("genEnv", () => {
     expect(result).toEqual(expectedEnv);
   });
 
-  test("handles ignoreWatchMode for helm chart", () => {
+  it("handles ignoreWatchMode for helm chart", () => {
     const config: ModuleConfig = {
       uuid: "12345",
       logLevel: "error",

--- a/src/lib/core/module.test.ts
+++ b/src/lib/core/module.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { beforeEach, expect, jest, test, describe } from "@jest/globals";
+import { beforeEach, expect, jest, it, describe } from "@jest/globals";
 import { clone } from "ramda";
 import { Capability } from "./capability";
 import { Schedule } from "./schedule";
@@ -38,30 +38,30 @@ const packageJSON: PackageJSON = {
   },
 };
 
-test("should instantiate Controller and start it with the default port", () => {
+it("should instantiate Controller and start it with the default port", () => {
   new PeprModule(packageJSON);
   expect(startServerMock).toHaveBeenCalledWith(3000);
 });
 
-test("should instantiate Controller and start it with the specified port", () => {
+it("should instantiate Controller and start it with the specified port", () => {
   const module = new PeprModule(packageJSON, [], { deferStart: true });
   const port = Math.floor(Math.random() * 10000) + 1000;
   module.start(port);
   expect(startServerMock).toHaveBeenCalledWith(port);
 });
 
-test("should not start if deferStart is true", () => {
+it("should not start if deferStart is true", () => {
   new PeprModule(packageJSON, [], { deferStart: true });
   expect(startServerMock).not.toHaveBeenCalled();
 });
 
-test("should reject invalid pepr onError conditions", () => {
+it("should reject invalid pepr onError conditions", () => {
   const cfg = clone(packageJSON);
   cfg.pepr.onError = "invalidError";
   expect(() => new PeprModule(cfg)).toThrow();
 });
 
-test("should allow valid pepr onError conditions", () => {
+it("should allow valid pepr onError conditions", () => {
   const cfg = clone(packageJSON);
   cfg.pepr.onError = OnError.AUDIT;
   expect(() => new PeprModule(cfg)).not.toThrow();
@@ -73,13 +73,13 @@ test("should allow valid pepr onError conditions", () => {
   expect(() => new PeprModule(cfg)).not.toThrow();
 });
 
-test("should not create a controller if PEPR_MODE is set to build", () => {
+it("should not create a controller if PEPR_MODE is set to build", () => {
   process.env.PEPR_MODE = "build";
   new PeprModule(packageJSON);
   expect(startServerMock).not.toHaveBeenCalled();
 });
 
-test("should send the capabilities to the parent process if PEPR_MODE is set to build", () => {
+it("should send the capabilities to the parent process if PEPR_MODE is set to build", () => {
   const sendMock = jest.spyOn(process, "send").mockImplementation(() => true);
   process.env.PEPR_MODE = "build";
 
@@ -119,7 +119,7 @@ describe("Capability", () => {
     };
   });
 
-  test("should handle OnSchedule", () => {
+  it("should handle OnSchedule", () => {
     const { OnSchedule } = capability;
     OnSchedule(schedule);
     expect(capability.hasSchedule).toBe(true);

--- a/src/lib/deploymentChecks.test.ts
+++ b/src/lib/deploymentChecks.test.ts
@@ -1,4 +1,4 @@
-import { describe, jest, test, beforeEach, afterEach, expect } from "@jest/globals";
+import { describe, jest, it, beforeEach, afterEach, expect } from "@jest/globals";
 import { K8s, GenericClass, KubernetesObject } from "kubernetes-fluent-client";
 import { K8sInit } from "kubernetes-fluent-client/dist/fluent/types";
 import { checkDeploymentStatus, namespaceDeploymentsReady } from "./deploymentChecks";
@@ -22,7 +22,7 @@ describe("namespaceDeploymentsReady", () => {
     jest.useRealTimers();
   });
 
-  test("should return true if all deployments are ready", async () => {
+  it("should return true if all deployments are ready", async () => {
     const deployments = {
       items: [
         {
@@ -64,7 +64,7 @@ describe("namespaceDeploymentsReady", () => {
     expect(result).toBe(expected);
   });
 
-  test("should call checkDeploymentStatus if any deployments are not ready", async () => {
+  it("should call checkDeploymentStatus if any deployments are not ready", async () => {
     const deployments = {
       items: [
         {
@@ -157,7 +157,7 @@ describe("checkDeploymentStatus", () => {
     jest.resetAllMocks();
     jest.useRealTimers();
   });
-  test("should return true if all deployments are ready", async () => {
+  it("should return true if all deployments are ready", async () => {
     const deployments = {
       items: [
         {
@@ -199,7 +199,7 @@ describe("checkDeploymentStatus", () => {
     expect(result).toBe(expected);
   });
 
-  test("should return false if any deployments are not ready", async () => {
+  it("should return false if any deployments are not ready", async () => {
     const deployments = {
       items: [
         {

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, test, describe } from "@jest/globals";
+import { expect, it, describe } from "@jest/globals";
 import * as fc from "fast-check";
 import { ErrorList, ValidateError } from "./errors";
 import { OnError } from "../cli/init/enums";
 
 describe("ValidateError Fuzz Testing", () => {
-  test("should only accept predefined error values", () => {
+  it("should only accept predefined error values", () => {
     fc.assert(
       fc.property(fc.string(), error => {
         if (ErrorList.includes(error)) {
@@ -23,7 +23,7 @@ describe("ValidateError Fuzz Testing", () => {
   });
 });
 describe("ValidateError Fake Data Testing", () => {
-  test("should correctly handle typical fake error data", () => {
+  it("should correctly handle typical fake error data", () => {
     const fakeErrors = ["error", "failure", "null", "undefined", "exception"];
     fakeErrors.forEach(fakeError => {
       if (ErrorList.includes(fakeError)) {
@@ -37,7 +37,7 @@ describe("ValidateError Fake Data Testing", () => {
   });
 });
 describe("ValidateError Property-Based Testing", () => {
-  test("should only validate errors that are part of the ErrorList", () => {
+  it("should only validate errors that are part of the ErrorList", () => {
     fc.assert(
       fc.property(fc.constantFrom(...ErrorList), validError => {
         expect(() => ValidateError(validError)).not.toThrow();
@@ -59,7 +59,7 @@ describe("ValidateError Property-Based Testing", () => {
   });
 });
 
-test("Errors object should have correct properties", () => {
+it("Errors object should have correct properties", () => {
   expect(OnError).toEqual({
     AUDIT: "audit",
     IGNORE: "ignore",
@@ -67,7 +67,7 @@ test("Errors object should have correct properties", () => {
   });
 });
 
-test("ValidateError should not throw an error for valid errors", () => {
+it("ValidateError should not throw an error for valid errors", () => {
   expect(() => {
     ValidateError("audit");
     ValidateError("ignore");
@@ -75,7 +75,7 @@ test("ValidateError should not throw an error for valid errors", () => {
   }).not.toThrow();
 });
 
-test("ValidateError should throw an error for invalid errors", () => {
+it("ValidateError should throw an error for invalid errors", () => {
   expect(() => ValidateError("invalidError")).toThrowError({
     message: "Invalid error: invalidError. Must be one of: audit, ignore, reject",
   });

--- a/src/lib/included-files.test.ts
+++ b/src/lib/included-files.test.ts
@@ -2,14 +2,14 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { createDockerfile } from "./included-files";
-import { expect, describe, test } from "@jest/globals";
+import { expect, describe, it } from "@jest/globals";
 import { promises as fs } from "fs";
 
 describe("createDockerfile", () => {
   const version = "0.0.1";
   const description = "Pepr supports WASM modules!";
   const includedFiles = ["main.wasm", "wasm_exec.js"];
-  test("should create a Dockerfile.controller with the correct content", async () => {
+  it("should create a Dockerfile.controller with the correct content", async () => {
     await createDockerfile(version, description, includedFiles);
 
     const generatedContent = await fs.readFile("Dockerfile.controller", "utf-8");

--- a/src/lib/telemetry/metrics.test.ts
+++ b/src/lib/telemetry/metrics.test.ts
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, test } from "@jest/globals";
+import { expect, it } from "@jest/globals";
 import { performance } from "perf_hooks";
 
 import { MetricsCollector } from "./metrics";
 
-test("constructor initializes counters correctly", () => {
+it("constructor initializes counters correctly", () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   expect(collector).toBeTruthy();
 });
 
-test("error method increments error counter", async () => {
+it("error method increments error counter", async () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   collector.error();
@@ -21,7 +21,7 @@ test("error method increments error counter", async () => {
   expect(metrics).toMatch(/testPrefix_errors 1/);
 });
 
-test("alert method increments alerts counter", async () => {
+it("alert method increments alerts counter", async () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   collector.alert();
@@ -30,7 +30,7 @@ test("alert method increments alerts counter", async () => {
   expect(metrics).toMatch(/testPrefix_alerts 1/);
 });
 
-test("observeStart returns current timestamp", () => {
+it("observeStart returns current timestamp", () => {
   const timeBefore: number = performance.now();
   const startTime: number = MetricsCollector.observeStart();
   const timeAfter: number = performance.now();
@@ -39,7 +39,7 @@ test("observeStart returns current timestamp", () => {
   expect(timeAfter >= startTime).toBe(true);
 });
 
-test("observeEnd updates summary", async () => {
+it("observeEnd updates summary", async () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   const startTime: number = MetricsCollector.observeStart();
@@ -58,7 +58,7 @@ test("observeEnd updates summary", async () => {
   expect(metrics).toMatch(/testPrefix_validate_sum \d+\.\d+/);
 });
 
-test("coverage tests, with duplicate counters, default prefix (pepr) and still works properly", async () => {
+it("coverage tests, with duplicate counters, default prefix (pepr) and still works properly", async () => {
   const collector: MetricsCollector = new MetricsCollector();
   collector.addCounter("testCounter", "testHelp");
   // second one should log, but still work fine TODO: validate log
@@ -81,7 +81,7 @@ test("coverage tests, with duplicate counters, default prefix (pepr) and still w
   expect(metrics).toMatch(/pepr_testSummary_sum \d+\.\d+/);
 });
 
-test("incCacheMiss increments cache miss gauge", async () => {
+it("incCacheMiss increments cache miss gauge", async () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   collector.incCacheMiss("window1");
@@ -90,7 +90,7 @@ test("incCacheMiss increments cache miss gauge", async () => {
   expect(metrics).toMatch(/testPrefix_cache_miss{window="window1"} 1/);
 });
 
-test("incRetryCount increments retry count gauge", async () => {
+it("incRetryCount increments retry count gauge", async () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   collector.incRetryCount(1);
@@ -99,7 +99,7 @@ test("incRetryCount increments retry count gauge", async () => {
   expect(metrics).toMatch(/testPrefix_resync_failure_count{count="1"} 1/);
 });
 
-test("initCacheMissWindow initializes cache miss gauge to zero", async () => {
+it("initCacheMissWindow initializes cache miss gauge to zero", async () => {
   const collector: MetricsCollector = new MetricsCollector("testPrefix");
 
   collector.initCacheMissWindow("window1");
@@ -108,7 +108,7 @@ test("initCacheMissWindow initializes cache miss gauge to zero", async () => {
   expect(metrics).toMatch(/testPrefix_cache_miss{window="window1"} 0/);
 });
 
-test("should initialize cache miss window and maintain size limit", async () => {
+it("should initialize cache miss window and maintain size limit", async () => {
   process.env.PEPR_MAX_CACHE_MISS_WINDOWS = "3";
   const collector: MetricsCollector = new MetricsCollector("pepr");
   collector.initCacheMissWindow("window1");

--- a/src/lib/tls.test.ts
+++ b/src/lib/tls.test.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, test, describe } from "@jest/globals";
+import { expect, it, describe } from "@jest/globals";
 import { genTLS } from "./tls";
 
 describe("tls", () => {
-  test("genTLS should generate a valid TLSOut object", () => {
+  it("genTLS should generate a valid TLSOut object", () => {
     const tls = genTLS("test");
     expect(tls).toHaveProperty("ca");
     expect(tls).toHaveProperty("crt");

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, test, describe } from "@jest/globals";
+import { expect, it, describe } from "@jest/globals";
 import { convertToBase64Map, convertFromBase64Map, base64Decode, base64Encode } from "./utils";
 
 describe("utils", () => {
-  test("convertToBase64Map should encode all ascii values and skip listed values in skip array", () => {
+  it("convertToBase64Map should encode all ascii values and skip listed values in skip array", () => {
     const obj = {
       data: {
         test1: "test1",
@@ -22,7 +22,7 @@ describe("utils", () => {
     expect(obj.data["test4"]).toBe("test4");
   });
 
-  test("convertFromBase64Map should decode all ascii values and skip values in skip array", () => {
+  it("convertFromBase64Map should decode all ascii values and skip values in skip array", () => {
     const obj = {
       data: {
         test1: base64Encode("test1"),
@@ -41,24 +41,24 @@ describe("utils", () => {
     expect(obj.data["test5"]).toBe("");
   });
 
-  test("base64Decode should decode a base64 string", () => {
+  it("base64Decode should decode a base64 string", () => {
     const data = "dGVzdDE=";
     expect(base64Decode(data)).toBe("test1");
   });
 
-  test("base64Encode should encode a string to base64", () => {
+  it("base64Encode should encode a string to base64", () => {
     const data = "test1";
     expect(base64Encode(data)).toBe("dGVzdDE=");
   });
 
-  test("convertToBase64Map empty object", () => {
+  it("convertToBase64Map empty object", () => {
     const obj = {};
     const objOut = { data: {} };
     convertToBase64Map(obj, []);
     expect(obj).toStrictEqual(objOut);
   });
 
-  test("convertFromBase64Map empty object", () => {
+  it("convertFromBase64Map empty object", () => {
     const obj = {};
     const objOut = { data: {} };
     const skip = convertFromBase64Map(obj);

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { expect, test } from "@jest/globals";
 import { PeprValidateRequest } from "../lib/validate-request";
 import { PeprMutateRequest } from "../lib/mutate-request";
 import { a } from "../lib";
 import { containers, writeEvent, getOwnerRefFrom, sanitizeResourceName } from "./sdk";
 import * as fc from "fast-check";
-import { beforeEach, describe, it, jest } from "@jest/globals";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { GenericKind } from "kubernetes-fluent-client";
 import { K8s, kind } from "kubernetes-fluent-client";
 import { Mock } from "jest-mock";
@@ -26,7 +25,7 @@ jest.mock("kubernetes-fluent-client", () => ({
 }));
 
 describe("containers", () => {
-  test("should return a list of containers in the pod when in a validate block", async () => {
+  it("should return a list of containers in the pod when in a validate block", async () => {
     const standardContainers = [
       {
         name: "container-1",
@@ -70,7 +69,7 @@ describe("containers", () => {
     expect(result).toHaveLength(ephemeralContainers.length);
   });
 
-  test("should return a list of containers in the pod when in a mutate block", async () => {
+  it("should return a list of containers in the pod when in a mutate block", async () => {
     const standardContainers = [
       {
         name: "container-1",
@@ -191,7 +190,7 @@ describe("getOwnerRefFrom", () => {
     controller: false,
   }));
 
-  test.each([
+  it.each([
     [true, false, ownerRefWithAllFields],
     [false, undefined, ownerRefWithBlockOwnerDeletion],
     [undefined, true, ownerRefWithController],
@@ -212,7 +211,7 @@ describe("getOwnerRefFrom", () => {
 });
 
 describe("sanitizeResourceName Fuzzing Tests", () => {
-  test("should handle any random string input", () => {
+  it("should handle any random string input", () => {
     fc.assert(
       fc.property(fc.string(), name => {
         expect(() => sanitizeResourceName(name)).not.toThrow();
@@ -224,7 +223,7 @@ describe("sanitizeResourceName Fuzzing Tests", () => {
 });
 
 describe("sanitizeResourceName Property-Based Tests", () => {
-  test("should always return lowercase, alphanumeric names without leading/trailing hyphens", () => {
+  it("should always return lowercase, alphanumeric names without leading/trailing hyphens", () => {
     fc.assert(
       fc.property(fc.string(), name => {
         const sanitized = sanitizeResourceName(name);


### PR DESCRIPTION
## Description

Our test suite uses `test()` and `it()` in declaring tests. While they're aliases for each other and do the same thing, it provides uncertainty for new contributors on which pattern to use. Additionally, using `it()` prompts test writers to think in a BDD-style for test naming.

This PR replaces the use of `test()` with `it()`.

## Related Issue

Hotfix

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
