### PR TITLE
chore: new org username and password

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,5 @@ registries:
   chainguard:
     type: "docker-registry"
     url: "https://cgr.dev"
-    username: "oauth2"
-    password: "${{ secrets.CHAINGUARD_REGISTRY_TOKEN }}"
+    username: "{{ secrets.CHAINGUARD_USERNAME }}"
+    password: "{{ secrets.CHAINGUARD_PASSWORD }}"


### PR DESCRIPTION
## Description

We have an org username and password for chainguard that I was not aware of. This should allow us to authenticate to their registry like they do in [renovate](https://github.com/defenseunicorns/uds-common/blob/6a3348a1d747ff49c69b5edf9fb56be24bc4840c/config/renovate.json5#L49)

