### PR TITLE
chore: remove process.exit in pods and propagate to src/cli

### DIFF
--- a/src/lib/assets/pods.test.ts
+++ b/src/lib/assets/pods.test.ts
@@ -393,11 +393,10 @@ describe("moduleSecret function", () => {
     jest.spyOn(helpers, "secretOverLimit").mockReturnValue(true);
 
     const consoleErrorMock = jest.spyOn(console, "error").mockImplementation(() => {});
-    const processExitMock = jest.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
 
-    expect(() => getModuleSecret(name, data, hash)).toThrow("process.exit");
+    expect(() => getModuleSecret(name, data, hash)).toThrow(
+      "Module secret for test is over the 1MB limit",
+    );
 
     expect(consoleErrorMock).toHaveBeenCalledWith(
       "Uncaught Exception:",
@@ -405,6 +404,5 @@ describe("moduleSecret function", () => {
     );
 
     consoleErrorMock.mockRestore();
-    processExitMock.mockRestore();
   });
 });

--- a/src/lib/assets/pods.test.ts
+++ b/src/lib/assets/pods.test.ts
@@ -398,11 +398,6 @@ describe("moduleSecret function", () => {
       "Module secret for test is over the 1MB limit",
     );
 
-    expect(consoleErrorMock).toHaveBeenCalledWith(
-      "Uncaught Exception:",
-      new Error(`Module secret for ${name} is over the 1MB limit`),
-    );
-
     consoleErrorMock.mockRestore();
   });
 });

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -348,7 +348,6 @@ export function getModuleSecret(name: string, data: Buffer, hash: string): kind.
   const compressedData = compressed.toString("base64");
   if (secretOverLimit(compressedData)) {
     const error = new Error(`Module secret for ${name} is over the 1MB limit`);
-    console.error("Uncaught Exception:", error);
     throw error;
   } else {
     return {

--- a/src/lib/assets/pods.ts
+++ b/src/lib/assets/pods.ts
@@ -349,7 +349,7 @@ export function getModuleSecret(name: string, data: Buffer, hash: string): kind.
   if (secretOverLimit(compressedData)) {
     const error = new Error(`Module secret for ${name} is over the 1MB limit`);
     console.error("Uncaught Exception:", error);
-    process.exit(1);
+    throw error;
   } else {
     return {
       apiVersion: "v1",


### PR DESCRIPTION
## Description

remove process.exit in pods and propagate to src/cli

Example:

```bash
> npx pepr build
Registered Pepr Capability "hello-pepr"
Uncaught Exception: Error: Module secret for pepr-static-test is over the 1MB limit
    at getModuleSecret (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2030:19)
    at generateAllYaml (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2159:5)
    at async generateYamlAndWriteToDisk (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2292:18)
    at async Command.<anonymous> (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2392:5)
Error generating YAML: Error: Module secret for pepr-static-test is over the 1MB limit

> npx pepr deploy
Uncaught Exception: Error: Module secret for pepr-static-test is over the 1MB limit
    at getModuleSecret (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2030:19)
    at setupController (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2666:15)
    at deployWebhook (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2642:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Assets.deploy (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:1126:5)
    at async buildAndDeployModule (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2799:5)
    at async Command.<anonymous> (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2822:5)
Error deploying module: Error: Module secret for pepr-static-test is over the 1MB limit
    at getModuleSecret (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2030:19)
    at setupController (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2666:15)
    at deployWebhook (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2642:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Assets.deploy (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:1126:5)
    at async buildAndDeployModule (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2799:5)
    at async Command.<anonymous> (/Users/cmwylie19/pepr/pepr-test-module/node_modules/pepr/dist/cli.js:2822:5)
[12:01:59.483] INFO (15521): Applying module secret
```
## Related Issue

Fixes #1979 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
