### PR TITLE
chore: removes the `migrateAndSetupWatch` out of `store.ts` for improved testability

### DIFF
--- a/src/lib/controller/migrateStore.test.ts
+++ b/src/lib/controller/migrateStore.test.ts
@@ -1,0 +1,103 @@
+import { migrateAndSetupWatch, StoreMigration } from "./migrateStore";
+import Log from "../telemetry/logger";
+import * as storeCache from "./storeCache";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Operation } from "fast-json-patch";
+import { Storage } from "../core/storage";
+
+const mockPatch = jest.fn();
+jest.mock("../telemetry/logger", () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+  redactedStore: jest.fn(x => x),
+}));
+
+jest.mock("kubernetes-fluent-client", () => {
+  return {
+    ...(jest.requireActual("kubernetes-fluent-client") as object),
+    K8s: jest.fn().mockImplementation(() => ({
+      Patch: mockPatch,
+    })),
+  };
+});
+jest.mock("./storeCache", () => ({
+  ...(jest.requireActual("./storeCache") as object),
+  sendUpdatesAndFlushCache: jest.fn(),
+}));
+
+describe("migrateAndSetupWatch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should patch the store, transform keys, and call setupWatch", async () => {
+    const setupWatch = jest.fn();
+
+    // non-migrated store v1
+    const storeMigrationData: StoreMigration = {
+      name: "pepr-static-test-store",
+      namespace: "pepr-system",
+      setupWatch,
+      store: {
+        kind: "PeprStore",
+        data: {
+          __pepr_do_not_delete__: "k-thx-bye",
+          "hello-pepr-example-1": "was-here",
+          "hello-pepr-example-1-data": '{"key":"ex-1-val"}',
+          "hello-pepr-watch-data": "This data was stored by a Watch Action.",
+        },
+        metadata: {
+          labels: {
+            "pepr.dev-cacheID": "1744214317282",
+          },
+          name: "pepr-static-test-store",
+          namespace: "pepr-system",
+        },
+      },
+      stores: {
+        "hello-pepr-example-1": new Storage(),
+      },
+    };
+
+    (
+      storeCache.sendUpdatesAndFlushCache as jest.MockedFunction<
+        typeof storeCache.sendUpdatesAndFlushCache
+      >
+    ).mockResolvedValue({} as Record<string, Operation>);
+
+    await migrateAndSetupWatch(storeMigrationData);
+    const [actualCache, actualNamespace, actualName] = (
+      storeCache.sendUpdatesAndFlushCache as jest.Mock
+    ).mock.calls[0] as [Record<string, Operation>, string, string];
+
+    expect(Log.debug).toHaveBeenCalledWith(expect.anything(), "Pepr Store migration");
+    expect(actualNamespace).toBe("pepr-system");
+    expect(actualName).toBe("pepr-static-test-store");
+
+    expect(mockPatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        op: "add",
+        path: "/metadata/labels/pepr.dev-cacheID",
+        value: expect.any(String),
+      }),
+    ]);
+
+    expect(storeCache.sendUpdatesAndFlushCache).toHaveBeenCalled();
+    const transformedKeys = Object.keys(actualCache);
+
+    // Make sure we actually get the correct migration
+    expect(transformedKeys).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching("remove:/data/hello-pepr-example-1-"),
+        expect.stringMatching("add:/data/hello-pepr-example-1-v2-:was-here"),
+        expect.stringMatching("remove:/data/hello-pepr-example-1-data"),
+        expect.stringMatching('add:/data/hello-pepr-example-1-v2-data:{"key":"ex-1-val"}'),
+      ]),
+    );
+
+    expect(setupWatch).toHaveBeenCalled();
+  });
+});

--- a/src/lib/controller/migrateStore.test.ts
+++ b/src/lib/controller/migrateStore.test.ts
@@ -127,7 +127,7 @@ describe("migrateAndSetupWatch", () => {
     expect(actualCache).toEqual({});
   });
 
-  it("should log that the store is being migrated to easier debuggin through the logs", async () => {
+  it("should log that the store is being migrated for easier debugging through the logs", async () => {
     await migrateAndSetupWatch(storeMigrationData);
     expect(Log.debug).toHaveBeenCalledWith(expect.anything(), "Pepr Store migration");
   });

--- a/src/lib/controller/migrateStore.test.ts
+++ b/src/lib/controller/migrateStore.test.ts
@@ -6,6 +6,7 @@ import type { Operation } from "fast-json-patch";
 import { Storage } from "../core/storage";
 
 const mockPatch = jest.fn();
+const setupWatch = jest.fn();
 jest.mock("../telemetry/logger", () => ({
   __esModule: true,
   default: {
@@ -28,55 +29,39 @@ jest.mock("./storeCache", () => ({
   sendUpdatesAndFlushCache: jest.fn(),
 }));
 
+// non-migrated store v1
+const storeMigrationData: StoreMigration = {
+  name: "pepr-static-test-store",
+  namespace: "pepr-system",
+  setupWatch,
+  store: {
+    kind: "PeprStore",
+    data: {
+      __pepr_do_not_delete__: "k-thx-bye",
+      "hello-pepr-example-1": "was-here",
+      "hello-pepr-example-1-data": '{"key":"ex-1-val"}',
+      "hello-pepr-watch-data": "This data was stored by a Watch Action.",
+    },
+    metadata: {
+      labels: {
+        "pepr.dev-cacheID": "1744214317282",
+      },
+      name: "pepr-static-test-store",
+      namespace: "pepr-system",
+    },
+  },
+  stores: {
+    "hello-pepr-example-1": new Storage(),
+  },
+};
+
 describe("migrateAndSetupWatch", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should patch the store, transform keys, and call setupWatch", async () => {
-    const setupWatch = jest.fn();
-
-    // non-migrated store v1
-    const storeMigrationData: StoreMigration = {
-      name: "pepr-static-test-store",
-      namespace: "pepr-system",
-      setupWatch,
-      store: {
-        kind: "PeprStore",
-        data: {
-          __pepr_do_not_delete__: "k-thx-bye",
-          "hello-pepr-example-1": "was-here",
-          "hello-pepr-example-1-data": '{"key":"ex-1-val"}',
-          "hello-pepr-watch-data": "This data was stored by a Watch Action.",
-        },
-        metadata: {
-          labels: {
-            "pepr.dev-cacheID": "1744214317282",
-          },
-          name: "pepr-static-test-store",
-          namespace: "pepr-system",
-        },
-      },
-      stores: {
-        "hello-pepr-example-1": new Storage(),
-      },
-    };
-
-    (
-      storeCache.sendUpdatesAndFlushCache as jest.MockedFunction<
-        typeof storeCache.sendUpdatesAndFlushCache
-      >
-    ).mockResolvedValue({} as Record<string, Operation>);
-
+  it("should should patch the stor with a pepr.dev-cacheID label", async () => {
     await migrateAndSetupWatch(storeMigrationData);
-    const [actualCache, actualNamespace, actualName] = (
-      storeCache.sendUpdatesAndFlushCache as jest.Mock
-    ).mock.calls[0] as [Record<string, Operation>, string, string];
-
-    expect(Log.debug).toHaveBeenCalledWith(expect.anything(), "Pepr Store migration");
-    expect(actualNamespace).toBe("pepr-system");
-    expect(actualName).toBe("pepr-static-test-store");
-
     expect(mockPatch).toHaveBeenCalledWith([
       expect.objectContaining({
         op: "add",
@@ -84,8 +69,20 @@ describe("migrateAndSetupWatch", () => {
         value: expect.any(String),
       }),
     ]);
+  });
 
-    expect(storeCache.sendUpdatesAndFlushCache).toHaveBeenCalled();
+  it("should transform keys to v2 with correct values", async () => {
+    await migrateAndSetupWatch(storeMigrationData);
+    const [actualCache] = (storeCache.sendUpdatesAndFlushCache as jest.Mock).mock.calls[0] as [
+      Record<string, Operation>,
+    ];
+
+    (
+      storeCache.sendUpdatesAndFlushCache as jest.MockedFunction<
+        typeof storeCache.sendUpdatesAndFlushCache
+      >
+    ).mockResolvedValue({} as Record<string, Operation>);
+
     const transformedKeys = Object.keys(actualCache);
 
     // Make sure we actually get the correct migration
@@ -97,7 +94,41 @@ describe("migrateAndSetupWatch", () => {
         expect.stringMatching('add:/data/hello-pepr-example-1-v2-data:{"key":"ex-1-val"}'),
       ]),
     );
+  });
 
+  it("should call sendUpdatesAndFlushCache with correct name and namespace", async () => {
+    await migrateAndSetupWatch(storeMigrationData);
+    const [actualCache, actualNamespace, actualName] = (
+      storeCache.sendUpdatesAndFlushCache as jest.Mock
+    ).mock.calls[0] as [Record<string, Operation>, string, string];
+
+    expect(actualCache).toBeDefined();
+    expect(actualNamespace).toBe("pepr-system");
+    expect(actualName).toBe("pepr-static-test-store");
+  });
+
+  it("should call setupWatch", async () => {
+    await migrateAndSetupWatch(storeMigrationData);
     expect(setupWatch).toHaveBeenCalled();
+  });
+
+  it("should not transform keys when store is empty", async () => {
+    const emptyStoreMigrationData: StoreMigration = {
+      ...storeMigrationData,
+      store: {
+        ...storeMigrationData.store,
+        data: {},
+      },
+    };
+    await migrateAndSetupWatch(emptyStoreMigrationData);
+    const [actualCache] = (storeCache.sendUpdatesAndFlushCache as jest.Mock).mock.calls[0] as [
+      Record<string, Operation>,
+    ];
+    expect(actualCache).toEqual({});
+  });
+
+  it("should log that the store is being migrated to easier debuggin through the logs", async () => {
+    await migrateAndSetupWatch(storeMigrationData);
+    expect(Log.debug).toHaveBeenCalledWith(expect.anything(), "Pepr Store migration");
   });
 });

--- a/src/lib/controller/migrateStore.ts
+++ b/src/lib/controller/migrateStore.ts
@@ -27,7 +27,7 @@ export async function migrateAndSetupWatch(storeData: StoreMigration): Promise<v
     },
   ]);
 
-  const data: DataStore = store.data || {};
+  const data: DataStore = store.data;
   let storeCache: Record<string, Operation> = {};
 
   for (const name of Object.keys(stores)) {

--- a/src/lib/controller/migrateStore.ts
+++ b/src/lib/controller/migrateStore.ts
@@ -1,0 +1,55 @@
+import { DataStore, Storage } from "../core/storage";
+import { startsWith } from "ramda";
+import Log, { redactedStore } from "../telemetry/logger";
+import { K8s } from "kubernetes-fluent-client";
+import { Store } from "../k8s";
+import { Operation } from "fast-json-patch";
+import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
+
+interface StoreMigration {
+  name: string;
+  namespace: string;
+  store: Store;
+  stores: Record<string, Storage>;
+  setupWatch: () => void;
+}
+
+export async function migrateAndSetupWatch(storeData: StoreMigration): Promise<void> {
+  const { store, namespace, name, stores, setupWatch } = storeData;
+  Log.debug(redactedStore(store), "Pepr Store migration");
+  // Add cacheID label to store
+  await K8s(Store, { namespace, name }).Patch([
+    {
+      op: "add",
+      path: "/metadata/labels/pepr.dev-cacheID",
+      value: `${Date.now()}`,
+    },
+  ]);
+
+  const data: DataStore = store.data || {};
+  let storeCache: Record<string, Operation> = {};
+
+  for (const name of Object.keys(stores)) {
+    // Get the prefix offset for the keys
+    const offset = `${name}-`.length;
+
+    // Loop over each key in the store
+    for (const key of Object.keys(data)) {
+      // Match on the capability name as a prefix for non v2 keys
+      if (startsWith(name, key) && !startsWith(`${name}-v2`, key)) {
+        // populate migrate cache
+        storeCache = fillStoreCache(storeCache, name, "remove", {
+          key: [key.slice(offset)],
+          value: data[key],
+        });
+        storeCache = fillStoreCache(storeCache, name, "add", {
+          key: [key.slice(offset)],
+          value: data[key],
+          version: "v2",
+        });
+      }
+    }
+  }
+  storeCache = await sendUpdatesAndFlushCache(storeCache, namespace, name);
+  setupWatch();
+}

--- a/src/lib/controller/migrateStore.ts
+++ b/src/lib/controller/migrateStore.ts
@@ -6,7 +6,7 @@ import { Store } from "../k8s";
 import { Operation } from "fast-json-patch";
 import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
 
-interface StoreMigration {
+export interface StoreMigration {
   name: string;
   namespace: string;
   store: Store;
@@ -16,6 +16,7 @@ interface StoreMigration {
 
 export async function migrateAndSetupWatch(storeData: StoreMigration): Promise<void> {
   const { store, namespace, name, stores, setupWatch } = storeData;
+
   Log.debug(redactedStore(store), "Pepr Store migration");
   // Add cacheID label to store
   await K8s(Store, { namespace, name }).Patch([

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -10,6 +10,7 @@ import { Store } from "../k8s";
 import Log, { redactedPatch, redactedStore } from "../telemetry/logger";
 import { DataOp, DataSender, DataStore, Storage } from "../core/storage";
 import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
+import { migrateAndSetupWatch } from "./migrateStore";
 
 const namespace = "pepr-system";
 const debounceBackoffReceive = 1000;
@@ -56,7 +57,16 @@ export class StoreController {
         K8s(Store)
           .InNamespace(namespace)
           .Get(this.#name)
-          .then(async (store: Store) => await this.#migrateAndSetupWatch(store))
+          .then(
+            async (store: Store) =>
+              await migrateAndSetupWatch({
+                name,
+                namespace,
+                store,
+                stores: this.#stores,
+                setupWatch: this.#setupWatch,
+              }),
+          )
           .catch(this.#createStoreResource),
       Math.random() * 3000, // Add a jitter to the Store creation to avoid collisions
     );
@@ -65,45 +75,6 @@ export class StoreController {
   #setupWatch = (): void => {
     const watcher = K8s(Store, { name: this.#name, namespace }).Watch(this.#receive);
     watcher.start().catch(e => Log.error(e, "Error starting Pepr store watch"));
-  };
-
-  #migrateAndSetupWatch = async (store: Store): Promise<void> => {
-    Log.debug(redactedStore(store), "Pepr Store migration");
-    // Add cacheID label to store
-    await K8s(Store, { namespace, name: this.#name }).Patch([
-      {
-        op: "add",
-        path: "/metadata/labels/pepr.dev-cacheID",
-        value: `${Date.now()}`,
-      },
-    ]);
-
-    const data: DataStore = store.data || {};
-    let storeCache: Record<string, Operation> = {};
-
-    for (const name of Object.keys(this.#stores)) {
-      // Get the prefix offset for the keys
-      const offset = `${name}-`.length;
-
-      // Loop over each key in the store
-      for (const key of Object.keys(data)) {
-        // Match on the capability name as a prefix for non v2 keys
-        if (startsWith(name, key) && !startsWith(`${name}-v2`, key)) {
-          // populate migrate cache
-          storeCache = fillStoreCache(storeCache, name, "remove", {
-            key: [key.slice(offset)],
-            value: data[key],
-          });
-          storeCache = fillStoreCache(storeCache, name, "add", {
-            key: [key.slice(offset)],
-            value: data[key],
-            version: "v2",
-          });
-        }
-      }
-    }
-    storeCache = await sendUpdatesAndFlushCache(storeCache, namespace, this.#name);
-    this.#setupWatch();
   };
 
   #receive = (store: Store): void => {


### PR DESCRIPTION
## Description


removes the `migrateAndSetupWatch` out of `store.ts` for improved testability

## Related Issue

Fixes #1324 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
