### PR TITLE
chore: use uuidv4() when user does not provide a module UUID

### DIFF
--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -3,7 +3,7 @@
 
 import { dumpYaml } from "@kubernetes/client-node";
 import { inspect } from "util";
-import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
+import { v4 as uuidv4 } from "uuid";
 
 import eslintJSON from "../../templates/.eslintrc.template.json";
 import peprSnippetsJSON from "../../templates/pepr.code-snippets.json";
@@ -48,7 +48,7 @@ export type peprPackageJSON = {
 
 export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string): peprPackageJSON {
   // Generate a random UUID for the module based on the module name if it is not provided
-  const uuid = !opts.uuid ? uuidv5(opts.name, uuidv4()) : opts.uuid;
+  const uuid = !opts.uuid ? uuidv4() : opts.uuid;
   // Generate a name for the module based on the module name
   const name = sanitizeName(opts.name);
   // Make typescript a dev dependency


### PR DESCRIPTION
## Description

This module resolves some convoluted uuid generation. See also, #1963 

## Related Issue

Fixes #1973

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
