### PR TITLE
chore(ci): remove bypass rule when dependabot triggers CI

### DIFF
--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -19,7 +19,6 @@ permissions:
 
 jobs:
   journey-unicorn:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -30,7 +30,6 @@ on:
 
 jobs:
   pepr-build:
-    if: github.actor != 'dependabot[bot]'
     name: controller image
     runs-on: ubuntu-latest
     steps:
@@ -103,7 +102,6 @@ jobs:
           retention-days: 1
 
   examples-matrix:
-    if: github.actor != 'dependabot[bot]'
     name: job matrix
     runs-on: ubuntu-latest
     needs:
@@ -150,7 +148,7 @@ jobs:
         id: create-matrix
 
   excellent-examples:
-    if: github.actor != 'dependabot[bot]' && needs.examples-matrix.outputs.matrix != ''
+    if: needs.examples-matrix.outputs.matrix != ''
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Description

This hotfix resolves an authentication error in CI after we updated project and org configs. Dependabot can now reference the correct variable, as shown in [project settings](https://github.com/defenseunicorns/pepr/settings/secrets/dependabot) (if you have access).

## Related Issue

Relates to #1852 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
