### PR TITLE
chore: override jsonpath-plus cve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7507,9 +7507,9 @@
       "license": "MIT"
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "license": "MIT",
       "dependencies": {
         "@jsep-plugin/assignment": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "undici": "^7.0.1"
   },
   "overrides": {
-    "glob": "^9.0.0"
+    "glob": "^9.0.0",
+    "jsonpath-plus": "^10.3.0"
   },
   "peerDependencies": {
     "@types/prompts": "2.4.9",


### PR DESCRIPTION
## Description

A high severity vulnerability is blocking CI due to `jsonpath-plus`, a dependency from `@kubernetes/client-node`. It allows remote code execution, we are not vulnerable to it but it is coming up on all of the scanners

Before:

```plaintext
> grype pepr:dev                                                                                          
 ✔ Loaded image                                                                                                                                                                                                                                                                                                                                    pepr:dev
 ✔ Parsed image                                                                                                                                                                                                                                                                     sha256:f2e11bb34f9f0d5552e3c213b4fea6350d85059cb4879c768908444c2cd64470
 ✔ Cataloged contents                                                                                                                                                                                                                                                                      cf61f69efe56091292ee8f158c0c1d3abec739499f0fb0e83cc8893c756171f5
   ├── ✔ Packages                        [313 packages]  
   ├── ✔ File digests                    [1,560 files]  
   ├── ✔ File metadata                   [1,560 locations]  
   └── ✔ Executables                     [282 executables]  
 ✔ Scanned for vulnerabilities     [18 vulnerability matches]  
   ├── by severity: 0 critical, 2 high, 1 medium, 0 low, 15 negligible
   └── by status:   1 fixed, 17 not-fixed, 0 ignored 
NAME           INSTALLED         FIXED-IN     TYPE  VULNERABILITY        SEVERITY   
gcc-12-base    12.2.0-14                      deb   CVE-2023-4039        Negligible  
gcc-12-base    12.2.0-14                      deb   CVE-2022-27943       Negligible  
jsonpath-plus  10.2.0            10.3.0       npm   GHSA-hw8r-x6gr-5gjp  High        
libc6          2.36-9+deb12u9    (won't fix)  deb   CVE-2025-0395        High        
libc6          2.36-9+deb12u9                 deb   CVE-2019-9192        Negligible  
libc6          2.36-9+deb12u9                 deb   CVE-2019-1010025     Negligible  
libc6          2.36-9+deb12u9                 deb   CVE-2019-1010024     Negligible  
libc6          2.36-9+deb12u9                 deb   CVE-2019-1010023     Negligible  
libc6          2.36-9+deb12u9                 deb   CVE-2019-1010022     Negligible  
libc6          2.36-9+deb12u9                 deb   CVE-2018-20796       Negligible  
libc6          2.36-9+deb12u9                 deb   CVE-2010-4756        Negligible  
libgcc-s1      12.2.0-14                      deb   CVE-2023-4039        Negligible  
libgcc-s1      12.2.0-14                      deb   CVE-2022-27943       Negligible  
libgomp1       12.2.0-14                      deb   CVE-2023-4039        Negligible  
libgomp1       12.2.0-14                      deb   CVE-2022-27943       Negligible  
libssl3        3.0.15-1~deb12u1  (won't fix)  deb   CVE-2024-13176       Medium      
libstdc++6     12.2.0-14                      deb   CVE-2023-4039        Negligible  
libstdc++6     12.2.0-14                      deb   CVE-2022-27943       Negligible
```

After:

```plaintext
> grype pepr:dev     
 ✔ Loaded image                                                                                                                                                                                                                                                                                                                                    pepr:dev
 ✔ Parsed image                                                                                                                                                                                                                                                                     sha256:ee0c770b6776e36a959ee4c844e424fdbb88b164b64980f055f81cbfa99d4565
 ✔ Cataloged contents                                                                                                                                                                                                                                                                      b1fefb5c9f89ba786f3216eb66a8dfa7e34364a9d526d5671edce6fec85dea00
   ├── ✔ Packages                        [313 packages]  
   ├── ✔ File digests                    [1,560 files]  
   ├── ✔ File metadata                   [1,560 locations]  
   └── ✔ Executables                     [282 executables]  
 ✔ Scanned for vulnerabilities     [17 vulnerability matches]  
   ├── by severity: 0 critical, 1 high, 1 medium, 0 low, 15 negligible
   └── by status:   0 fixed, 17 not-fixed, 0 ignored 
NAME         INSTALLED         FIXED-IN     TYPE  VULNERABILITY     SEVERITY   
gcc-12-base  12.2.0-14                      deb   CVE-2023-4039     Negligible  
gcc-12-base  12.2.0-14                      deb   CVE-2022-27943    Negligible  
libc6        2.36-9+deb12u9    (won't fix)  deb   CVE-2025-0395     High        
libc6        2.36-9+deb12u9                 deb   CVE-2019-9192     Negligible  
libc6        2.36-9+deb12u9                 deb   CVE-2019-1010025  Negligible  
libc6        2.36-9+deb12u9                 deb   CVE-2019-1010024  Negligible  
libc6        2.36-9+deb12u9                 deb   CVE-2019-1010023  Negligible  
libc6        2.36-9+deb12u9                 deb   CVE-2019-1010022  Negligible  
libc6        2.36-9+deb12u9                 deb   CVE-2018-20796    Negligible  
libc6        2.36-9+deb12u9                 deb   CVE-2010-4756     Negligible  
libgcc-s1    12.2.0-14                      deb   CVE-2023-4039     Negligible  
libgcc-s1    12.2.0-14                      deb   CVE-2022-27943    Negligible  
libgomp1     12.2.0-14                      deb   CVE-2023-4039     Negligible  
libgomp1     12.2.0-14                      deb   CVE-2022-27943    Negligible  
libssl3      3.0.15-1~deb12u1  (won't fix)  deb   CVE-2024-13176    Medium      
libstdc++6   12.2.0-14                      deb   CVE-2023-4039     Negligible  
libstdc++6   12.2.0-14                      deb   CVE-2022-27943    Negligible
```
## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
