### PR TITLE
chore: finalize example in actions docs

### DIFF
--- a/docs/030_user-guide/030_actions/050_finalize.md
+++ b/docs/030_user-guide/030_actions/050_finalize.md
@@ -1,6 +1,6 @@
 # Finalize
 
-A specialized combination of Pepr's [Mutate](./010_mutate.md) & [Watch](./040_watch.md) functionalities that allow a module author to run logic while Kubernetes is [Finalizing](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) a resource (i.e. cleaning up related resources _after_ a deleteion request has been accepted).
+A specialized combination of Pepr's [Mutate](./010_mutate.md) & [Watch](./040_watch.md) functionalities that allow a module author to run logic while Kubernetes is [Finalizing](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) a resource (i.e. cleaning up related resources _after_ a deleteion request has been accepted). `Finalize()` can only be accessed after a `Watch()` or `Reconcile()`.
 
 This method will:
 
@@ -9,3 +9,17 @@ This method will:
 1. Watch appropriate resource lifecycle events & invoke the given callback.
 
 1. Remove the injected finalizer from the `metadata.finalizers` field of the requested resource.
+
+
+```ts
+When(a.ConfigMap)
+  .IsCreated()
+  .InNamespace("hello-pepr-finalize-create")
+  .WithName("cm-reconcile-create")
+  .Reconcile(function reconcileCreate(cm) {
+    Log.info(cm, "external api call (create): reconcile/callback")
+  })
+  .Finalize(function finalizeCreate(cm) {
+    Log.info(cm, "external api call (create): reconcile/finalize")
+  });
+```


### PR DESCRIPTION
## Description

Our doc for the finalize action explains the action but shows no example. We are trying to bring uniformity to the docs so need to include examples.

## Related Issue

Fixes #1995 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
