### PR TITLE
chore: test iron bank images nightly based on main

### DIFF
--- a/.github/actions/ironbank-setup/action.yaml
+++ b/.github/actions/ironbank-setup/action.yaml
@@ -83,6 +83,7 @@ runs:
       run: |
         cd "$PEPR"
         npm run build
+        mv pepr-0.0.0-development.tgz pepr-0.0.0-development.tar.gz
         mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
         docker build -t pepr:amd -f Dockerfile.ironbank.amd .
         docker build -t pepr:arm -f Dockerfile.ironbank.arm .

--- a/.github/actions/ironbank-setup/action.yaml
+++ b/.github/actions/ironbank-setup/action.yaml
@@ -1,0 +1,85 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Pepr Iron Bank Setup"
+description: "Pepr Iron Bank Environment Setup"
+inputs:
+  registry1Username:
+    description: 'IRON_BANK_ROBOT_USERNAME'
+    required: true
+  registry1Password:
+    description: 'IRON_BANK_ROBOT_PASSWORD'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+      with:
+        egress-policy: audit
+        
+    - name: Use Node.js 22
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      with:
+        node-version: 22
+
+    - name: Install k3d
+      shell: bash
+      run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+    - name: Iron Bank Login
+      if: ${{ inputs.registry1Username != '' }}
+      env:
+        REGISTRY_USERNAME: ${{ inputs.registry1Username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry1Password }}
+      run: echo "${{ env.REGISTRY_PASSWORD }}" | uds zarf tools registry login -u "${{ env.REGISTRY_USERNAME }}" --password-stdin registry1.dso.mil
+      shell: bash
+
+    - name: Clone Pepr
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: defenseunicorns/pepr
+        path: pepr
+
+    - name: Set Pepr Environment Variable
+      shell: bash
+      run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
+
+    - name: Clone Iron Bank Repo & Transfer Dockerfiles
+      shell: bash
+      run: |
+        git clone https://repo1.dso.mil/dsop/opensource/defenseunicorns/pepr/controller.git
+        cd controller
+        git checkout development
+        mv Dockerfile $PEPR/Dockefile.ironbank.amd
+        mv Dockerfile.arm $PEPR/Dockerfile.ironbank.arm
+
+    - name: Install Pepr Dependencies
+      shell: bash
+      run: |
+        cd "$PEPR"
+        npm ci
+
+    - name: Build Pepr Iron Bank Images
+      shell: bash
+      run: |
+        cd "$PEPR"
+        docker build -t pepr:amd -f Dockerfile.ironbank.amd .
+        docker build -t pepr:arm -f Dockerfile.ironbank.arm .
+
+    - name: Import Pepr Iron Bank Images into K3d cluster 
+      shell: bash
+      run: |
+        cd "$PEPR"
+        npm run build
+        mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
+        docker build -t pepr:amd -f Dockerfile.ironbank.amd .
+        docker build -t pepr:arm -f Dockerfile.ironbank.arm .
+
+    - name: Create K3d Cluster & Import Pepr Iron Bank Images
+      shell: bash
+      run: |
+        k3d cluster create iron-bank-pepr-e2es
+        k3d image import pepr:amd pepr:arm -c iron-bank-pepr-e2es
+

--- a/.github/actions/ironbank-setup/action.yaml
+++ b/.github/actions/ironbank-setup/action.yaml
@@ -46,14 +46,24 @@ runs:
       shell: bash
       run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
 
+    - name: Clone Pepr Excellent Examples
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: defenseunicorns/pepr-excellent-examples
+        path: pepr-excellent-examples
+
+    - name: "set env: PEPR_EXCELLENT_EXAMPLES_PATH"
+      shell: bash
+      run: echo "PEPR_EXCELLENT_EXAMPLES_PATH=${GITHUB_WORKSPACE}/pepr-excellent-examples" >> "$GITHUB_ENV"
+
     - name: Clone Iron Bank Repo & Transfer Dockerfiles
       shell: bash
       run: |
         git clone https://repo1.dso.mil/dsop/opensource/defenseunicorns/pepr/controller.git
         cd controller
-        git checkout development
         mv Dockerfile $PEPR/Dockefile.ironbank.amd
         mv Dockerfile.arm $PEPR/Dockerfile.ironbank.arm
+        mv removeScript.js $PEPR/removeScript.js
 
     - name: Install Pepr Dependencies
       shell: bash
@@ -65,8 +75,8 @@ runs:
       shell: bash
       run: |
         cd "$PEPR"
-        docker build -t pepr:amd -f Dockerfile.ironbank.amd .
-        docker build -t pepr:arm -f Dockerfile.ironbank.arm .
+        docker build --build-arg PEPR_BUILD_VERSION=dev pepr:amd -f Dockerfile.ironbank.amd .
+        docker build --build-arg PEPR_BUILD_VERSION=dev -t pepr:arm -f Dockerfile.ironbank.arm .
 
     - name: Import Pepr Iron Bank Images into K3d cluster 
       shell: bash

--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
       - name: Environment setup
-        uses: ./.github/ironbank-actions/setup
+        uses: ./.github/actions/ironbank-setup
         with:
           registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
           registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}

--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -9,8 +9,8 @@ on:
     - cron: '0 6 * * *' # 2AM EST/11PM PST
 
 jobs:
-  setup:
-    name: controller image
+  ib-amd-e2e:
+    name: Iron Bank AMD Image E2E Test
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
@@ -21,7 +21,7 @@ jobs:
           registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
           registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
 
-      - name: create matrix
+      - name: Create Matrix
         run: |
           matrix=$(
             node "$PEPR/.github/workflows/pepr-excellent-examples-matrix.js" "$PEPR_EXCELLENT_EXAMPLES_PATH"
@@ -29,7 +29,7 @@ jobs:
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
         id: create-matrix
 
-      - name: run e2e tests
+      - name: Run e2e tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           max_attempts: 3
@@ -41,7 +41,7 @@ jobs:
               --image pepr:amd \
               --custom-package ../pepr-0.0.0-development.tgz
 
-      - name: upload artifacts (troubleshooting)
+      - name: Upload artifacts (troubleshooting)
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()
         with:

--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -1,0 +1,54 @@
+name: E2E - Pepr Excellent Examples - IronBank AMD Image
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *' # 2AM EST/11PM PST
+
+jobs:
+  setup:
+    name: controller image
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.matrix }}
+    steps:
+      - name: Environment setup
+        uses: ./.github/ironbank-actions/setup
+        with:
+          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
+          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
+
+      - name: create matrix
+        run: |
+          matrix=$(
+            node "$PEPR/.github/workflows/pepr-excellent-examples-matrix.js" "$PEPR_EXCELLENT_EXAMPLES_PATH"
+          )
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+        id: create-matrix
+
+      - name: run e2e tests
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 6
+          command: |
+            cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
+            npm run --workspace=${{ matrix.name }} test:e2e -- \
+              --image pepr:amd \
+              --custom-package ../pepr-0.0.0-development.tgz
+
+      - name: upload artifacts (troubleshooting)
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        if: always()
+        with:
+          name: "troubleshooting_logs_${{matrix.name}}"
+          path: | 
+            pepr-excellent-examples/package.json
+            pepr-excellent-examples/package-lock.json
+          if-no-files-found: error
+          retention-days: 1
+

--- a/.github/workflows/pepr-excellent-examples-ironbank-arm.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-arm.yml
@@ -9,8 +9,8 @@ on:
     - cron: '0 5 * * *' # 1AM EST/10PM PST
 
 jobs:
-  setup:
-    name: controller image
+  ib-arm-e2e:
+    name: Iron Bank ARM Image E2E Test
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
@@ -21,7 +21,7 @@ jobs:
           registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
           registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
 
-      - name: create matrix
+      - name: Create Matrix
         run: |
           matrix=$(
             node "$PEPR/.github/workflows/pepr-excellent-examples-matrix.js" "$PEPR_EXCELLENT_EXAMPLES_PATH"
@@ -29,7 +29,7 @@ jobs:
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
         id: create-matrix
 
-      - name: run e2e tests
+      - name: Run e2e tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           max_attempts: 3
@@ -41,7 +41,7 @@ jobs:
               --image pepr:arm \
               --custom-package ../pepr-0.0.0-development.tgz
 
-      - name: upload artifacts (troubleshooting)
+      - name: Upload artifacts (troubleshooting)
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()
         with:

--- a/.github/workflows/pepr-excellent-examples-ironbank-arm.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-arm.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
       - name: Environment setup
-        uses: ./.github/ironbank-actions/setup
+        uses: ./.github/actions/ironbank-setup
         with:
           registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
           registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}

--- a/.github/workflows/pepr-excellent-examples-ironbank-arm.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-arm.yml
@@ -1,0 +1,54 @@
+name: E2E - Pepr Excellent Examples - IronBank ARM Image
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *' # 1AM EST/10PM PST
+
+jobs:
+  setup:
+    name: controller image
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.matrix }}
+    steps:
+      - name: Environment setup
+        uses: ./.github/ironbank-actions/setup
+        with:
+          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
+          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
+
+      - name: create matrix
+        run: |
+          matrix=$(
+            node "$PEPR/.github/workflows/pepr-excellent-examples-matrix.js" "$PEPR_EXCELLENT_EXAMPLES_PATH"
+          )
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+        id: create-matrix
+
+      - name: run e2e tests
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 6
+          command: |
+            cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
+            npm run --workspace=${{ matrix.name }} test:e2e -- \
+              --image pepr:arm \
+              --custom-package ../pepr-0.0.0-development.tgz
+
+      - name: upload artifacts (troubleshooting)
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        if: always()
+        with:
+          name: "troubleshooting_logs_${{matrix.name}}"
+          path: | 
+            pepr-excellent-examples/package.json
+            pepr-excellent-examples/package-lock.json
+          if-no-files-found: error
+          retention-days: 1
+


### PR DESCRIPTION
## Description

Pepr needs visibility into the Iron Bank images. We already test the upstream and unicorn images during PRs. However, we do not perform any e2e tests on our two Iron Bank images. This PR creates nightly jobs that will test the Iron Bank images.

## Related Issue

Fixes #1896 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
