### PR TITLE
chore: fixes the upgrade tests to pass ci

### DIFF
--- a/journey/pepr-upgrade.test.ts
+++ b/journey/pepr-upgrade.test.ts
@@ -29,12 +29,6 @@ export function peprUpgrade() {
       // Install pepr@nightly
       execSync("npm i pepr@nightly", { cwd: "pepr-upgrade-test", stdio: "inherit" });
 
-      // // Update manifests of pepr@latest
-      // execSync("node ./node_modules/pepr/dist/cli.js update --skip-template-update", {
-      //   cwd: "pepr-upgrade-test",
-      //   stdio: "inherit",
-      // });
-
       // Generate manifests with pepr@latest
       execSync("node ./node_modules/pepr/dist/cli.js build", {
         cwd: "pepr-upgrade-test",

--- a/journey/pepr-upgrade.test.ts
+++ b/journey/pepr-upgrade.test.ts
@@ -26,14 +26,14 @@ export function peprUpgrade() {
 
   it("should prepare, build, and deploy hello-pepr with pepr@latest", async () => {
     try {
-      // Install pepr@latest
+      // Install pepr@nightly
       execSync("npm i pepr@nightly", { cwd: "pepr-upgrade-test", stdio: "inherit" });
 
-      // Update manifests of pepr@latest
-      execSync("node ./node_modules/pepr/dist/cli.js update --skip-template-update", {
-        cwd: "pepr-upgrade-test",
-        stdio: "inherit",
-      });
+      // // Update manifests of pepr@latest
+      // execSync("node ./node_modules/pepr/dist/cli.js update --skip-template-update", {
+      //   cwd: "pepr-upgrade-test",
+      //   stdio: "inherit",
+      // });
 
       // Generate manifests with pepr@latest
       execSync("node ./node_modules/pepr/dist/cli.js build", {

--- a/journey/pepr-upgrade.test.ts
+++ b/journey/pepr-upgrade.test.ts
@@ -27,7 +27,7 @@ export function peprUpgrade() {
   it("should prepare, build, and deploy hello-pepr with pepr@latest", async () => {
     try {
       // Install pepr@latest
-      execSync("npm i pepr@latest", { cwd: "pepr-upgrade-test", stdio: "inherit" });
+      execSync("npm i pepr@nightly", { cwd: "pepr-upgrade-test", stdio: "inherit" });
 
       // Update manifests of pepr@latest
       execSync("node ./node_modules/pepr/dist/cli.js update --skip-template-update", {


### PR DESCRIPTION
## Description

Fixes the upgrade test in order to pass CI. The upgrade builds a Pepr module with latest, deploys it, then rebuilds with the pepr release candidate. In the v0.51.0 there will be a migration path that must occur for this behavior to happen due to a breaking change in ESLint. The upgrade path is documented [here](https://github.com/defenseunicorns/pepr-excellent-examples/pull/298). For now, we are using `nightly` in place of latest in order to test the upgrade path in the same manner as before. This change will need to be updated after the v0.51.0 release 

## Related Issue

Fixes #2152
<!-- or -->
Relates to #2153

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
