### PR TITLE
chore: dependabot token for cgr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+    registries:
+      - chainguard
 
   - package-ecosystem: docker
     directory: /config
     schedule:
       interval: daily
+    registries:
+      - chainguard
+
+registries:
+  chainguard:
+    type: "docker-registry"
+    url: "https://cgr.dev"
+    username: "oauth2"
+    password: "${{ secrets.CHAINGUARD_REGISTRY_TOKEN }}"


### PR DESCRIPTION
## Description

Grants dependabot the ability to authenticate to chainguard to check if there are updates


We may need to check if we can automate the auto-creation of tokens and push them to our repo or try to get a service account token, it seems as though they may expire in [30 days](https://edu.chainguard.dev/chainguard/chainguard-registry/authenticating/#:~:text=This%20token%20expires%20in%2030,the%20pull%20token%20was%20created), we could also put a reminder in slack every 20 or so days 


## Related Issue

Fixes #1918 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
