### PR TITLE
chore: node-fips

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -35,7 +35,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.15.0slim@sha256:80f43f7a53733029448de10ab810a1669e1feeb3fa5f34eb64a7d75e476afd45
+FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.15.0-slim@sha256:80f43f7a53733029448de10ab810a1669e1feeb3fa5f34eb64a7d75e476afd45
 
 WORKDIR /app
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-FROM cgr.dev/du-uds-defenseunicorns/node:22.15.0@sha256:f1b59864d19685d36762ef60507aef3d61aee5f782559107b975ba7b85ac910f AS build
+FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.15.0@sha256:886cb29e11b35f89448cd859371cc321d96fd773978e629ce8ed7f6333df8cc8 AS build
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM cgr.dev/du-uds-defenseunicorns/node:22.15.0-slim@sha256:267be25d87fac37092967e784952043aeb576bcf9a2733bc61383f960a927edf
+FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.15.0slim@sha256:80f43f7a53733029448de10ab810a1669e1feeb3fa5f34eb64a7d75e476afd45
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

We have to update our chainguard images by hand since we do not get dependabot updates from the chainguard registry. After looking at the chainguard registry, I noticed that there is now a fip build of the nodejs image.

After chatting with @chance & @mjnagel they suggested that this should be the default image for the unicorn build.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
