### PR TITLE
chore: rbac config requires v1PolicyRule[]

### DIFF
--- a/docs/030_user-guide/120_customization.md
+++ b/docs/030_user-guide/120_customization.md
@@ -134,7 +134,7 @@ Below are the available configurations through `package.json`.
 | `watch`        | watcher namespaces to always ignor     | `{alwaysIgnore: {namespaces: []}}` |
 | `includedFiles`  | For working with WebAssembly           | ["main.wasm", "wasm_exec.js"]      |
 | `env`            | Environment variables for the container| `{LOG_LEVEL: "warn"}`              |
-| `rbac`           | Custom RBAC rules (requires building with `rbacMode: scoped`)               | `{"rbac": [{"apiGroups": ["<apiGroups>"], "resources": ["<resources>"], "verbs": ["<verbs>"]}]}` |
+| `rbac`           | Custom RBAC rules (requires building with `rbacMode: scoped`)               | `[{"apiGroups": ["<apiGroups>"], "resources": ["<resources>"], "verbs": ["<verbs>"]}]` |
 | `rbacMode`       | Configures module to build binding RBAC with principal of least privilege | `scoped`, `admin` |
 
 **admission.alwaysIgnore && watcher.alwaysIgnore**: These configurations cannot be used with the global `alwaysIgnore` field. They are used to specify namespaces that should always be ignored by the admission controller or watcher, respectively.


### PR DESCRIPTION
## Description

When I was configuring the `minio-manager` for prod, configuring RBAC for least privileged I got a build error when following the docs. That is when I realized the docs do not show the `v1PolicyRule[]`. It had an object starting with `{"rbac": ...}`, which results in an error.

```bash
 > npx pepr@latest build 
Error building module: Error: Command failed: /Users/cmwylie19/minio-manager/node_modules/.bin/tsc --project /Users/cmwylie19/minio-manager/tsconfig.json --outdir dist
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:890:11)
    at execFileSync (node:child_process:926:15)
    at buildModule (/Users/cmwylie19/minio-manager/node_modules/pepr/dist/cli.js:9746:44)
    at async Command.<anonymous> (/Users/cmwylie19/minio-manager/node_modules/pepr/dist/cli.js:9654:31) {
  status: 1,
  signal: null,
  output: [
    null,
    <Buffer 70 65 70 72 2e 74 73 28 35 2c 31 36 29 3a 20 65 72 72 6f 72 20 54 53 32 33 34 35 3a 20 41 72 67 75 6d 65 6e 74 20 6f 66 20 74 79 70 65 20 27 7b 20 6e ... 1342 more bytes>,
    <Buffer >
  ],
  pid: 94369,
  stdout: <Buffer 70 65 70 72 2e 74 73 28 35 2c 31 36 29 3a 20 65 72 72 6f 72 20 54 53 32 33 34 35 3a 20 41 72 67 75 6d 65 6e 74 20 6f 66 20 74 79 70 65 20 27 7b 20 6e ... 1342 more bytes>,
  stderr: <Buffer >
}
pepr.ts(5,16): error TS2345: Argument of type '{ name: string; version: string; description: string; keywords: string[]; engines: { node: string; }; pepr: { uuid: string; onError: string; webhookTimeout: number; customLabels: { namespace: { "pepr.dev": string; }; }; ... 4 more ...; env: { ...; }; }; scripts: { ...; }; dependencies: { ...; }; devDependencies: { ....' is not assignable to parameter of type 'PackageJSON'.
  Types of property 'pepr' are incompatible.
    Type '{ uuid: string; onError: string; webhookTimeout: number; customLabels: { namespace: { "pepr.dev": string; }; }; rbac: { rbac: { apiGroups: string[]; resources: string[]; verbs: string[]; }[]; }; rbacMode: string; alwaysIgnore: { ...; }; includedFiles: any[]; env: { ...; }; }' is not assignable to type 'ModuleConfig'.
      Type '{ uuid: string; onError: string; webhookTimeout: number; customLabels: { namespace: { "pepr.dev": string; }; }; rbac: { rbac: { apiGroups: string[]; resources: string[]; verbs: string[]; }[]; }; rbacMode: string; alwaysIgnore: { ...; }; includedFiles: any[]; env: { ...; }; }' is not assignable to type 'Partial<ModuleConfigOptions>'.
        Types of property 'rbac' are incompatible.
          Type '{ rbac: { apiGroups: string[]; resources: string[]; verbs: string[]; }[]; }' is missing the following properties from type 'V1PolicyRule[]': length, pop, push, concat, and 29 more.


/Users/cmwylie19/minio-manager/node_modules/pepr/dist/cli.js:9655
    const { cfg, path: path3 } = buildModuleResult;
            ^

TypeError: Cannot destructure property 'cfg' of 'buildModuleResult' as it is undefined.
    at Command.<anonymous> (/Users/cmwylie19/minio-manager/node_modules/pepr/dist/cli.js:9655:13)

Node.js v22.9.0
```


Here is an example of using [`custom-rbac`](https://github.com/defenseunicorns/pepr-excellent-examples/blob/ddcd973268559a8aa49542358a988ef36358948d/hello-pepr-custom-rbac/package.custom.json#L25)

## Related Issue

Fixes #2118 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
