### PR TITLE
feat: separate config for admission and watch

### DIFF
--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -123,18 +123,21 @@ Below are the available configurations through `package.json`.
 
 ### package.json Configurations Table
 
-| Field            | Description                            | Example Values                  |
-|------------------|----------------------------------------|---------------------------------|
-| `uuid`           | Unique identifier for the module       | `hub-operator`                  |
-| `onError`        | Behavior of the webhook failure policy | `audit`, `ignore`, `reject`     |
-| `webhookTimeout` | Webhook timeout in seconds             | `1` - `30`                      |
-| `customLabels`   | Custom labels for namespaces           | `{namespace: {}}`               |
-| `alwaysIgnore`   | Conditions to always ignore            | `{namespaces: []}`              |
-| `includedFiles`  | For working with WebAssembly           | ["main.wasm", "wasm_exec.js"]   |
-| `env`            | Environment variables for the container| `{LOG_LEVEL: "warn"}`           |
-| `rbac`           | Custom RBAC rules (requires building with `rbacMode: scoped`)            | `{"rbac": [{"apiGroups": ["<apiGroups>"], "resources": ["<resources>"], "verbs": ["<verbs>"]}]}` |
+| Field            | Description                            | Example Values                     |
+|------------------|----------------------------------------|------------------------------------|
+| `uuid`           | Unique identifier for the module       | `hub-operator`                     |
+| `onError`        | Behavior of the webhook failure policy | `audit`, `ignore`, `reject`        |
+| `webhookTimeout` | Webhook timeout in seconds             | `1` - `30`                         |
+| `customLabels`   | Custom labels for namespaces           | `{namespace: {}}`                  |
+| `alwaysIgnore`   | Conditions to always ignore            | `{namespaces: []}`                 |
+| `admission`      | admission namespaces to always ignore  | `{alwaysIgnore: {namespaces: []}}` |
+| `watcher`        | watcher namespaces to always ignor     | `{alwaysIgnore: {namespaces: []}}` |
+| `includedFiles`  | For working with WebAssembly           | ["main.wasm", "wasm_exec.js"]      |
+| `env`            | Environment variables for the container| `{LOG_LEVEL: "warn"}`              |
+| `rbac`           | Custom RBAC rules (requires building with `rbacMode: scoped`)               | `{"rbac": [{"apiGroups": ["<apiGroups>"], "resources": ["<resources>"], "verbs": ["<verbs>"]}]}` |
 | `rbacMode`       | Configures module to build binding RBAC with principal of least privilege | `scoped`, `admin` |
 
+**admission.alwaysIgnore && watcher.alwaysIgnore**: These configurations cannot be used with the global `alwaysIgnore` field. They are used to specify namespaces that should always be ignored by the admission controller or watcher, respectively.
 **uuid**: An identifier for the module in the `pepr-system` namespace. If not provided, a UUID will be generated. It can be any [kubernetes acceptable name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that is under 36 characters.
 
 These tables provide a comprehensive overview of the fields available for customization within the Helm overrides and the `package.json` file. Modify these according to your deployment requirements.

--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -131,7 +131,7 @@ Below are the available configurations through `package.json`.
 | `customLabels`   | Custom labels for namespaces           | `{namespace: {}}`                  |
 | `alwaysIgnore`   | Conditions to always ignore            | `{namespaces: []}`                 |
 | `admission`      | admission namespaces to always ignore  | `{alwaysIgnore: {namespaces: []}}` |
-| `watcher`        | watcher namespaces to always ignor     | `{alwaysIgnore: {namespaces: []}}` |
+| `watch`        | watcher namespaces to always ignor     | `{alwaysIgnore: {namespaces: []}}` |
 | `includedFiles`  | For working with WebAssembly           | ["main.wasm", "wasm_exec.js"]      |
 | `env`            | Environment variables for the container| `{LOG_LEVEL: "warn"}`              |
 | `rbac`           | Custom RBAC rules (requires building with `rbacMode: scoped`)               | `{"rbac": [{"apiGroups": ["<apiGroups>"], "resources": ["<resources>"], "verbs": ["<verbs>"]}]}` |

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -33,6 +33,8 @@ export type peprPackageJSON = {
       webhookTimeout: number;
       customLabels: CustomLabels;
       alwaysIgnore: { namespaces: string[] };
+      admission: { alwaysIgnore: { namespaces: string[] } };
+      watch: { alwaysIgnore: { namespaces: string[] } };
       includedFiles: string[];
       env: object;
       rbac?: PolicyRule[];
@@ -78,6 +80,16 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string): peprPack
       },
       alwaysIgnore: {
         namespaces: [],
+      },
+      admission: {
+        alwaysIgnore: {
+          namespaces: [],
+        },
+      },
+      watch: {
+        alwaysIgnore: {
+          namespaces: [],
+        },
       },
       includedFiles: [],
       env: pgkVerOverride ? testEnv : {},

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -101,7 +101,14 @@ export class Assets {
     this.capabilities = await loadCapabilities(this.path);
     // give error if namespaces are not respected
     for (const capability of this.capabilities) {
+      // until deployment, Pepr does not distinguish between watch and admission
       namespaceComplianceValidator(capability, this.alwaysIgnore?.namespaces);
+      namespaceComplianceValidator(
+        capability,
+        this.config.admission?.alwaysIgnore?.namespaces,
+        false,
+      );
+      namespaceComplianceValidator(capability, this.config.watch?.alwaysIgnore?.namespaces, true);
     }
 
     const code = await fs.readFile(this.path);

--- a/src/lib/assets/ignoredNamespaces.test.ts
+++ b/src/lib/assets/ignoredNamespaces.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+import { it, describe, expect } from "@jest/globals";
+import { resolveIgnoreNamespaces } from "./ignoredNamespaces";
+describe("resolveIgnoreNamespaces", () => {
+  it("should default to empty array if config is empty", () => {
+    const result = resolveIgnoreNamespaces();
+    expect(result).toEqual([]);
+  });
+  it("should return the config ignore namespaces", () => {
+    const result = resolveIgnoreNamespaces(["payments", "istio-system"]);
+    expect(result).toEqual(["payments", "istio-system"]);
+  });
+  describe("when PEPR_ADDITIONAL_IGNORED_NAMESPACES are provided", () => {
+    it("should include additionalIgnoredNamespaces", () => {
+      process.env.PEPR_ADDITIONAL_IGNORED_NAMESPACES = "uds, project-fox";
+      const result = resolveIgnoreNamespaces(["zarf", "lula"]);
+      expect(result).toEqual(["uds", "project-fox", "zarf", "lula"]);
+    });
+  });
+});

--- a/src/lib/assets/ignoredNamespaces.ts
+++ b/src/lib/assets/ignoredNamespaces.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+export function resolveIgnoreNamespaces(ignoredNSConfig: string[] = []): string[] {
+  const ignoredNSEnv = process.env.PEPR_ADDITIONAL_IGNORED_NAMESPACES;
+  if (!ignoredNSEnv) {
+    return ignoredNSConfig;
+  }
+
+  const namespaces = ignoredNSEnv.split(",").map(ns => ns.trim());
+
+  // add alwaysIgnore.namespaces to the list
+  if (ignoredNSConfig) {
+    namespaces.push(...ignoredNSConfig);
+  }
+  return namespaces.filter(ns => ns.length > 0);
+}

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 import { it, describe, expect } from "@jest/globals";
 import {
-  resolveIgnoreNamespaces,
   peprIgnoreNamespaces,
   validateRule,
   generateWebhookRules,
@@ -334,23 +333,5 @@ describe("peprIgnoreNamespaces", () => {
     expect(peprIgnoreNamespaces).toEqual(["kube-system", "pepr-system"]);
     expect(peprIgnoreNamespaces[0]).toEqual("kube-system");
     expect(peprIgnoreNamespaces[1]).toEqual("pepr-system");
-  });
-});
-
-describe("resolveIgnoreNamespaces", () => {
-  it("should default to empty array if config is empty", () => {
-    const result = resolveIgnoreNamespaces();
-    expect(result).toEqual([]);
-  });
-  it("should return the config ignore namespaces", () => {
-    const result = resolveIgnoreNamespaces(["payments", "istio-system"]);
-    expect(result).toEqual(["payments", "istio-system"]);
-  });
-  describe("when PEPR_ADDITIONAL_IGNORED_NAMESPACES are provided", () => {
-    it("should include additionalIgnoredNamespaces", () => {
-      process.env.PEPR_ADDITIONAL_IGNORED_NAMESPACES = "uds, project-fox";
-      const result = resolveIgnoreNamespaces(["zarf", "lula"]);
-      expect(result).toEqual(["uds", "project-fox", "zarf", "lula"]);
-    });
   });
 });

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -84,7 +84,11 @@ export async function webhookConfigGenerator(
   const { name, tls, config, apiPath, host } = assets;
   const ignoreNS = concat(
     peprIgnoreNamespaces,
-    resolveIgnoreNamespaces(config?.alwaysIgnore?.namespaces),
+    resolveIgnoreNamespaces(
+      config?.alwaysIgnore?.namespaces?.length
+        ? config?.alwaysIgnore?.namespaces
+        : config?.admission?.alwaysIgnore?.namespaces,
+    ),
   );
 
   // Add any namespaces to ignore

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -8,7 +8,7 @@ import {
 } from "@kubernetes/client-node";
 import { kind } from "kubernetes-fluent-client";
 import { concat, equals, uniqWith } from "ramda";
-
+import { resolveIgnoreNamespaces } from "./ignoredNamespaces";
 import { Assets } from "./assets";
 import { Event, WebhookType } from "../enums";
 import { Binding } from "../types";
@@ -41,21 +41,6 @@ export const validateRule = (
 
   return ruleObject;
 };
-
-export function resolveIgnoreNamespaces(ignoredNSConfig: string[] = []): string[] {
-  const ignoredNSEnv = process.env.PEPR_ADDITIONAL_IGNORED_NAMESPACES;
-  if (!ignoredNSEnv) {
-    return ignoredNSConfig;
-  }
-
-  const namespaces = ignoredNSEnv.split(",").map(ns => ns.trim());
-
-  // add alwaysIgnore.namespaces to the list
-  if (ignoredNSConfig) {
-    namespaces.push(...ignoredNSConfig);
-  }
-  return namespaces.filter(ns => ns.length > 0);
-}
 
 export async function generateWebhookRules(
   assets: Assets,

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -3,7 +3,7 @@ import { CapabilityExport, ModuleConfig } from "../../types";
 import { dumpYaml } from "@kubernetes/client-node";
 import { clusterRole } from "../rbac";
 import { promises as fs } from "fs";
-import { resolveIgnoreNamespaces } from "../webhooks";
+import { resolveIgnoreNamespaces } from "../ignoredNamespaces";
 export type ChartOverrides = {
   apiPath: string;
   capabilities: CapabilityExport[];

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -3,7 +3,7 @@ import { CapabilityExport, ModuleConfig } from "../../types";
 import { dumpYaml } from "@kubernetes/client-node";
 import { clusterRole } from "../rbac";
 import { promises as fs } from "fs";
-
+import { resolveIgnoreNamespaces } from "../webhooks";
 export type ChartOverrides = {
   apiPath: string;
   capabilities: CapabilityExport[];
@@ -23,7 +23,11 @@ export async function overridesFile(
 
   const overrides = {
     imagePullSecrets,
-    additionalIgnoredNamespaces: [],
+    additionalIgnoredNamespaces: resolveIgnoreNamespaces(
+      config?.alwaysIgnore?.namespaces?.length
+        ? config?.alwaysIgnore?.namespaces
+        : config?.admission?.alwaysIgnore?.namespaces,
+    ),
     rbac: rbacOverrides,
     secrets: {
       apiPath: Buffer.from(apiPath).toString("base64"),

--- a/src/lib/controller/createHooks.ts
+++ b/src/lib/controller/createHooks.ts
@@ -1,5 +1,5 @@
 import { ControllerHooks } from ".";
-import { resolveIgnoreNamespaces } from "../assets/webhooks";
+import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
 import { Capability } from "../core/capability";
 import { isWatchMode, isDevMode } from "../core/envChecks";
 import { setupWatch } from "../processors/watch-processor";

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -60,7 +60,9 @@ export class PeprModule {
     const controllerHooks = createControllerHooks(
       opts,
       capabilities,
-      pepr?.alwaysIgnore?.namespaces,
+      pepr?.alwaysIgnore?.namespaces?.length
+        ? pepr.alwaysIgnore.namespaces
+        : config?.watch?.alwaysIgnore?.namespaces,
     );
 
     this.#controller = new Controller(config, capabilities, controllerHooks);

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -592,6 +592,40 @@ describe("namespaceComplianceValidator", () => {
       `Ignoring Watch Callback: Regex namespace: ${namespaceViolationCapability.bindings[0].filters.regexNamespaces[0]}, is an ignored namespace: miami.`,
     );
   });
+  it("should check watch bindings namespaces and regex namespaces", () => {
+    const nonNamespaceViolationCapability: CapabilityExport = {
+      ...nonNsViolation[0],
+      bindings: nonNsViolation[0].bindings.map(binding => ({
+        ...binding,
+        filters: {
+          ...binding.filters,
+          namespaces: ["something"],
+          regexNamespaces: [new RegExp("^brickell").source],
+        },
+        isWatch: true,
+      })),
+    };
+    expect(() => {
+      namespaceComplianceValidator(nonNamespaceViolationCapability, ["miami"], true);
+    }).toThrow();
+  });
+  it("should check admission binding namespaces and regex namespaces", () => {
+    const nonNamespaceViolationCapability: CapabilityExport = {
+      ...nonNsViolation[0],
+      bindings: nonNsViolation[0].bindings.map(binding => ({
+        ...binding,
+        filters: {
+          ...binding.filters,
+          namespaces: ["something"],
+          regexNamespaces: [new RegExp("^brickell").source],
+        },
+        isWatch: true,
+      })),
+    };
+    expect(() => {
+      namespaceComplianceValidator(nonNamespaceViolationCapability, ["miami"], false);
+    }).toThrow();
+  });
   it("should not throw an error for valid regex ignored namespaces", () => {
     const nonNamespaceViolationCapability: CapabilityExport = {
       ...nonNsViolation[0],

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -141,30 +141,27 @@ export function namespaceComplianceValidator(
   watch?: boolean,
 ): void {
   const { namespaces: capabilityNamespaces, bindings, name } = capability;
-  const bindingNamespaces: string[] = bindings.flatMap((binding: Binding) => {
-    if (watch && binding.isWatch) {
-      return binding.filters.namespaces || [];
-    }
-    if ((!watch && binding.isMutate) || binding.isValidate) {
-      return binding.filters.namespaces || [];
-    }
-    return binding.filters.namespaces || [];
-  });
-  const bindingRegexNamespaces: string[] = bindings.flatMap((binding: Binding) => {
-    if (watch && binding.isWatch) {
-      return binding.filters.regexNamespaces || [];
-    }
-    if ((!watch && binding.isMutate) || binding.isValidate) {
-      return binding.filters.regexNamespaces || [];
-    }
-    return binding.filters.regexNamespaces || [];
-  });
+
+  const shouldInclude = (binding: Binding): boolean => {
+    if (watch === true) return !!binding.isWatch;
+    if (watch === false) return !!binding.isMutate;
+    return true;
+  };
+
+  const bindingNamespaces: string[] = bindings.flatMap(binding =>
+    shouldInclude(binding) ? binding.filters.namespaces || [] : [],
+  );
+
+  const bindingRegexNamespaces: string[] = bindings.flatMap(binding =>
+    shouldInclude(binding) ? binding.filters.regexNamespaces || [] : [],
+  );
 
   const namespaceError = generateWatchNamespaceError(
-    ignoredNamespaces ? ignoredNamespaces : [],
+    ignoredNamespaces ?? [],
     bindingNamespaces,
-    capabilityNamespaces ? capabilityNamespaces : [],
+    capabilityNamespaces ?? [],
   );
+
   if (namespaceError !== "") {
     throw new Error(
       `Error in ${name} capability. A binding violates namespace rules. Please check ignoredNamespaces and capability namespaces: ${namespaceError}`,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -138,14 +138,27 @@ export function generateWatchNamespaceError(
 export function namespaceComplianceValidator(
   capability: CapabilityExport,
   ignoredNamespaces?: string[],
+  watch?: boolean,
 ): void {
   const { namespaces: capabilityNamespaces, bindings, name } = capability;
-  const bindingNamespaces: string[] = bindings.flatMap(
-    (binding: Binding) => binding.filters.namespaces,
-  );
-  const bindingRegexNamespaces: string[] = bindings.flatMap(
-    (binding: Binding) => binding.filters.regexNamespaces || [],
-  );
+  const bindingNamespaces: string[] = bindings.flatMap((binding: Binding) => {
+    if (watch && binding.isWatch) {
+      return binding.filters.namespaces || [];
+    }
+    if ((!watch && binding.isMutate) || binding.isValidate) {
+      return binding.filters.namespaces || [];
+    }
+    return binding.filters.namespaces || [];
+  });
+  const bindingRegexNamespaces: string[] = bindings.flatMap((binding: Binding) => {
+    if (watch && binding.isWatch) {
+      return binding.filters.regexNamespaces || [];
+    }
+    if ((!watch && binding.isMutate) || binding.isValidate) {
+      return binding.filters.regexNamespaces || [];
+    }
+    return binding.filters.regexNamespaces || [];
+  });
 
   const namespaceError = generateWatchNamespaceError(
     ignoredNamespaces ? ignoredNamespaces : [],

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -13,7 +13,7 @@ import { ModuleConfig } from "../types";
 import { PeprMutateRequest } from "../mutate-request";
 import { base64Encode } from "../utils";
 import { OnError } from "../../cli/init/enums";
-import { resolveIgnoreNamespaces } from "../assets/webhooks";
+import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
 import { Operation } from "fast-json-patch";
 import { WebhookType } from "../enums";
 

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -149,7 +149,11 @@ export async function mutateProcessor(
         bind.binding,
         bind.req,
         bind.namespaces,
-        resolveIgnoreNamespaces(bind.config?.alwaysIgnore?.namespaces),
+        resolveIgnoreNamespaces(
+          bind?.config?.alwaysIgnore?.namespaces?.length
+            ? bind.config?.alwaysIgnore?.namespaces
+            : bind.config?.admission?.alwaysIgnore?.namespaces,
+        ),
       );
       if (shouldSkip !== "") {
         Log.debug(shouldSkip);

--- a/src/lib/processors/validate-processor.ts
+++ b/src/lib/processors/validate-processor.ts
@@ -10,7 +10,7 @@ import Log from "../telemetry/logger";
 import { convertFromBase64Map } from "../utils";
 import { PeprValidateRequest } from "../validate-request";
 import { ModuleConfig } from "../types";
-import { resolveIgnoreNamespaces } from "../assets/webhooks";
+import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
 import { MeasureWebhookTimeout } from "../telemetry/webhookTimeouts";
 import { WebhookType } from "../enums";
 import { AdmissionRequest } from "../common-types";

--- a/src/lib/processors/validate-processor.ts
+++ b/src/lib/processors/validate-processor.ts
@@ -95,7 +95,11 @@ export async function validateProcessor(
         binding,
         req,
         namespaces,
-        resolveIgnoreNamespaces(config?.alwaysIgnore?.namespaces),
+        resolveIgnoreNamespaces(
+          config?.alwaysIgnore?.namespaces?.length
+            ? config?.alwaysIgnore?.namespaces
+            : config?.admission?.alwaysIgnore?.namespaces,
+        ),
       );
       if (shouldSkip !== "") {
         Log.debug(shouldSkip);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -292,6 +292,14 @@ export type ModuleConfig = {
   uuid: string;
   /** Configure global exclusions that will never be processed by Pepr. */
   alwaysIgnore: WebhookIgnore;
+  /** admission specific ignore */
+  admission?: {
+    alwaysIgnore: WebhookIgnore;
+  };
+  /** watch specific ignore */
+  watch?: {
+    alwaysIgnore: WebhookIgnore;
+  };
 } & Partial<ModuleConfigOptions>;
 
 export type PackageJSON = {

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -15,6 +15,16 @@
     "alwaysIgnore": {
       "namespaces": []
     },
+    "admission": {
+      "alwaysIgnore": {
+        "namespaces": []
+      }
+    },
+    "watcher": {
+      "alwaysIgnore": {
+        "namespaces": []
+      }
+    },
     "includedFiles": []
   }
 }


### PR DESCRIPTION
## Description

Due to circle dependencies around AdmissionWebhooks with failurePolicy set to fail and running on a single node, we need to have a way to ignore the `istio-system` namespace for Admission but still be able to react to events through the informer.

This PR adds new configs specifically for admission and watch, but if using admission or watch, then the global config cannot be used since it will override admission and watch. 

Needs:
- [x] Docs 
- [x] [PEXEX Test](https://github.com/defenseunicorns/pepr-excellent-examples/pull/283)
- [x] Updated unit test for `namespaceComplianceValidator`
- [x] Account for the fact that Finalize bindings may have watch and mutate to true
- [x] Set admission.alwaysIgnore namespaces into `namespaceSelector` on `*WebhookConfiguration`

## Related Issue

Fixes #2077 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
