### PR TITLE
fix: remove broken docs link

### DIFF
--- a/docs/100_community/050_pepr-media.md
+++ b/docs/100_community/050_pepr-media.md
@@ -4,7 +4,7 @@
 
 ### Presentations
 
-- [Building Smarter Kubernetes Workflows: Pepr for the modern SRE](https://sreday.com/2025-london-q1/Casey_Wylie_Defense_Unicorns_Building_Smarter_Kubernetes_Workflows_Pepr_for_the_Modern_SRE)
+- Building Smarter Kubernetes Workflows: Pepr for the modern SRE
 
 ## 2024
 


### PR DESCRIPTION
## Description

This hotfix removes a broken link from our docs.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

hotfix

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
