### PR TITLE
chore: chainguard image to ghcr

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -34,6 +34,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
+      - name: Chainguard Login
+        uses: chainguard-dev/setup-chainctl@2302a56a61228140753b428d1018cb0d0addbec6 # v0.3.0
+        with:
+          identity: ${{ secrets.CHAINGUARD_IDENTITY }}
+          
       - name: "Pepr Controller: Login to GHCR"
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
+      - name: Chainguard Login
+        uses: chainguard-dev/setup-chainctl@2302a56a61228140753b428d1018cb0d0addbec6 # v0.3.0
+        with:
+          identity: ${{ secrets.CHAINGUARD_IDENTITY }}
+
       - name: "Pepr Controller: Login to GHCR"
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -50,9 +55,9 @@ jobs:
 
           npm run set:version
 
-          # Build Controller Image
+          # Build Controller Images
           docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:${{ github.ref_name }} .
-
+          docker buildx build -f Dockerfile.unicorn --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/private/controller:${{ github.ref_name }} .
   slsa:
     permissions:
       id-token: write

--- a/Dockerfile.unicorn
+++ b/Dockerfile.unicorn
@@ -1,0 +1,48 @@
+### BUILD ###
+
+# NOTE:
+# Used to build Controller image
+# In this file, we delete the *.ts intentionally
+# Any other changes to Dockerfile should be reflected in Publish
+
+# crane digest cgr.dev/chainguard/node-lts:latest-dev
+# cgr.dev/chainguard/node:latest-dev@sha256:96260affdd273eb612d5fa031b8230cde59e06e21cdaf67f85a8f6399abd889a
+FROM cgr.dev/du-uds-defenseunicorns/node:22.14.0@sha256:18160bed0e77c8300b99a8d1af8cc997280e189e590b55b5ff94893bd398a1e6 AS build
+
+WORKDIR /app
+
+# Copy the node config files
+COPY --chown=node:node ./package*.json ./
+
+# Install deps
+RUN npm ci
+
+COPY --chown=node:node ./hack/ ./hack/
+
+COPY --chown=node:node ./tsconfig.json ./build.mjs ./
+
+COPY --chown=node:node ./src/ ./src/
+
+RUN npm run build && \
+    npm ci --omit=dev --omit=peer && \
+    npm cache clean --force && \
+    # Remove @types
+    rm -rf node_modules/@types && \
+    # Remove Ramda unused Ramda files
+    rm -rf node_modules/ramda/dist && \
+    rm -rf node_modules/ramda/es && \
+    find . -name "*.ts" -type f -delete && \
+    mkdir node_modules/pepr && \
+    cp -r dist node_modules/pepr/dist && \
+    cp package.json node_modules/pepr
+
+##### DELIVER #####
+
+# crane digest cgr.dev/chainguard/node-lts:latest
+# cgr.dev/chainguard/node:latest@sha256:f771505c29d1f766c1dc4d3b2ed0f8660a76553685b9d886728bc55d6f430ce8
+# gcr.io/distroless/nodejs22-debian12@sha256:d00edbf864c5b989f1b69951a13c5c902bf369cca572de59b5ec972552848e33
+FROM cgr.dev/du-uds-defenseunicorns/node:22.14.0-slim@sha256:95ce4c850fd71a7fe53d9cbaf7f9db318bba9c0ade54717078d9e60c317b5496
+
+WORKDIR /app
+
+COPY --from=build --chown=node:node /app/node_modules/ ./node_modules/

--- a/scripts/nightlies.sh
+++ b/scripts/nightlies.sh
@@ -34,6 +34,7 @@ echo "FULL_VERSION=$FULL_VERSION" >> "$GITHUB_ENV"
 npm version --no-git-tag-version "$FULL_VERSION"
 
 docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/controller:v"$FULL_VERSION" .
+docker buildx build -f Dockerfile.unicorn --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/pepr/private/controller:v"$FULL_VERSION" .
 
 npm install 
 npm run build


### PR DESCRIPTION
## Description

This will publish a release/nightly chainguard image to the `ghcr.io/defenseunicorns/pepr/private/controller` package.

## Related Issue

Fixes #1829 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
