### PR TITLE
chore: integration test for scoped rbac mode

### DIFF
--- a/integration/cli/build.rbacmode.test.ts
+++ b/integration/cli/build.rbacmode.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import * as f from "node:fs";
+import { execSync } from "node:child_process";
+import { Workdir } from "../helpers/workdir";
+import * as time from "../helpers/time";
+import * as pepr from "../helpers/pepr";
+import * as resource from "../helpers/resource";
+import { kind } from "kubernetes-fluent-client";
+import YAML from "yaml";
+
+const FILE = path.basename(__filename);
+const HERE = __dirname;
+
+describe("build rbacMode=scoped", () => {
+  const workdir = new Workdir(`${FILE}`, `${HERE}/../testroot/cli`);
+
+  beforeAll(async () => {
+    await workdir.recreate();
+  }, time.toMs("60s"));
+
+  describe("builds a module", () => {
+    const id = FILE.split(".").at(1);
+    const testModule = `${workdir.path()}/${id}`;
+
+    beforeAll(async () => {
+      await fs.rm(testModule, { recursive: true, force: true });
+      const argz = [
+        `--name ${id}`,
+        `--description ${id}`,
+        `--errorBehavior reject`,
+        `--uuid ${id}`,
+        "--confirm",
+        "--skip-post-init",
+      ].join(" ");
+      await pepr.cli(workdir.path(), { cmd: `pepr init ${argz}` });
+      await pepr.tgzifyModule(testModule);
+      await pepr.cli(testModule, { cmd: `npm install` });
+    }, time.toMs("2m"));
+
+    describe("scoped rbac cluster role", () => {
+      const outputDir = `${testModule}/dist`;
+
+      let packageJson;
+      let uuid: string;
+
+      beforeAll(async () => {
+        const build = await pepr.cli(testModule, { cmd: `pepr build --rbac-mode scoped` });
+
+        expect(build.exitcode).toBe(0);
+        expect(build.stderr.join("").trim()).toBe("");
+        expect(build.stdout.join("").trim()).toContain("K8s resource for the module saved");
+
+        packageJson = await resource.fromFile(`${testModule}/package.json`);
+        uuid = packageJson.pepr.uuid;
+      }, time.toMs("1m"));
+
+      it("creates a scoped rbac role to the kubernetes manifests", async () => {
+        const clusterRole = await resource.getK8sObjectByKindAndName<kind.ClusterRole>(`${outputDir}/pepr-module-${uuid}.yaml`, "ClusterRole", `pepr-${uuid}`);
+        expect(clusterRole).toBeDefined();
+        expect(clusterRole!.rules).toEqual([
+          { apiGroups: ["pepr.dev"], resources: ["peprstores"], verbs: ["create", "get", "patch", "watch"] },
+          { apiGroups: ["apiextensions.k8s.io"], resources: ["customresourcedefinitions"], verbs: ["patch", "create"] },
+          { apiGroups: [""], resources: ["namespaces"], verbs: ["watch"] },
+          { apiGroups: [""], resources: ["configmaps"], verbs: ["watch"] },
+        ]);
+      });
+
+      it("creates a scoped rbac clusterrole for the helm chart", async () => {
+        execSync(`helm template .  > ${outputDir}/helm-template.yaml`, {
+          cwd: `${outputDir}/${uuid}-chart`,
+        });
+        const clusterRole = await resource.getK8sObjectByKindAndName<kind.ClusterRole>(`${outputDir}/helm-template.yaml`, "ClusterRole", `pepr-${uuid}`);
+        expect(clusterRole).toBeDefined();
+        expect(clusterRole!.rules).toEqual([
+          { apiGroups: ["pepr.dev"], resources: ["peprstores"], verbs: ["create", "get", "patch", "watch"] },
+          { apiGroups: ["apiextensions.k8s.io"], resources: ["customresourcedefinitions"], verbs: ["patch", "create"] },
+          { apiGroups: [""], resources: ["namespaces"], verbs: ["watch"] },
+          { apiGroups: [""], resources: ["configmaps"], verbs: ["watch"] },
+        ]);
+      });
+    });
+  });
+});

--- a/integration/cli/build.rbacmode.test.ts
+++ b/integration/cli/build.rbacmode.test.ts
@@ -4,14 +4,12 @@
 import { beforeAll, describe, expect, it } from "@jest/globals";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
-import * as f from "node:fs";
 import { execSync } from "node:child_process";
 import { Workdir } from "../helpers/workdir";
 import * as time from "../helpers/time";
 import * as pepr from "../helpers/pepr";
 import * as resource from "../helpers/resource";
 import { kind } from "kubernetes-fluent-client";
-import YAML from "yaml";
 
 const FILE = path.basename(__filename);
 const HERE = __dirname;
@@ -60,11 +58,23 @@ describe("build rbacMode=scoped", () => {
       }, time.toMs("1m"));
 
       it("creates a scoped rbac role to the kubernetes manifests", async () => {
-        const clusterRole = await resource.getK8sObjectByKindAndName<kind.ClusterRole>(`${outputDir}/pepr-module-${uuid}.yaml`, "ClusterRole", `pepr-${uuid}`);
+        const clusterRole = await resource.getK8sObjectByKindAndName<kind.ClusterRole>(
+          `${outputDir}/pepr-module-${uuid}.yaml`,
+          "ClusterRole",
+          `pepr-${uuid}`,
+        );
         expect(clusterRole).toBeDefined();
         expect(clusterRole!.rules).toEqual([
-          { apiGroups: ["pepr.dev"], resources: ["peprstores"], verbs: ["create", "get", "patch", "watch"] },
-          { apiGroups: ["apiextensions.k8s.io"], resources: ["customresourcedefinitions"], verbs: ["patch", "create"] },
+          {
+            apiGroups: ["pepr.dev"],
+            resources: ["peprstores"],
+            verbs: ["create", "get", "patch", "watch"],
+          },
+          {
+            apiGroups: ["apiextensions.k8s.io"],
+            resources: ["customresourcedefinitions"],
+            verbs: ["patch", "create"],
+          },
           { apiGroups: [""], resources: ["namespaces"], verbs: ["watch"] },
           { apiGroups: [""], resources: ["configmaps"], verbs: ["watch"] },
         ]);
@@ -74,11 +84,23 @@ describe("build rbacMode=scoped", () => {
         execSync(`helm template .  > ${outputDir}/helm-template.yaml`, {
           cwd: `${outputDir}/${uuid}-chart`,
         });
-        const clusterRole = await resource.getK8sObjectByKindAndName<kind.ClusterRole>(`${outputDir}/helm-template.yaml`, "ClusterRole", `pepr-${uuid}`);
+        const clusterRole = await resource.getK8sObjectByKindAndName<kind.ClusterRole>(
+          `${outputDir}/helm-template.yaml`,
+          "ClusterRole",
+          `pepr-${uuid}`,
+        );
         expect(clusterRole).toBeDefined();
         expect(clusterRole!.rules).toEqual([
-          { apiGroups: ["pepr.dev"], resources: ["peprstores"], verbs: ["create", "get", "patch", "watch"] },
-          { apiGroups: ["apiextensions.k8s.io"], resources: ["customresourcedefinitions"], verbs: ["patch", "create"] },
+          {
+            apiGroups: ["pepr.dev"],
+            resources: ["peprstores"],
+            verbs: ["create", "get", "patch", "watch"],
+          },
+          {
+            apiGroups: ["apiextensions.k8s.io"],
+            resources: ["customresourcedefinitions"],
+            verbs: ["patch", "create"],
+          },
           { apiGroups: [""], resources: ["namespaces"], verbs: ["watch"] },
           { apiGroups: [""], resources: ["configmaps"], verbs: ["watch"] },
         ]);

--- a/integration/cli/crd.test.ts
+++ b/integration/cli/crd.test.ts
@@ -414,4 +414,3 @@ describe("crd", () => {
     });
   });
 });
-// Not optional, subresource must be present and it is empty

--- a/integration/cli/crd.test.ts
+++ b/integration/cli/crd.test.ts
@@ -415,4 +415,3 @@ describe("crd", () => {
   });
 });
 // Not optional, subresource must be present and it is empty
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
## Description

Adds integration tests for running `npx pepr build --rbac-mode=scoped`. This PR makes assertions on the outputs of the helm chart and Kubernetes manifests.

## Related Issue

Fixes #2111 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
