### PR TITLE
chore: remove indirect alias for string generation

### DIFF
--- a/src/cli/crd/generate.ts
+++ b/src/cli/crd/generate.ts
@@ -4,7 +4,7 @@
 import { Command } from "commander";
 import fs from "fs";
 import path from "path";
-import { stringify as toYAML } from "yaml";
+import { stringify } from "yaml";
 import {
   Project,
   InterfaceDeclaration,
@@ -108,7 +108,7 @@ export function processSourceFile(
   });
 
   const outPath = path.join(outputDir, `${kind.toLowerCase()}.yaml`);
-  fs.writeFileSync(outPath, toYAML(crd), "utf8");
+  fs.writeFileSync(outPath, stringify(crd), "utf8");
   console.log(`✔ Created ${outPath}`);
 }
 


### PR DESCRIPTION
## Description

This PR removes an alias for a function call. [stringify()](https://eemeli.org/yaml/#yaml-stringify) is provided by `yaml` and referring to it as an alias may introduce a level of indirection for anyone who examines this code later.

That said, since it's used to create a YAML string, I can see why aliasing it to `toYaml()` was done. I'm indifferent on merging this PR in ¯\\_(ツ)_/¯

## Related Issue

Fixes #2068 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
