### PR TITLE
chore: validate namespaces on deploy

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -12,7 +12,7 @@ import { namespaceDeploymentsReady } from "../lib/deploymentChecks";
 import { sanitizeName } from "./init/utils";
 import { validateCapabilityNames } from "../lib/helpers";
 import { namespaceComplianceValidator } from "../lib/helpers";
-
+import { loadCapabilities } from "../lib/assets/loader";
 export interface ImagePullSecretDetails {
   pullSecret?: string;
   dockerServer?: string;
@@ -107,8 +107,8 @@ async function buildAndDeployModule(image: string, force: boolean): Promise<void
     [],
   );
   webhook.image = image ?? webhook.image;
-
-  for (const capability of webhook.capabilities) {
+  const capabilities = await loadCapabilities(webhook.path);
+  for (const capability of capabilities) {
     namespaceComplianceValidator(capability, webhook.alwaysIgnore?.namespaces);
     namespaceComplianceValidator(
       capability,


### PR DESCRIPTION
## Description

Validates namespaces on `npx pepr deploy` similar to how namespaces are validated in `npx pepr build`. This makes the commands more consistent with checks.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #2103 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
