### PR TITLE
chore: make uds test use library

### DIFF
--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -48,6 +48,7 @@ jobs:
           npm run build
           PEPR_TGZ="${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz"
           echo "PEPR_TGZ=${PEPR_TGZ}" >> "$GITHUB_ENV"
+          mv "$PEPR/pepr-0.0.0-development.tgz" "$PEPR_TGZ"
 
       - name: tar pepr image
         run: |
@@ -117,13 +118,13 @@ jobs:
 
           uds version
 
-      - name: dowload image tar artifact
+      - name: download image tar artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: pepr-img.tar
           path: ${{ github.workspace }}
 
-      - name: dowload image tgz artifact
+      - name: download tgz artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: pepr-0.0.0-development.tgz

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -42,6 +42,13 @@ jobs:
           cd "$PEPR"
           npm run build:image
 
+      - name: build pepr library npm module
+        run: |
+          cd "$PEPR"
+          npm run build
+          PEPR_TGZ="${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz"
+          echo "PEPR_TGZ=${PEPR_TGZ}" >> "$GITHUB_ENV"
+
       - name: tar pepr image
         run: |
           PEPR_TAR="${GITHUB_WORKSPACE}/pepr-img.tar"
@@ -53,6 +60,13 @@ jobs:
         with:
           name: pepr-img.tar
           path: pepr-img.tar
+          retention-days: 1
+
+      - name: upload pepr tgz artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pepr-0.0.0-development.tgz
+          path: pepr-0.0.0-development.tgz
           retention-days: 1
 
   uds-run:
@@ -109,6 +123,12 @@ jobs:
           name: pepr-img.tar
           path: ${{ github.workspace }}
 
+      - name: dowload image tgz artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: pepr-0.0.0-development.tgz
+          path: ${{ github.workspace }}
+
       - name: "set env: PEPR_IMG"
         run: echo "PEPR_IMG=${GITHUB_WORKSPACE}/pepr-img.tar" >> "$GITHUB_ENV"
 
@@ -128,4 +148,5 @@ jobs:
       - name: uds run
         run: |
           cd "$UDS_CORE"
+          npm i --no-save pepr-0.0.0-development.tgz
           PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -129,6 +129,9 @@ jobs:
           name: pepr-0.0.0-development.tgz
           path: ${{ github.workspace }}
 
+      - name: "set env: PEPR_TGZ"
+        run: echo "PEPR_TGZ=${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz" >> "$GITHUB_ENV"
+
       - name: "set env: PEPR_IMG"
         run: echo "PEPR_IMG=${GITHUB_WORKSPACE}/pepr-img.tar" >> "$GITHUB_ENV"
 
@@ -148,5 +151,5 @@ jobs:
       - name: uds run
         run: |
           cd "$UDS_CORE"
-          npm i --no-save pepr-0.0.0-development.tgz
+          npm i "$PEPR_TGZ" 
           PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -152,5 +152,5 @@ jobs:
       - name: uds run
         run: |
           cd "$UDS_CORE"
-          npm i "$PEPR_TGZ" 
+          npm install "$PEPR_TGZ" 
           PEPR_CUSTOM_IMAGE="pepr:dev" uds run slim-dev


### PR DESCRIPTION
## Description

Pepr is testing using the library candidate in the integration tests, however, it is not as sensitive to missing types as UDS Core. 

As seen in this [comment](https://github.com/defenseunicorns/pepr/issues/1989#issuecomment-2787472053) a basic Pepr module will build if a type is excluded from the library, but UDS Core will fail the build.

We already have a UDS test, where we install `slim-dev`, however, the test was only testing the pepr release candidate controller image, and not installing the release candidate library.

This PR results in UDS Core `slim-dev` package being build with the release candidate

```json
  "dependencies": {
    "pepr": "file:pepr-0.0.0-development.tgz"
  },
```

## Related Issue

Fixes #1989 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
