### PR TITLE
chore: use default Node behavior during SIGTERM signals

### DIFF
--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -135,7 +135,6 @@ export class Controller {
       Log.info("Received SIGTERM, closing server");
       server.close(() => {
         Log.info("Server closed");
-        process.exit(0);
       });
     });
   };

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -132,9 +132,10 @@ export class Controller {
 
     // Listen for the SIGTERM signal and gracefully close the server
     process.on("SIGTERM", () => {
-      Log.info("Received SIGTERM, closing server");
+      Log.info("Received SIGTERM, closing server.");
       server.close(() => {
-        Log.info("Server closed");
+        Log.info("Server closed.");
+        process.exit(143);
       });
     });
   };


### PR DESCRIPTION
## Description

This PR updates a call to `process.exit(0)` when a `SIGTERM` event is raised. According to the [node docs](https://nodejs.org/api/process.html#processexitcode), `process.exit()` will default to `0`, which corresponds to a 'success' code. From [the docs](https://nodejs.org/api/process.html#signal-events):

> 'SIGTERM' and 'SIGINT' have default handlers on non-Windows platforms that reset the terminal mode before exiting with code 128 + signal number. If one of these signals has a listener installed, its default behavior will be removed (Node.js will no longer exit).

Based upon that, I think we ought to keep the call to `process.exit()` and present a `143` exit code (128 + 15) to reflect how the process actually exited.

## Related Issue

Fixes #1798

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed

## Other Notes

See also, docs on [signal](https://man7.org/linux/man-pages/man7/signal.7.html) for info on various codes.

Testing this one was a bit of a pain, here's the local workflow I used:

```bash
npm run build:image # Build source
npm i pepr@file://../pepr/pepr-0.0.0-development.tgz # Install recent build to module under test
watch -n 1 'ps | grep pepr' # Watch process list for pepr-related processes
npx pepr@latest dev --confirm # Start up dev mode
# Observe pepr-*.js in process list, get the PID from ps or Dev logs 
kill $PID # send a SIGTERM
# Observe logs & PS output
```

That manual process shows that it's insufficient to just set the `process.exitCode` value since the controller will continue to listen and just call cleanup repeatedly. See the following log output from `pepr dev`:

```log
[16:15:19.440] INFO (72188): ✅ Scheduling processed
# kill 72188
[16:15:24.738] INFO (72188): Received SIGTERM, closing server.
[16:15:24.739] INFO (72188): Server closed.
# kill 72188
[16:15:27.789] INFO (72188): Received SIGTERM, closing server.
[16:15:27.790] INFO (72188): Server closed.
# kill 72188
[16:15:29.777] INFO (72188): Received SIGTERM, closing server.
[16:15:29.778] INFO (72188): Server closed.
```