### PR TITLE
feat: expose log level during npx pepr dev

### DIFF
--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -75,7 +75,7 @@ export default function (program: RootCmd): void {
           program = fork(path, {
             env: {
               ...process.env,
-              LOG_LEVEL: "debug",
+              LOG_LEVEL: process.env.LOG_LEVEL ?? "debug",
               PEPR_MODE: "dev",
               PEPR_API_PATH: webhook.apiPath,
               PEPR_PRETTY_LOGS: "true",


### PR DESCRIPTION
## Description

UDS Core wants to control the LOG_LEVEL when using `npx pepr dev`. The `LOG_LEVEL` is currently [defaulted](https://github.com/defenseunicorns/pepr/blob/633ca0310d4630567933f0c0982e8482f5476dd4/src/cli/dev.ts#L78) to `debug`.

## Related Issue

Fixes #1909
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
