### PR TITLE
chore: format integration test

### DIFF
--- a/integration/cli/format.format.test.ts
+++ b/integration/cli/format.format.test.ts
@@ -41,7 +41,7 @@ describe("build", () => {
       formatOutput = await pepr.cli(testModule, { cmd: `pepr format` });
     }, time.toMs("3m"));
 
-    it("should execute 'pepr form,at'", () => {
+    it("should execute 'pepr format'", () => {
       expect(formatOutput.exitcode).toBe(0);
       expect(formatOutput.stderr.join("").trim()).toContain("");
       expect(formatOutput.stdout.join("").trim()).toContain("✅ Module formatted");

--- a/integration/cli/format.format.test.ts
+++ b/integration/cli/format.format.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { Workdir } from "../helpers/workdir";
+import * as time from "../helpers/time";
+import * as pepr from "../helpers/pepr";
+import { Result } from "../helpers/cmd";
+
+const FILE = path.basename(__filename);
+const HERE = __dirname;
+
+describe("build", () => {
+  const workdir = new Workdir(`${FILE}`, `${HERE}/../testroot/cli`);
+
+  beforeAll(async () => {
+    await workdir.recreate();
+  }, time.toMs("60s"));
+
+  describe("when building a module", () => {
+    const id = FILE.split(".").at(1);
+    const testModule = `${workdir.path()}/${id}`;
+    let formatOutput: Result;
+
+    beforeAll(async () => {
+      await fs.rm(testModule, { recursive: true, force: true });
+      const initArgs = [
+        `--name ${id}`,
+        `--description ${id}`,
+        `--errorBehavior reject`,
+        `--uuid format`,
+        "--confirm",
+        "--skip-post-init",
+      ].join(" ");
+      await pepr.cli(workdir.path(), { cmd: `pepr init ${initArgs}` });
+      await pepr.tgzifyModule(testModule);
+      await pepr.cli(testModule, { cmd: `npm install` });
+
+      formatOutput = await pepr.cli(testModule, { cmd: `pepr format` });
+    }, time.toMs("3m"));
+
+    it("should execute 'pepr form,at'", () => {
+      expect(formatOutput.exitcode).toBe(0);
+      expect(formatOutput.stderr.join("").trim()).toContain("");
+      expect(formatOutput.stdout.join("").trim()).toContain("✅ Module formatted");
+    });
+  });
+});


### PR DESCRIPTION
## Description


Adds an integration test for `npx pepr format`

## Related Issue

Fixes #2112 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
