### PR TITLE
fix: use consistent uuid length limit in docs

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -12,7 +12,7 @@ Initialize a new Pepr Module.
 - `--name <string>` - Set the name of the new module.
 - `--skip-post-init` - Skip npm install, git init, and VSCode launch.
 - `--errorBehavior <audit|ignore|reject>` - Set an errorBehavior.
-- `--uuid [string]` - Unique identifier for your module with a max length of 32 characters.
+- `--uuid [string]` - Unique identifier for your module with a max length of 36 characters.
 ---
 
 ## `npx pepr update`

--- a/src/cli/init/enums.ts
+++ b/src/cli/init/enums.ts
@@ -7,3 +7,5 @@ export enum OnError {
   IGNORE = "ignore",
   REJECT = "reject",
 }
+
+export const UUID_LENGTH_LIMIT = 36;

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -23,6 +23,7 @@ import {
 import { createDir, sanitizeName, write } from "./utils";
 import { confirm, PromptOptions, walkthrough } from "./walkthrough";
 import { ErrorList } from "../../lib/errors";
+import { UUID_LENGTH_LIMIT } from "./enums";
 
 export default function (program: RootCmd): void {
   let response = {} as PromptOptions;
@@ -37,11 +38,9 @@ export default function (program: RootCmd): void {
     .option(`--errorBehavior <${ErrorList.join("|")}>`, "Set an errorBehavior.")
     .option(
       "--uuid [string]",
-      "Unique identifier for your module with a max length of 32 characters.",
+      "Unique identifier for your module with a max length of 36 characters.",
       (uuid: string): string => {
-        const uuidLengthLimit = 36;
-        // length of generated uuid
-        if (uuid.length > uuidLengthLimit) {
+        if (uuid.length > UUID_LENGTH_LIMIT) {
           throw new Error("The UUID must be 36 characters or fewer.");
         }
         return uuid.toLocaleLowerCase();

--- a/src/cli/init/walkthrough.ts
+++ b/src/cli/init/walkthrough.ts
@@ -6,7 +6,7 @@ import prompt, { Answers, PromptObject } from "prompts";
 
 import { eslint, gitignore, prettier, readme, tsConfig } from "./templates";
 import { sanitizeName } from "./utils";
-import { OnError } from "./enums";
+import { OnError, UUID_LENGTH_LIMIT } from "./enums";
 import { ErrorList } from "../../lib/errors";
 
 export type PromptOptions = {
@@ -33,9 +33,9 @@ async function setUUID(uuid?: string): Promise<Answers<string>> {
     name: "uuid",
     message: "Enter a unique identifier for the new Pepr module.\n",
     validate: (val: string) => {
-      const uuidLengthLimit = 36;
       return (
-        val.length <= uuidLengthLimit || `The UUID must be ${uuidLengthLimit} characters or fewer.`
+        val.length <= UUID_LENGTH_LIMIT ||
+        `The UUID must be ${UUID_LENGTH_LIMIT} characters or fewer.`
       );
     },
   };


### PR DESCRIPTION
## Description

This PR fixes a minor docs issue. See [k8s slack](https://kubernetes.slack.com/archives/C06DGH40UCB/p1743533521313019?thread_ts=1743523799.611479&cid=C06DGH40UCB).

A UUIDv4 (Universally Unique Identifier version 4) is:
	•	128 bits long (which is 16 bytes).
	•	When represented as a string, it is typically shown in a 36-character format, including hyphens:
`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
