### PR TITLE
chore: update path in CI to avoid unnecessary nesting

### DIFF
--- a/.github/actions/ironbank-setup/action.yaml
+++ b/.github/actions/ironbank-setup/action.yaml
@@ -39,7 +39,7 @@ runs:
 
     - name: Set Pepr Environment Variable
       shell: bash
-      run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
+      run: echo "PEPR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
 
     - name: Clone Iron Bank Repo & Transfer Dockerfiles
       shell: bash

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -34,7 +34,7 @@ jobs:
           path: pepr
 
       - name: "set env: PEPR"
-        run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
+        run: echo "PEPR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
 
       - name: setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
## Description

Our CI jobs run in a needlessly-nested context ending in `pepr/pepr/`. This hotfix PR removes that in support of #1911 

## Related Issue

Relates to #1911 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
