### PR TITLE
chore: `npx pepr dev` integration test

### DIFF
--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -93,6 +93,9 @@ jobs:
         with:
           node-version: 22
           cache: "npm"
+      - name: "Install K3d"
+        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        shell: bash
       - name: Setup Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:

--- a/integration/cli/dev.dev-test.test.ts
+++ b/integration/cli/dev.dev-test.test.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { beforeAll, afterAll, describe, expect, it } from "@jest/globals";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { Workdir } from "../helpers/workdir";
+import * as time from "../helpers/time";
+import * as pepr from "../helpers/pepr";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { fetch, K8s, kind } from "kubernetes-fluent-client";
+import { RequestInit, Agent } from "undici";
+
+const FILE = path.basename(__filename);
+const HERE = __dirname;
+
+let expectedLines = [
+  "Establishing connection to Kubernetes",
+  "Capability hello-pepr registered",
+  "Mutate Action configured for CREATE",
+  "Validate Action configured for CREATE",
+  "Server listening on port 3000",
+  "Controller startup complete",
+];
+let success = false;
+describe("dev", () => {
+  const workdir = new Workdir(`${FILE}`, `${HERE}/../testroot/cli`);
+  beforeAll(async () => {
+    await workdir.recreate();
+  }, time.toMs("1m"));
+
+  describe("runs a module in dev mode", () => {
+    const id = FILE.split(".").at(1);
+    const testModule = `${workdir.path()}/${id}`;
+    let cmd: ChildProcessWithoutNullStreams;
+
+    beforeAll(async () => {
+      await pepr.cli(workdir.path(), {
+        cmd: `k3d cluster delete pepr-dev-cli && k3d cluster create pepr-dev-cli --k3s-arg '--debug@server:0' --wait && kubectl rollout status deployment -n kube-system`,
+      });
+      await fs.rm(testModule, { recursive: true, force: true });
+      const argz = [
+        `--name ${id}`,
+        `--description ${id}`,
+        `--errorBehavior reject`,
+        `--uuid dev-test`,
+        "--confirm",
+        "--skip-post-init",
+      ].join(" ");
+      await pepr.cli(workdir.path(), { cmd: `pepr init ${argz}` });
+      await pepr.tgzifyModule(testModule);
+      await pepr.cli(testModule, { cmd: `npm install` });
+    }, time.toMs("2m"));
+
+    it("should start the pepr dev server", async () => {
+      cmd = spawn("npx", ["pepr", "dev", "--confirm"], { cwd: testModule, stdio: "pipe" });
+
+      // This command should not exit on its own
+      cmd.on("close", code => {
+        if (!success) {
+          throw new Error(`Command exited with code ${code}`);
+        }
+      });
+
+      // Log stderr
+      cmd.stderr.on("data", data => {
+        if (!success) {
+          console.error(`stderr: ${data}`);
+        }
+      });
+
+      // Reject on error
+      cmd.on("error", error => {
+        if (!success) {
+          throw error;
+        }
+      });
+    }, 180000);
+    it(
+      "should be properly configured by the module ",
+      done => {
+        K8s(kind.Namespace).Apply({ metadata: { name: "pepr-demo-2" } });
+        K8s(kind.ConfigMap).Apply({
+          metadata: {
+            name: "example-1",
+            namespace: "pepr-demo-2",
+          },
+          data: {
+            key: "ex-1-val",
+          },
+        });
+        cmd.stdout.on("data", (data: Buffer) => {
+          if (success) {
+            return;
+          }
+
+          // Convert buffer to string
+          const strData = data.toString();
+
+          // Check if any expected lines are found
+          expectedLines = expectedLines.filter(expectedLine => {
+            // Check if the expected line is found in the output, ignoring whitespace
+            return !strData.replace(/\s+/g, " ").includes(expectedLine);
+          });
+
+          // If all expected lines are found, resolve the promise
+          if (expectedLines.length > 0) {
+            console.log(`still waiting on ${expectedLines.length} lines...`);
+          } else {
+            console.log(`FINISHED!!!!!!`);
+            // Abort all further processing
+            success = true;
+            // Finish the test
+            done();
+          }
+        });
+      },
+      60000 * 10,
+    );
+    it("should be ready to accept requests", async () => {
+      await waitForServer();
+    });
+    it("should protect the mutate and validate endpoints with an API path", async () => {
+      await validateAPIPath();
+    });
+    it("should expose prometheus metrics", async () => {
+      const metrics = await validateMetrics();
+      expect(metrics).toMatch("pepr_validate");
+      expect(metrics).toMatch("pepr_mutate");
+      expect(metrics).toMatch("pepr_errors");
+      expect(metrics).toMatch("pepr_alerts");
+    });
+
+    afterAll(async () => {
+      // Close or destroy the streams
+      if (cmd.stdin) {
+        cmd.stdin.end();
+      }
+      if (cmd.stdout) {
+        cmd.stdout.destroy();
+      }
+      if (cmd.stderr) {
+        cmd.stderr.destroy();
+      }
+
+      // Remove the event listeners
+      cmd.removeAllListeners("close");
+      cmd.removeAllListeners("error");
+
+      // Kill the process
+      cmd.kill(9);
+      await pepr.cli(workdir.path(), { cmd: `k3d cluster delete pepr-dev-cli` });
+    }, 60000);
+  });
+});
+
+const fetchBaseUrl = "https://localhost:3000";
+const fetchOpts: RequestInit = {
+  method: "GET",
+  headers: {
+    "Content-Type": "application/json; charset=UTF-8",
+  },
+  dispatcher: new Agent({
+    // disable keep-alive https://github.com/nodejs/undici/issues/2522#issuecomment-1859213319
+    pipelining: 0,
+    connect: {
+      rejectUnauthorized: false,
+    },
+  }),
+};
+
+// Wait for the server to start and report healthy
+async function waitForServer() {
+  const resp = await fetch(`${fetchBaseUrl}/healthz`, fetchOpts);
+  if (!resp.ok) {
+    await sleep(2);
+    return waitForServer();
+  }
+}
+
+async function validateAPIPath() {
+  const mutateUrl = `${fetchBaseUrl}/mutate/`;
+  const validateUrl = `${fetchBaseUrl}/validate/`;
+  const fetchPushOpts = { ...fetchOpts, method: "POST" };
+
+  // Test for empty api path
+  const emptyMutatePath = await fetch(mutateUrl, fetchPushOpts);
+  expect(emptyMutatePath.status).toBe(404);
+  const emptyValidatePath = await fetch(validateUrl, fetchPushOpts);
+  expect(emptyValidatePath.status).toBe(404);
+
+  // Test api path validation
+  const evilMutatePath = await fetch(`${mutateUrl}evil-path`, fetchPushOpts);
+  expect(evilMutatePath.status).toBe(401);
+  const evilValidatePath = await fetch(`${validateUrl}evil-path`, fetchPushOpts);
+  expect(evilValidatePath.status).toBe(401);
+}
+
+async function validateMetrics() {
+  const metricsOk = await fetch<string>(`${fetchBaseUrl}/metrics`, fetchOpts);
+  expect(metricsOk.ok).toBe(true);
+
+  return metricsOk.data;
+}
+
+function sleep(seconds: number) {
+  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+}

--- a/integration/cli/dev.dev-test.test.ts
+++ b/integration/cli/dev.dev-test.test.ts
@@ -13,7 +13,8 @@ import { RequestInit, Agent } from "undici";
 
 const FILE = path.basename(__filename);
 const HERE = __dirname;
-jest.setTimeout(1000 * 60 * 5);
+const five_mins = 1000 * 60 * 5;
+jest.setTimeout(five_mins);
 let expectedLines = [
   "Establishing connection to Kubernetes",
   "Capability hello-pepr registered",


### PR DESCRIPTION
## Description

Adds integration tests for `npx pepr dev` in support of refactoring/getting rid of the journey tests

## Related Issue

Fixes #2057 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
