### PR TITLE
chore: reduce complexity in mutate-processor

### DIFF
--- a/config/unicorn.yaml
+++ b/config/unicorn.yaml
@@ -1,3 +1,3 @@
 images:
-  build: cgr.dev/du-uds-defenseunicorns/node:22.14.0@sha256:18160bed0e77c8300b99a8d1af8cc997280e189e590b55b5ff94893bd398a1e6
-  base: cgr.dev/du-uds-defenseunicorns/node:22.14.0-slim@sha256:95ce4c850fd71a7fe53d9cbaf7f9db318bba9c0ade54717078d9e60c317b5496
+  build: cgr.dev/du-uds-defenseunicorns/node:22.14.0@sha256:b1240ac4f77e28349febd9dfa0a7176d459688a4bd2df98ef0160a80e6e78e33
+  base: cgr.dev/du-uds-defenseunicorns/node:22.14.0-slim@sha256:9ac4adb34641d76753c39798916877f2038b7618450ca25609aec67d18a7ac68

--- a/scripts/read-unicorn-build-args.js
+++ b/scripts/read-unicorn-build-args.js
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { readFileSync } from "fs";
-import { load } from "js-yaml";
+const { readFileSync } = require("fs");
+const { load } = require("js-yaml");
 
 try {
   const config = load(readFileSync("./config/unicorn.yaml", "utf8"));

--- a/scripts/read-unicorn-build-args.mjs
+++ b/scripts/read-unicorn-build-args.mjs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-const { readFileSync } = require("fs");
-const { load } = require("js-yaml");
+import { readFileSync } from "fs";
+import { load } from "js-yaml";
 
 try {
   const config = load(readFileSync("./config/unicorn.yaml", "utf8"));

--- a/src/lib/processors/mutate-processor.test.ts
+++ b/src/lib/processors/mutate-processor.test.ts
@@ -226,13 +226,14 @@ describe("processRequest", () => {
     testBindable.config.onError = OnError.AUDIT;
     const testPeprMutateRequest = defaultPeprMutateRequest();
     const testMutateResponse = clone(defaultMutateResponse);
-    const annote = `${defaultModuleConfig.uuid}.pepr.dev/${defaultBindable.name}`;
 
     const result = await processRequest(testBindable, testPeprMutateRequest, testMutateResponse);
 
     expect(result).toEqual({ wrapped: testPeprMutateRequest, response: testMutateResponse });
     expect(result.wrapped.Raw.metadata?.annotations).toBeDefined();
-    expect(result.wrapped.Raw.metadata!.annotations![annote]).toBe("warning");
+    expect(
+      result.wrapped.Raw.metadata!.annotations![`${defaultModuleConfig.uuid}.pepr.dev/${defaultBindable.name}`],
+    ).toBe("warning");
 
     expect(result.response.warnings).toHaveLength(1);
     expect(result.response.warnings![0]).toBe("Action failed: An error occurred with the mutate action.");

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -188,7 +188,7 @@ export async function mutateProcessor(
   // Compare the original request to the modified request to get the patches
   const patches = jsonPatch.compare(req.object, transformed);
 
-  updateResponsePatchAndWarnings(patches, { ...response, allowed: true });
+  updateResponsePatchAndWarnings(patches, response);
 
   Log.debug({ ...reqMetadata, patches }, `Patches generated`);
   webhookTimer.stop();

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -167,6 +167,8 @@ export async function mutateProcessor(
     }
   }
 
+  // The request is allowed
+
   // If no capability matched the request, exit early
   if (bindables.length === 0) {
     Log.info(reqMetadata, `No matching actions found`);


### PR DESCRIPTION
## Description

After #1895 we increased the complexity in mutate-processor. This PR reduces it under the limit by consolidating the binding filter.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
