### PR TITLE
chore: refactor to resolve max-statement on filter.test

### DIFF
--- a/src/lib/filter/filter.test.ts
+++ b/src/lib/filter/filter.test.ts
@@ -165,22 +165,6 @@ describe("shouldSkipRequest", () => {
   });
 
   it("delete: should not reject when regex name does match", () => {
-    // const binding = {
-    //   model: kind.Pod,
-    //   event: Event.ANY,
-    //   kind: podKind,
-    //   filters: {
-    //     name: "",
-    //     namespaces: [],
-    //     regexNamespaces: [],
-    //     regexName: "^cool",
-    //     labels: {},
-    //     annotations: {},
-    //     deletionTimestamp: false,
-    //   },
-    //   callback,
-    // };
-
     const binding = createBinding({
       filters: { regexName: "^cool" },
       callback,


### PR DESCRIPTION


## Description
Resolve max-statements warning in `src/lib/filter/filter.test.ts`
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue


<!-- or -->
Relates to #1695 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
