### PR TITLE
chore: fix PEPR_BUILD_VERSION for new IB Dockerfiles

### DIFF
--- a/hack/build-iron-bank.sh
+++ b/hack/build-iron-bank.sh
@@ -54,8 +54,10 @@ tar -zcvf pepr-0.0.0-development.tar.gz pepr
 mv pepr-0.0.0-development.tgz "${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz"
 
 # Build Docker images
-docker build --build-arg PEPR_BUILD_VERSION=0.0.0 -t pepr:amd -f Dockerfile.ironbank.amd .
-docker build --build-arg PEPR_BUILD_VERSION=0.0.0 -t pepr:arm -f Dockerfile.ironbank.arm .
+export PEPR_BUILD_VERSION
+PEPR_BUILD_VERSION=v$(npx pepr@latest --version)
+docker build --build-arg PEPR_BUILD_VERSION="$PEPR_BUILD_VERSION" -t pepr:amd -f Dockerfile.ironbank.amd .
+docker build --build-arg PEPR_BUILD_VERSION="$PEPR_BUILD_VERSION" -t pepr:arm -f Dockerfile.ironbank.arm .
 
 # Save Docker images
 docker image save --output "$PEPR_AMD_TAR" pepr:amd


### PR DESCRIPTION
## Description

We need to update the `PEPR_BUILD_VERSION` now that we changed our Iron Bank Dockerfiles. Now our `PEPR_BUILD_VERSION` corresponds to the latest released version of Pepr.

- Here is the CI [failure](https://github.com/defenseunicorns/pepr/actions/runs/14509226640/job/40704191374#step:3:24741).
- Here is the new [Dockerfile](https://repo1.dso.mil/dsop/opensource/defenseunicorns/pepr/controller/-/blob/development/Dockerfile?ref_type=heads)
- Here is the old [Dockerfile](https://repo1.dso.mil/dsop/opensource/defenseunicorns/pepr/controller/-/blob/master/Dockerfile?ref_type=heads) that was using an arbitrary build version.

This is necessary because we are pulling the `node_modules` from the latest GHCR image. 
Here is the result from the update:

```bash
> export PEPR_BUILD_VERSION
PEPR_BUILD_VERSION=v$(npx pepr@latest --version)
#docker build --build-arg PEPR_BUILD_VERSION="$PEPR_BUILD_VERSION" -t pepr:amd -f Dockerfile.ironbank.amd .
docker build --build-arg PEPR_BUILD_VERSION="$PEPR_BUILD_VERSION" -t pepr:arm -f Dockerfile.ironbank.arm .
[+] Building 11.1s (10/10) FINISHED                                                            docker:desktop-linux
 => [internal] load build definition from Dockerfile.ironbank.arm                                              0.0s
 => => transferring dockerfile: 412B                                                                           0.0s
 => [internal] load metadata for ghcr.io/defenseunicorns/pepr/controller:v0.48.1                               0.0s
 => [internal] load metadata for registry1.dso.mil/ironbank/opensource/nodejs/nodejs22:22.14.0-slim            2.1s
 => [auth] ironbank/opensource/nodejs/nodejs22:pull token for registry1.dso.mil                                0.0s
 => [internal] load .dockerignore                                                                              0.0s
 => => transferring context: 136B                                                                              0.0s
 => [stage-1 1/3] FROM registry1.dso.mil/ironbank/opensource/nodejs/nodejs22:22.14.0-slim@sha256:a02e795de0f3  7.0s
 => => resolve registry1.dso.mil/ironbank/opensource/nodejs/nodejs22:22.14.0-slim@sha256:a02e795de0f36c96c7e5  0.0s
 => => sha256:a02e795de0f36c96c7e51fa435b6609d67f28c72994e8efb7bcaf5f12ea6b595 506B / 506B                     0.0s
 => => sha256:b745fd83ba5d59fc781fae31085baa4e26b59fcd0446bda23c4435c9110a656a 954B / 954B                     0.0s
 => => sha256:a8969d1e48286fd2e812701a763155c85ddbc0e89dbedd7b97243a22afbf6b3a 12.43kB / 12.43kB               0.0s
 => => sha256:7a9304494a9170800b6c4e2ece616f3c0d0e055d172c4648c80cc82b32f20899 1.62MB / 1.62MB                 0.9s
 => => sha256:3ad92d8dd7d30698f8b079831b66de087be0a0d9531da34643394ce4db1e5a51 62.41MB / 62.41MB               5.1s
 => => extracting sha256:7a9304494a9170800b6c4e2ece616f3c0d0e055d172c4648c80cc82b32f20899                      0.1s
 => => extracting sha256:3ad92d8dd7d30698f8b079831b66de087be0a0d9531da34643394ce4db1e5a51                      1.8s
 => CACHED [upstream 1/1] FROM ghcr.io/defenseunicorns/pepr/controller:v0.48.1                                 0.0s
 => [stage-1 2/3] WORKDIR /app                                                                                 0.1s
 => [stage-1 3/3] COPY --from=upstream /app/node_modules ./node_modules                                        1.6s
 => exporting to image                                                                                         0.3s
 => => exporting layers                                                                                        0.3s
 => => writing image sha256:36533523d8308529620574dccfd8f54a99f5195f4a533ee805a103063c1f5a72                   0.0s
 => => naming to docker.io/library/pepr:arm                                                                    0.0s

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
```
## Related Issue

Fixes #2047 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
