### PR TITLE
chore: reconcile and watch examples in action docs

### DIFF
--- a/docs/030_user-guide/030_actions/030_reconcile.md
+++ b/docs/030_user-guide/030_actions/030_reconcile.md
@@ -5,3 +5,34 @@ Reconcile functions the same as Watch but is tailored for building Kubernetes Co
 Ordering can be configured to operate in one of two ways: as a single queue that maintains ordering of operations across all resources of a kind (default) or with separate processing queues per resource instance.
 
 See [Configuring Reconcile](../120_customization.md#configuring-reconcile) for more on configuring how Reconcile behaves.
+
+
+```ts
+When(WebApp)
+  .IsCreatedOrUpdated()
+  .Validate(validator) // Validate the shape of the resource
+  .Reconcile(async instance => {
+    try {
+      Store.setItem(instance.metadata.name, JSON.stringify(instance));
+      await reconciler(instance); // Reconcile the resource - Deploy Kubernetes manifests, etc.
+    } catch (error) {
+      Log.info(`Error reconciling instance of WebApp`);
+    }
+  });
+
+export async function validator(req: PeprValidateRequest<WebApp>) {
+  const ns = req.Raw.metadata?.namespace ?? "_unknown_";
+
+  if (req.Raw.spec.replicas > 7) {
+    return req.Deny("max replicas is 7 to prevent noisy neighbors");
+  }
+  if (invalidNamespaces.includes(ns)) {
+    if (req.Raw.metadata?.namespace === "default") {
+      return req.Deny("default namespace is not allowed");
+    }
+    return req.Deny("invalid namespace");
+  }
+
+  return req.Approve();
+}
+```

--- a/docs/030_user-guide/030_actions/040_watch.md
+++ b/docs/030_user-guide/030_actions/040_watch.md
@@ -1,3 +1,32 @@
 # Watch
 
 [Kubernetes](https://kubernetes.io/docs/reference/using-api/api-concepts) supports efficient change notifications on resources via watches. Pepr uses the Watch action for monitoring resources that previously existed in the cluster and for performing long-running asynchronous events upon receiving change notifications on resources, as watches are not limited by [timeouts](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts).
+
+
+```ts
+When(a.Namespace)
+  .IsCreated()
+  .WithName("pepr-demo-2")
+  .Watch(async ns => {
+    Log.info("Namespace pepr-demo-2 was created.");
+
+    try {
+      // Apply the ConfigMap using K8s server-side apply
+      await K8s(kind.ConfigMap).Apply({
+        metadata: {
+          name: "pepr-ssa-demo",
+          namespace: "pepr-demo-2",
+        },
+        data: {
+          "ns-uid": ns.metadata.uid,
+        },
+      });
+    } catch (error) {
+      // You can use the Log object to log messages to the Pepr controller pod
+      Log.error(error, "Failed to apply ConfigMap using server-side apply.");
+    }
+
+    // You can share data between actions using the Store, including between different types of actions
+    Store.setItem("watch-data", "This data was stored by a Watch Action.");
+  });
+```


### PR DESCRIPTION
## Description

Adds examples to action docs, adds uniformity across the action docs since some have examples and some don't 

## Related Issue

Fixes #1994 #1993 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
