### PR TITLE
chore: sync remove dom lib

### DIFF
--- a/src/build-artifact.test.ts
+++ b/src/build-artifact.test.ts
@@ -47,12 +47,17 @@ describe("Published package does not include unintended files", () => {
   });
 
   it("should warn the developer when lots of files are added to the build", async () => {
+    interface NpmMetadata {
+      dist: {
+        fileCount: number;
+      };
+    }
     async function getPublishedFileCount(pkg: string): Promise<number> {
       const response = await fetch(`https://registry.npmjs.org/${pkg}/latest`);
       if (!response.ok) {
         throw new Error(`Failed to fetch metadata for package "${pkg}"`);
       }
-      const metadata = await response.json();
+      const metadata: NpmMetadata = (await response.json()) as NpmMetadata;
       return metadata.dist.fileCount;
     }
 

--- a/src/lib/processors/validate-processor.ts
+++ b/src/lib/processors/validate-processor.ts
@@ -37,7 +37,9 @@ export async function processRequest(
     if (callbackResp.statusCode || callbackResp.statusMessage) {
       valResp.status = {
         code: callbackResp.statusCode || 400,
-        message: callbackResp.statusMessage || `Validation failed for ${name}`,
+        message:
+          callbackResp.statusMessage ||
+          `Validation failed for ${peprValidateRequest.Request.kind.kind.toLowerCase()}/${peprValidateRequest.Request.name}${peprValidateRequest.Request.namespace ? ` in ${peprValidateRequest.Request.namespace} namespace.` : ""}`,
       };
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "dist",


### PR DESCRIPTION
## Description

DOM was introduced to our tsconfig as some point which was a mistake. Our docs indicate that the _only_ reason to use DOM would be to bring in the web assembly types into a Pepr module. This PR removes DOM and updates some error messages that were not correct because they were looking for variables in the DOM types. This should unblock #1803

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
