### PR TITLE
chore: expose podAntiAffinity from helm chart

### DIFF
--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -179,6 +179,18 @@ export function admissionDeployTemplate(buildTimestamp: string): string {
               app: {{ .Values.uuid }}
               pepr.dev/controller: admission
           spec:
+            {{- if .Values.admission.antiAffinity }}
+            affinity:
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchExpressions:
+                        - key: pepr.dev/controller
+                          operator: In
+                          values:
+                            - admission
+                    topologyKey: "kubernetes.io/hostname"
+            {{- end }}
             terminationGracePeriodSeconds: {{ .Values.admission.terminationGracePeriodSeconds }}
             priorityClassName: system-node-critical
             serviceAccountName: {{ .Values.uuid }}

--- a/src/lib/assets/yaml/overridesFile.test.ts
+++ b/src/lib/assets/yaml/overridesFile.test.ts
@@ -37,6 +37,7 @@ interface OverridesFileSchema {
   };
   uuid: string;
   admission: {
+    antiAffinity: boolean;
     terminationGracePeriodSeconds: number;
     failurePolicy: string;
     annotations: {
@@ -100,6 +101,7 @@ describe("overridesFile", () => {
     expect(parsedYaml.imagePullSecrets).toEqual(["secret1", "secret2"]);
     expect(parsedYaml.hash).toBe(mockOverrides.hash);
     expect(parsedYaml.admission.image).toBe(mockOverrides.image);
+    expect(parsedYaml.admission.antiAffinity).toBe(false);
     expect(parsedYaml.admission.failurePolicy).toBe("Fail");
     expect(parsedYaml.watcher.image).toBe(mockOverrides.image);
     expect(parsedYaml.secrets.apiPath).toBe(Buffer.from(mockOverrides.apiPath).toString("base64"));

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -37,6 +37,7 @@ export async function overridesFile(
     },
     uuid: name,
     admission: {
+      antiAffinity: false,
       terminationGracePeriodSeconds: 5,
       failurePolicy: config.onError === "reject" ? "Fail" : "Ignore",
       webhookTimeout: config.webhookTimeout,


### PR DESCRIPTION
## Description

Expose `podAntiAffinity` from the helm chart to ensure the Admission Controller pods are scheduled on different nodes for greater availability during node recycling or failures.

```bash
> k get po -n pepr-system -o wide -l pepr.dev/controller=admission
NAME                                READY   STATUS    RESTARTS   AGE   IP          NODE                       NOMINATED NODE   READINESS GATES
pepr-static-test-785995b8d4-5lm5r   1/1     Running   0          99s   10.42.1.3   k3d-multiserver-server-1   <none>           <none>
pepr-static-test-785995b8d4-d86wn   1/1     Running   0          99s   10.42.2.4   k3d-multiserver-server-2   <none>           <none>

> k get deploy -n pepr-system pepr-static-test -ojsonpath="{.spec.template.spec.affinity}" | jq
{
  "podAntiAffinity": {
    "requiredDuringSchedulingIgnoredDuringExecution": [
      {
        "labelSelector": {
          "matchExpressions": [
            {
              "key": "pepr.dev/controller",
              "operator": "In",
              "values": [
                "admission"
              ]
            }
          ]
        },
        "topologyKey": "kubernetes.io/hostname"
      }
    ]
  }
}
```

## Related Issue

Fixes #2078 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
