### PR TITLE
chore: update sanitized name

### DIFF
--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -228,16 +228,21 @@ describe("sanitizeResourceName Property-Based Tests", () => {
       fc.property(fc.string(), name => {
         const sanitized = sanitizeResourceName(name);
         if (sanitized.length > 0) {
-          expect(sanitized).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+          expect(sanitized).toMatch(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
         }
         expect(sanitized).toBe(sanitized.toLowerCase());
-        expect(sanitized.length).toBeLessThanOrEqual(250);
+        expect(sanitized.length).toBeLessThanOrEqual(63);
       }),
     );
   });
 });
 
 describe("sanitizeResourceName", () => {
+  it("should allow numbers", () => {
+    const resourceName = "testing-123";
+    const sanitizedResourceName = sanitizeResourceName(resourceName);
+    expect(sanitizedResourceName).toEqual("testing-123");
+  });
   it("should return same resource name if no sanitization needed", () => {
     const resourceName = "test-resource";
     const sanitizedResourceName = sanitizeResourceName(resourceName);
@@ -253,21 +258,21 @@ describe("sanitizeResourceName", () => {
   it("should replace sequences of non-alphanumeric characters with a single -", () => {
     const resourceName = "test-*^%- -!=!resource";
     const sanitizedResourceName = sanitizeResourceName(resourceName);
-    expect(sanitizedResourceName).toEqual("test-resource");
+    expect(sanitizedResourceName).toEqual("test------resource");
   });
 
-  it("should truncate name to 250 characters", () => {
+  it("should truncate name to 253 characters", () => {
     const resourceName =
-      "test-resourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresource";
+      "test-resourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourcemoreletters";
     const sanitizedResourceName = sanitizeResourceName(resourceName);
     expect(sanitizedResourceName).toEqual(
-      "test-resourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresourceresou",
+      "test-resourceresourceresourceresourceresourceresourceresourcere",
     );
   });
 
   it("should remove leading and trailing non-letter characters", () => {
     const resourceName = " 1=-test-resource *2 ";
     const sanitizedResourceName = sanitizeResourceName(resourceName);
-    expect(sanitizedResourceName).toEqual("test-resource");
+    expect(sanitizedResourceName).toEqual("1--test-resource-2");
   });
 });

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -228,6 +228,7 @@ describe("sanitizeResourceName Property-Based Tests", () => {
       fc.property(fc.string(), name => {
         const sanitized = sanitizeResourceName(name);
         if (sanitized.length > 0) {
+          // https://regex101.com/r/3tqGf5/1
           expect(sanitized).toMatch(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
         }
         expect(sanitized).toBe(sanitized.toLowerCase());

--- a/src/sdk/sdk.test.ts
+++ b/src/sdk/sdk.test.ts
@@ -271,7 +271,7 @@ describe("sanitizeResourceName", () => {
     );
   });
 
-  it("should remove leading and trailing non-letter characters", () => {
+  it("should remove leading and trailing non-alphanumeric characters", () => {
     const resourceName = " 1=-test-resource *2 ";
     const sanitizedResourceName = sanitizeResourceName(resourceName);
     expect(sanitizedResourceName).toEqual("1--test-resource-2");

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -118,7 +118,7 @@ export function sanitizeResourceName(name: string): string {
       .toLowerCase()
       // Replace invalid characters (anything not a-z, 0-9, or '-') with '-'
       .replace(/[^a-z0-9-]+/g, "-")
-      // Trim to 63 characters (RFC 1035 Label Names)
+      // Trim to 63 characters (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names)
       .slice(0, 63)
       // Remove leading non-alphanumeric characters
       .replace(/^[^a-z0-9]+/, "")

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -113,13 +113,14 @@ export function getOwnerRefFrom(
 export function sanitizeResourceName(name: string): string {
   return (
     name
-      // The name must be lowercase
       .toLowerCase()
-      // Replace sequences of non-alphanumeric characters with a single '-'
-      .replace(/[^a-z0-9]+/g, "-")
-      // Truncate the name to 250 characters
-      .slice(0, 250)
-      // Remove leading and trailing non-letter characters
-      .replace(/^[^a-z]+|[^a-z]+$/g, "")
+      // Replace invalid characters (anything not a-z, 0-9, or '-') with '-'
+      .replace(/[^a-z0-9-]+/g, "-")
+      // Trim to 63 characters (DNS label max length)
+      .slice(0, 63)
+      // Remove leading non-alphanumeric characters
+      .replace(/^[^a-z0-9]+/, "")
+      // Remove trailing non-alphanumeric characters
+      .replace(/[^a-z0-9]+$/, "")
   );
 }

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -109,6 +109,8 @@ export function getOwnerRefFrom(
  *
  * @param name the name of the resource to sanitize
  * @returns the sanitized resource name
+ *
+ * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
  */
 export function sanitizeResourceName(name: string): string {
   return (
@@ -116,7 +118,7 @@ export function sanitizeResourceName(name: string): string {
       .toLowerCase()
       // Replace invalid characters (anything not a-z, 0-9, or '-') with '-'
       .replace(/[^a-z0-9-]+/g, "-")
-      // Trim to 63 characters (DNS label max length)
+      // Trim to 63 characters (RFC 1035 Label Names)
       .slice(0, 63)
       // Remove leading non-alphanumeric characters
       .replace(/^[^a-z0-9]+/, "")


### PR DESCRIPTION
## Description

The following are all valid names for objects in Kubernetes. The previous implementation of `sanitizeResourceName` was incorrect.

```bash
> k get po 
NAME                 READY   STATUS    RESTARTS   AGE
0--0                 1/1     Running   0          6m15s
1--test-resource-2   1/1     Running   0          16m
1pass                1/1     Running   0          17m
test------resource   1/1     Running   0          14m
```

## Related Issue

Fixes #2073 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
