### PR TITLE
chore: dependabot prs are read-only

### DIFF
--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -18,16 +18,8 @@ permissions:
   contents: read
 
 jobs:
-  on-demand-workflows:
-    uses: ./.github/workflows/on-demand-workflows.yaml
-    secrets:
-      CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-    with:
-      run-format: true
-      run-units: false
-      run-integration: false
-
   journey-unicorn:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -4,33 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
-    paths-ignore:
-      - "package.json"    
-      - "package-lock.json"    
-      - "Dockerfile"          
-      - "Dockerfile.controller"  
-      - "Dockerfile.kfc"         
-      - "Dockerfile.unicorn"     
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "package.json"    
-      - "package-lock.json"             
-      - "Dockerfile"              
-      - "Dockerfile.controller"   
-      - "Dockerfile.kfc"          
-      - "Dockerfile.unicorn" 
   merge_group:
     paths-ignore:
     - "LICENSE"
     - "CODEOWNERS"
     - "**.md"
-    - "package.json"    
-    - "package-lock.json"             
-    - "Dockerfile"              
-    - "Dockerfile.controller"   
-    - "Dockerfile.kfc"          
-    - "Dockerfile.unicorn" 
+
 
 permissions:
   id-token: write # This is needed for OIDC federation.
@@ -46,7 +27,7 @@ jobs:
       run-units: false
       run-integration: false
 
-  journey:
+  journey-unicorn:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -4,13 +4,33 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "package.json"    
+      - "package-lock.json"    
+      - "Dockerfile"          
+      - "Dockerfile.controller"  
+      - "Dockerfile.kfc"         
+      - "Dockerfile.unicorn"     
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "package.json"    
+      - "package-lock.json"             
+      - "Dockerfile"              
+      - "Dockerfile.controller"   
+      - "Dockerfile.kfc"          
+      - "Dockerfile.unicorn" 
   merge_group:
     paths-ignore:
     - "LICENSE"
     - "CODEOWNERS"
     - "**.md"
+    - "package.json"    
+    - "package-lock.json"             
+    - "Dockerfile"              
+    - "Dockerfile.controller"   
+    - "Dockerfile.kfc"          
+    - "Dockerfile.unicorn" 
 
 permissions:
   id-token: write # This is needed for OIDC federation.
@@ -23,11 +43,11 @@ jobs:
       CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
     with:
       run-format: true
-      run-units: true
-      run-integration: true
+      run-units: false
+      run-integration: false
+
   journey:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -44,7 +64,12 @@ jobs:
         run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
+      - name: Chainguard Login
+        uses: chainguard-dev/setup-chainctl@2302a56a61228140753b428d1018cb0d0addbec6 # v0.3.0
+        with:
+          identity: ${{ secrets.CHAINGUARD_IDENTITY }}
+
       - run: npm ci
       - run: |
-          npm run test:journey
-          npm run test:journey-wasm
+          npm run test:journey:unicorn
+          npm run test:journey-wasm:unicorn

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 jobs:
-  on-demand-tests:
+  on-demand-workflows:
     uses: ./.github/workflows/on-demand-workflows.yaml
     secrets:
       CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Node.js Unicorn CI
 
 on:
   workflow_dispatch:

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   on-demand-tests:
-    uses: ./.github/workflows/reusable-tests.yaml
+    uses: ./.github/workflows/on-demand-workflows.yaml
     secrets:
       CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
     with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   on-demand-tests:
-    uses: ./.github/workflows/reusable-tests.yaml
+    uses: ./.github/workflows/on-demand-workflows.yaml
     secrets:
       CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
     with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,6 @@
 name: Node.js CI
 
 on:
-  workflow_dispatch:
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  on-demand-tests:
+  on-demand-workflows:
     uses: ./.github/workflows/on-demand-workflows.yaml
     secrets:
       CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -1,0 +1,76 @@
+# Workflows that can be called on demand
+name: on-demand-workflows
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version"
+        required: false
+        type: string
+      run-integration:
+        description: "Run integration tests"
+        required: false
+        default: false
+        type: boolean
+
+    secrets:
+      CODECOV_ORG_TOKEN:
+        required: true
+      CHAINGUARD_IDENTITY:
+        required: false
+
+permissions:
+  id-token: write # This is needed for OIDC federation.
+  contents: read
+
+jobs:
+  format:
+    if: inputs.run-format == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Use Node.js latest
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: latest
+          cache: "npm"
+      - run: npm ci
+      - run: npm run format:check
+
+  test:
+    if: inputs.run-units == true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run test:unit
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+
+  integration:
+    if: inputs.run-integration == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Use Node.js 22
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 22
+          cache: "npm"
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.3.4
+      - run: npm ci
+      - run: npm run test:integration

--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -4,15 +4,25 @@ name: on-demand-workflows
 on:
   workflow_call:
     inputs:
-      node-version:
-        description: "Node.js version"
+      run-format:
+        description: "Run format check"
         required: false
-        type: string
+        default: false
+        type: boolean
+      run-units:
+        description: "Run unit tests"
+        required: false
+        default: false
+        type: boolean
       run-integration:
         description: "Run integration tests"
         required: false
         default: false
         type: boolean
+      node-version:
+        description: "Node.js version"
+        required: false
+        type: string
 
     secrets:
       CODECOV_ORG_TOKEN:

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -17,13 +17,6 @@ on:
     - "LICENSE"
     - "CODEOWNERS"
     - "**.md"
-    - "package.json"    
-    - "package-lock.json"             
-    - "Dockerfile"              
-    - "Dockerfile.controller"   
-    - "Dockerfile.kfc"          
-    - "Dockerfile.unicorn" 
-    - ".github/workflows/**" 
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -23,26 +23,13 @@ on:
     - "Dockerfile.controller"   
     - "Dockerfile.kfc"          
     - "Dockerfile.unicorn" 
+    - ".github/workflows/**" 
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:
     branches: ["main"]
-    paths-ignore:
-      - "package.json"    
-      - "package-lock.json"    
-      - "Dockerfile"          
-      - "Dockerfile.controller"  
-      - "Dockerfile.kfc"         
-      - "Dockerfile.unicorn"     
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "package.json"    
-      - "package-lock.json"             
-      - "Dockerfile"              
-      - "Dockerfile.controller"   
-      - "Dockerfile.kfc"          
-      - "Dockerfile.unicorn" 
 
 # refs
 # https://frontside.com/blog/2022-12-12-dynamic-github-action-jobs/

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -17,12 +17,32 @@ on:
     - "LICENSE"
     - "CODEOWNERS"
     - "**.md"
+    - "package.json"    
+    - "package-lock.json"             
+    - "Dockerfile"              
+    - "Dockerfile.controller"   
+    - "Dockerfile.kfc"          
+    - "Dockerfile.unicorn" 
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:
     branches: ["main"]
+    paths-ignore:
+      - "package.json"    
+      - "package-lock.json"    
+      - "Dockerfile"          
+      - "Dockerfile.controller"  
+      - "Dockerfile.kfc"         
+      - "Dockerfile.unicorn"     
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "package.json"    
+      - "package-lock.json"             
+      - "Dockerfile"              
+      - "Dockerfile.controller"   
+      - "Dockerfile.kfc"          
+      - "Dockerfile.unicorn" 
 
 # refs
 # https://frontside.com/blog/2022-12-12-dynamic-github-action-jobs/

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   pepr-build:
+    if: github.actor != 'dependabot[bot]'
     name: controller image
     runs-on: ubuntu-latest
     steps:
@@ -102,6 +103,7 @@ jobs:
           retention-days: 1
 
   examples-matrix:
+    if: github.actor != 'dependabot[bot]'
     name: job matrix
     runs-on: ubuntu-latest
     needs:
@@ -148,11 +150,11 @@ jobs:
         id: create-matrix
 
   excellent-examples:
+    if: github.actor != 'dependabot[bot]' && needs.examples-matrix.outputs.matrix != ''
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs:
       - examples-matrix
-    if: needs.examples-matrix.outputs.matrix != ''
     strategy:
       fail-fast: false
       max-parallel: 32 # Roughly matches the number of E2E tests and below GitHub concurrency limit


### PR DESCRIPTION
## Description

Our CI is blocked because we cannot pull the regcred for chainguard because dependabot PRs are read-only.

This PR intends to unblock CI by:
- Not running tests that require the image registry credential in dependabot PRs - excluding the actor
- Instead of duplicating files, it creates a new `on-demand-workflows` that can be accessed for common tests like format, unit, and integration. 

## Related Issue

Fixes CI
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
