### PR TITLE
Create a minimally-viable set of mocks for tests to pass

### DIFF
--- a/src/lib/assets/yaml/generateAllYaml.test.ts
+++ b/src/lib/assets/yaml/generateAllYaml.test.ts
@@ -52,20 +52,18 @@ jest.mock("../pods", () => ({
 }));
 
 jest.mock("../rbac", () => ({
-  clusterRole: jest.fn().mockReturnValue({ kind: "ClusterRole", metadata: { name: "mock-clusterrole" } }),
-  clusterRoleBinding: jest
-    .fn()
-    .mockReturnValue({ kind: "ClusterRoleBinding", metadata: { name: "mock-clusterrolebinding" } }),
-  serviceAccount: jest.fn().mockReturnValue({ kind: "ServiceAccount", metadata: { name: "mock-serviceaccount" } }),
-  storeRole: jest.fn().mockReturnValue({ kind: "Role", metadata: { name: "mock-storerole" } }),
-  storeRoleBinding: jest.fn().mockReturnValue({ kind: "RoleBinding", metadata: { name: "mock-storerolebinding" } }),
+  clusterRole: jest.fn().mockReturnValue({}),
+  clusterRoleBinding: jest.fn().mockReturnValue({}),
+  serviceAccount: jest.fn().mockReturnValue({}),
+  storeRole: jest.fn().mockReturnValue({}),
+  storeRoleBinding: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock("../networking", () => ({
-  apiPathSecret: jest.fn().mockReturnValue({ kind: "Secret", metadata: { name: "mock-api-path-secret" } }),
-  service: jest.fn().mockReturnValue({ kind: "Service", metadata: { name: "mock-service" } }),
-  tlsSecret: jest.fn().mockReturnValue({ kind: "Secret", metadata: { name: "mock-tls-secret" } }),
-  watcherService: jest.fn().mockReturnValue({ kind: "Service", metadata: { name: "mock-watcher-service" } }),
+  apiPathSecret: jest.fn().mockReturnValue({}),
+  service: jest.fn().mockReturnValue({}),
+  tlsSecret: jest.fn().mockReturnValue({}),
+  watcherService: jest.fn().mockReturnValue({}),
 }));
 describe("generateAllYaml", () => {
   const moduleConfig: ModuleConfig = {


### PR DESCRIPTION
## Description

This PR shows how some of the `.mockReturnValue()` calls set in the unit test don't actually mean anything. We'll want to consider this when working on #1764.

## Related Issue

Relates to #1845 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
