### PR TITLE
chore: account for early exit and stop timer

### DIFF
--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -186,6 +186,7 @@ export async function mutateProcessor(
   for (const bindable of bindables) {
     ({ wrapped, response } = await processRequest(bindable, wrapped, response));
     if (config.onError === OnError.REJECT && response?.warnings!.length > 0) {
+      webhookTimer.stop();
       return response;
     }
   }
@@ -196,11 +197,13 @@ export async function mutateProcessor(
   // If no capability matched the request, exit early
   if (bindables.length === 0) {
     Log.info(reqMetadata, `No matching actions found`);
+    webhookTimer.stop();
     return response;
   }
 
   // delete operations can't be mutate, just return before the transformation
   if (req.operation === "DELETE") {
+    webhookTimer.stop();
     return response;
   }
 


### PR DESCRIPTION
## Description

There are several places in the mutate process where the request will exit early before the final return of the response. This leads to metricCollector incrementing the count for mutation timeouts which is inaccurate. We need to stop the timer to ensure we have accurate metrics.

## Related Issue

Fixes #1894 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
