### PR TITLE
chore: remove circular dependency between `module.ts` and `lib.ts`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -41,11 +41,11 @@ jobs:
         run: |
           npx madge --circular --ts-config tsconfig.json --extensions ts,js src/ > tmp.log || true # Force exit 0 for post-processing
           tail -n +4 tmp.log > circular-deps.log
-          if [ $(wc -l < circular-deps.log) -gt 2 ]; then
-            echo "circular-deps.log has more than 2 circular dependencies."
+          if [ $(wc -l < circular-deps.log) -gt 1 ]; then
+            echo "circular-deps.log has more than 1 circular dependencies."
             wc -l circular-deps.log
             exit 1
           else
-            echo "circular-deps.log has 2 or fewer circular dependencies."
+            echo "circular-deps.log has 1 or fewer circular dependencies."
             exit 0
           fi

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -6,7 +6,7 @@ import { Controller, ControllerHooks } from "../controller";
 import { ValidateError } from "../errors";
 import { CapabilityExport } from "../types";
 import { setupWatch } from "../processors/watch-processor";
-import { Log } from "../../lib";
+import Log from "../../lib/telemetry/logger";
 import { resolveIgnoreNamespaces } from "../assets/webhooks";
 import { isBuildMode, isDevMode, isWatchMode } from "./envChecks";
 import { PackageJSON, PeprModuleOptions, ModuleConfig } from "../types";


### PR DESCRIPTION
## Description

Resolves a circular dependency.

## Related Issue

Fixes #1628 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
