### PR TITLE
chore: controller constructor calls store on ready

### DIFF
--- a/src/lib/controller/index.test.ts
+++ b/src/lib/controller/index.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+import { afterEach, describe, it, jest, beforeEach, expect } from "@jest/globals";
+import { Controller, ControllerHooks } from "./index";
+import { Capability } from "../core/capability";
+import { ModuleConfig, CapabilityCfg } from "../types";
+
+jest.mock("./store", () => {
+  return {
+    StoreController: jest.fn().mockImplementation((_capabilities, _name, onReady) => {
+      if (typeof onReady === "function") {
+        onReady();
+      }
+    }),
+  };
+});
+
+describe("Controller", () => {
+  let mockConfig: ModuleConfig;
+  let mockCapabilities: Capability[];
+  let mockHooks: ControllerHooks;
+  let controller: Controller;
+
+  beforeEach(() => {
+    mockConfig = { uuid: "test-uuid" } as ModuleConfig;
+
+    const mockCapabilityConfig: CapabilityCfg = {
+      name: `test-capability-${Math.random()}`,
+      description: "Test capability description",
+      namespaces: ["default"],
+    };
+    mockCapabilities = [new Capability(mockCapabilityConfig)];
+
+    mockHooks = {
+      beforeHook: jest.fn(),
+      afterHook: jest.fn(),
+      onReady: jest.fn(),
+    };
+
+    controller = new Controller(mockConfig, mockCapabilities, mockHooks);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("should initialize with provided config, capabilities, and hooks", () => {
+    expect(controller).toBeDefined();
+    expect(mockHooks.onReady).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

We had zero coverage around the Controller class. This add coverage to ensure that the `onReady` hook is called when the controller starts up ensuring that onSchedule, Store, and Watch/Reconcile work properly. Currently our only coverage around this is e2e testing

## Related Issue

Fixes #1826
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
