### PR TITLE
chore: add warning message for `npx pepr update` for eslint v8 use

### DIFF
--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -63,7 +63,7 @@ export default function (program: RootCmd): void {
             packageLockContent.match(/"eslint":\s*"[~^]?8\.[0-9]+\.[0-9]+"/)
           ) {
             console.warn(
-              "⚠️  Warning: Your project is using ESLint v8. ESLint will be upgraded to v9 in a future release.",
+              "\nWarning: This Pepr module uses ESLint v8. Pepr will be upgraded to use v9 in a future release.\nSee eslint@9.0.0 release notes for more details: https://eslint.org/blog/2024/04/eslint-v9.0.0-released/",
             );
           }
         }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -41,6 +41,33 @@ export default function (program: RootCmd): void {
       console.log("Updating the Pepr module...");
 
       try {
+        // Check if eslint v8 is a project dependency and warn about future upgrade
+        let packageLockContent = "";
+        let foundPackageLock = false;
+
+        try {
+          // Try to find package-lock.json in the current directory
+          if (fs.existsSync("./package-lock.json")) {
+            packageLockContent = fs.readFileSync("./package-lock.json", "utf-8");
+            foundPackageLock = true;
+          }
+        } catch {
+          // Ignore errors and continue with installation
+        }
+
+        // If we found the package-lock.json and could read it, check for eslint v8
+        if (foundPackageLock && packageLockContent) {
+          // Look for eslint version 8.x.x pattern in the file content
+          if (
+            packageLockContent.indexOf('"eslint":') >= 0 &&
+            packageLockContent.match(/"eslint":\s*"[~^]?8\.[0-9]+\.[0-9]+"/)
+          ) {
+            console.warn(
+              "⚠️  Warning: Your project is using ESLint v8. ESLint will be upgraded to v9 in a future release.",
+            );
+          }
+        }
+
         // Update Pepr for the module
         execSync("npm install pepr@latest", {
           stdio: "inherit",


### PR DESCRIPTION
## Description

This PR relates to #2121 and adds a warning to users in advance of a breaking change. There are some quirks to how `integration/` works that complicates writing a validation test for this at the moment.

You can see this locally by running:

```
rm -rf asdf && 
npm run build && 
npx -y pepr@file://./pepr-0.0.0-development.tgz init \
  --name asdf \
  --description asdf \
  --errorBehavior reject \
  --uuid asdf \
  --confirm
```

Next, execute:

```
cd asdf/
npx -y pepr@file://../pepr-0.0.0-development.tgz update --skip-template-update
```

Output will look something like this:
```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated @humanwhocodes/config-array@0.11.14: Use @eslint/config-array instead
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated eslint@8.57.0: This version is no longer supported. Please see https://eslint.org/version-support for other options.
Updating the Pepr module...

Warning: This Pepr module uses ESLint v8. Pepr will be upgraded to use v9 in a future release.
See eslint@9.0.0 release notes for more details: https://eslint.org/blog/2024/04/eslint-v9.0.0-released/

removed 4 packages, changed 3 packages, and audited 402 packages in 3s

74 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
✅ Module updated successfully
```

## Related Issue

Relates to #2121

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
