### PR TITLE
chore: increase coverage in overrides function

### DIFF
--- a/src/lib/assets/yaml/overridesFile.test.ts
+++ b/src/lib/assets/yaml/overridesFile.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { expect, describe, it, jest, beforeEach } from "@jest/globals";
+import { promises as fs } from "fs";
+import { overridesFile } from "./overridesFile";
+import type { ChartOverrides } from "./overridesFile";
+import { load as loadYaml } from "js-yaml";
+import { ModuleConfig } from "../../types";
+import { V1PolicyRule } from "@kubernetes/client-node";
+
+jest.mock("fs", () => ({
+  ...(jest.requireActual("fs") as object),
+  promises: {
+    readFile: jest.fn<() => Promise<string>>().mockResolvedValue("mocked"),
+    writeFile: jest.fn(),
+    access: jest.fn(),
+  },
+}));
+
+interface OverridesFileSchema {
+  imagePullSecrets: string[];
+  additionalIgnoredNamespaces: string[];
+  rbac: V1PolicyRule[];
+  image: string;
+  secrets: {
+    apiPath: string;
+  };
+  hash: string;
+  namespace: {
+    annotations: {
+      [key: string]: string;
+    };
+    labels: {
+      [key: string]: string;
+    };
+  };
+  uuid: string;
+  admission: {
+    terminationGracePeriodSeconds: number;
+    failurePolicy: string;
+    annotations: {
+      "pepr.dev/description": string;
+    };
+    image: string;
+    labels: {
+      [key: string]: string;
+    };
+  };
+  watcher: {
+    terminationGracePeriodSeconds: number;
+    failurePolicy: string;
+    annotations: {
+      "pepr.dev/description": string;
+    };
+    image: string;
+    labels: {
+      [key: string]: string;
+    };
+  };
+}
+
+describe("overridesFile", () => {
+  const mockPath = "/tmp/overrides.yaml";
+  const imagePullSecrets = ["secret1", "secret2"];
+  const config: ModuleConfig = {
+    uuid: "12345",
+    alwaysIgnore: {
+      namespaces: [],
+    },
+    onError: "reject",
+    webhookTimeout: 10,
+    description: "Test Module",
+    customLabels: {},
+    rbacMode: "namespace",
+    rbac: [],
+  };
+
+  const mockOverrides: ChartOverrides = {
+    apiPath: "/some/api",
+    capabilities: [],
+    config,
+    hash: "test-hash",
+    name: "test-module",
+    image: "test-image",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("writes a valid YAML file with expected contents", async () => {
+    await overridesFile(mockOverrides, mockPath, imagePullSecrets);
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    const [[writtenPath, writtenContent]] = (fs.writeFile as jest.Mock).mock.calls;
+
+    expect(writtenPath).toBe(mockPath);
+
+    const parsedYaml = loadYaml(writtenContent as string) as OverridesFileSchema;
+    expect(parsedYaml.imagePullSecrets).toEqual(["secret1", "secret2"]);
+    expect(parsedYaml.hash).toBe(mockOverrides.hash);
+    expect(parsedYaml.admission.image).toBe(mockOverrides.image);
+    expect(parsedYaml.admission.failurePolicy).toBe("Fail");
+    expect(parsedYaml.watcher.image).toBe(mockOverrides.image);
+    expect(parsedYaml.secrets.apiPath).toBe(Buffer.from(mockOverrides.apiPath).toString("base64"));
+    expect(parsedYaml.admission.annotations["pepr.dev/description"]).toBe(mockOverrides.config.description);
+  });
+
+  it("sets correct webhook failurePolicy based on config", async () => {
+    mockOverrides.config.onError = "ignore";
+    await overridesFile(mockOverrides, mockPath, imagePullSecrets);
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    const [[writtenPath, writtenContent]] = (fs.writeFile as jest.Mock).mock.calls;
+
+    expect(writtenPath).toBe(mockPath);
+
+    const parsedYaml = loadYaml(writtenContent as string) as OverridesFileSchema;
+
+    expect(parsedYaml.admission.failurePolicy).toBe("Ignore");
+  });
+
+  it("sets correct annotations based on config", async () => {
+    mockOverrides.config.description = "";
+    await overridesFile(mockOverrides, mockPath, imagePullSecrets);
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    const [[writtenPath, writtenContent]] = (fs.writeFile as jest.Mock).mock.calls;
+
+    expect(writtenPath).toBe(mockPath);
+
+    const parsedYaml = loadYaml(writtenContent as string) as OverridesFileSchema;
+    console.log(parsedYaml);
+    expect(parsedYaml.admission.annotations["pepr.dev/description"]).toBe("");
+    expect(parsedYaml.watcher.annotations["pepr.dev/description"]).toBe("");
+  });
+  it("properly encodes apiPath in base64", async () => {
+    await overridesFile(mockOverrides, mockPath, imagePullSecrets);
+
+    const [[, writtenContent]] = (fs.writeFile as jest.Mock).mock.calls;
+    const parsedYaml = loadYaml(writtenContent as string) as OverridesFileSchema;
+
+    expect(parsedYaml.secrets.apiPath).toBe(Buffer.from(mockOverrides.apiPath).toString("base64"));
+  });
+});

--- a/src/lib/assets/yaml/overridesFile.test.ts
+++ b/src/lib/assets/yaml/overridesFile.test.ts
@@ -130,7 +130,7 @@ describe("overridesFile", () => {
     expect(writtenPath).toBe(mockPath);
 
     const parsedYaml = loadYaml(writtenContent as string) as OverridesFileSchema;
-    console.log(parsedYaml);
+
     expect(parsedYaml.admission.annotations["pepr.dev/description"]).toBe("");
     expect(parsedYaml.watcher.annotations["pepr.dev/description"]).toBe("");
   });

--- a/src/lib/filter/adjudicators/kubernetesObject.test.ts
+++ b/src/lib/filter/adjudicators/kubernetesObject.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { expect, describe, it } from "@jest/globals";
+
+import {
+  carriedKind,
+  carriedVersion,
+  uncarryableNamespace,
+  missingCarriableNamespace,
+  carriesIgnoredNamespace,
+} from "./kubernetesObject";
+
+describe("carriedKind", () => {
+  it.each([
+    // Does carry kind
+    [{ kind: "kind" }, "kind"],
+    // does not carry kind
+    [{}, "not set"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const result = carriedKind(given);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("carriedVersion", () => {
+  it.each([
+    // Does carry version
+    [{ metadata: { resourceVersion: "version" } }, "version"],
+    // does not carry version
+    [{}, "not set"],
+  ])("given %j, returns '%s'", (given, expected) => {
+    const result = carriedVersion(given);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("uncarryableNamespace", () => {
+  it.each([
+    // namespaceSelector is empty, so the first condition (length > 0) fails - should return false
+    [[], {}, false],
+    // namespaceSelector is empty, Object has a namespace - should return false
+    [[], { kind: "Namespace", metadata: { name: "namespace" } }, false],
+    // namespaceSelector is default, object has default - should return false
+    [["default"], { kind: "Namespace", metadata: { name: "default" } }, false],
+    // namespaceSelector is kube-system, object has kube-public - should return true
+    [["kube-system"], { kind: "Pod", metadata: { namespace: "kube-public" } }, true],
+    // namespaceSelector is empty, object has namespace - should return false
+    [[], { metadata: { namespace: "namespace" } }, false],
+    // nameSpaceSelector is kube-system, object is cluster-scoped and has no namespace, should return false
+    [["kube-system"], { kind: "ClusterRole", metadata: { name: "cluster-admin" } }, false],
+  ])("given %j and %j, returns %s", (namespaceSelector, kubernetesObject, expected) => {
+    const result = uncarryableNamespace(namespaceSelector, kubernetesObject);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("missingCarriableNamespace", () => {
+  it.each([
+    // namespaceSelector is empty, so the first condition (length > 0) fails - should return false
+    [[], {}, false],
+
+    // Object has a namespace - should return false
+    [["namespace"], { metadata: { namespace: "namespace" } }, false],
+
+    // Namespace object, but its name is not in namespaceSelector - should return true
+    [["some-other-namespace"], { kind: "Namespace", metadata: { name: "namespace" } }, true],
+
+    // Pod with a namespace - should return false
+    [["kube-public"], { kind: "Pod", metadata: { namespace: "kube-public" } }, false],
+  ])(
+    "given namespaceSelector %j and kubernetesObject %j, returns %s",
+    (namespaceSelector, kubernetesObject, expected) => {
+      const result = missingCarriableNamespace(namespaceSelector, kubernetesObject);
+      expect(result).toEqual(expected);
+    },
+  );
+});
+
+describe("carriesIgnoredNamespace", () => {
+  it.each([
+    // namespaceSelector is empty, so the first condition (length > 0) fails - should return false
+    [[], {}, false],
+
+    // Object carries ignoredNamespace - should return true
+    [["namespace"], { metadata: { namespace: "namespace" } }, true],
+
+    // Ignored namespace is different thatn the namespace name
+    [["some-other-namespace"], { kind: "Namespace", metadata: { name: "namespace" } }, false],
+
+    // Pod with a namespace that is an ignored namespace - should return true
+    [["kube-public"], { kind: "Pod", metadata: { namespace: "kube-public" } }, true],
+
+    // Cluster-scoped object with no namespace - should return false
+    [["kube-system"], { kind: "ClusterRole", metadata: { name: "cluster-admin" } }, false],
+  ])(
+    "given namespaceSelector %j and kubernetesObject %j, returns %s",
+    (namespaceSelector, kubernetesObject, expected) => {
+      const result = carriesIgnoredNamespace(namespaceSelector, kubernetesObject);
+      expect(result).toEqual(expected);
+    },
+  );
+});

--- a/src/lib/filter/adjudicators/kubernetesObject.ts
+++ b/src/lib/filter/adjudicators/kubernetesObject.ts
@@ -62,6 +62,11 @@ export const uncarryableNamespace = allPass([
   }, not),
 ]);
 
+/*
+ * Returns true if the object is missing a carriable namespace.
+ * - If the object is a Namespace, it returns true if its name is not in the namespaceSelector.
+ * - Otherwise, it returns true if the object does not carry a namespace.
+ */
 export const missingCarriableNamespace = allPass([
   pipe(nthArg(0), length, gt(__, 0)),
   pipe((namespaceSelector: string[], kubernetesObject: KubernetesObject): boolean =>


### PR DESCRIPTION
## Description

Increases coverage in the overrides function to ensure the proper helm `values.yaml` file is being generated

```bash
  overridesFile.ts           |     100 |      100 |     100 |     100 | 
```

## Related Issue

Fixes #1935 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
