### PR TITLE
fix: add missing helm values/templates

### DIFF
--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -185,6 +185,7 @@ export function admissionDeployTemplate(buildTimestamp: string): string {
               app: {{ .Values.uuid }}
               pepr.dev/controller: admission
           spec:
+            {{- if or .Values.admission.antiAffinity .Values.admission.affinity }}
             affinity:
             {{- if .Values.admission.antiAffinity }}
               podAntiAffinity:
@@ -196,8 +197,10 @@ export function admissionDeployTemplate(buildTimestamp: string): string {
                           values:
                             - admission
                     topologyKey: "kubernetes.io/hostname"
-            {{- else }}
+            {{- end }}
+            {{- if .Values.admission.affinity }}
               {{- toYaml .Values.admission.affinity | nindent 8 }}
+            {{- end }}
             {{- end }}
             nodeSelector:
               {{- toYaml .Values.admission.nodeSelector | nindent 8 }}

--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -94,7 +94,13 @@ export function watcherDeployTemplate(buildTimestamp: string): string {
             terminationGracePeriodSeconds: {{ .Values.watcher.terminationGracePeriodSeconds }}
             serviceAccountName: {{ .Values.uuid }}
             securityContext:
-              {{- toYaml .Values.admission.securityContext | nindent 8 }}
+              {{- toYaml .Values.watcher.securityContext | nindent 8 }}
+            nodeSelector:
+              {{- toYaml .Values.watcher.nodeSelector | nindent 8 }}
+            tolerations:
+              {{- toYaml .Values.watcher.tolerations | nindent 8 }}
+            affinity:
+              {{- toYaml .Values.watcher.affinity | nindent 8 }}
             containers:
               - name: watcher
                 image: {{ .Values.watcher.image }}
@@ -179,8 +185,8 @@ export function admissionDeployTemplate(buildTimestamp: string): string {
               app: {{ .Values.uuid }}
               pepr.dev/controller: admission
           spec:
-            {{- if .Values.admission.antiAffinity }}
             affinity:
+            {{- if .Values.admission.antiAffinity }}
               podAntiAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   - labelSelector:
@@ -190,7 +196,13 @@ export function admissionDeployTemplate(buildTimestamp: string): string {
                           values:
                             - admission
                     topologyKey: "kubernetes.io/hostname"
+            {{- else }}
+              {{- toYaml .Values.admission.affinity | nindent 8 }}
             {{- end }}
+            nodeSelector:
+              {{- toYaml .Values.admission.nodeSelector | nindent 8 }}
+            tolerations:
+              {{- toYaml .Values.admission.tolerations | nindent 8 }}
             terminationGracePeriodSeconds: {{ .Values.admission.terminationGracePeriodSeconds }}
             priorityClassName: system-node-critical
             serviceAccountName: {{ .Values.uuid }}


### PR DESCRIPTION
## Description

Adds missing templating for helm values, also fixes one template in the watcher that pointed to the wrong admission value.

## Related Issue

Fixes https://github.com/defenseunicorns/pepr/issues/2100

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
