### PR TITLE
chore: complexity around validating namespaces in deploy

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import prompt from "prompts";
-
+import { CapabilityExport } from "../lib/types";
 import { Assets } from "../lib/assets/assets";
 import { ImagePullSecret } from "../lib/types";
 import { RootCmd } from "./root";
@@ -109,13 +109,7 @@ async function buildAndDeployModule(image: string, force: boolean): Promise<void
   webhook.image = image ?? webhook.image;
   const capabilities = await loadCapabilities(webhook.path);
   for (const capability of capabilities) {
-    namespaceComplianceValidator(capability, webhook.alwaysIgnore?.namespaces);
-    namespaceComplianceValidator(
-      capability,
-      webhook.config.admission?.alwaysIgnore?.namespaces,
-      false,
-    );
-    namespaceComplianceValidator(capability, webhook.config.watch?.alwaysIgnore?.namespaces, true);
+    validateNamespaces(capability, webhook);
   }
   try {
     await webhook.deploy(deployWebhook, force, builtModule.cfg.pepr.webhookTimeout ?? 10);
@@ -162,4 +156,14 @@ export default function (program: RootCmd): void {
 
       await buildAndDeployModule(opts.image, opts.force);
     });
+}
+
+export function validateNamespaces(capability: CapabilityExport, webhook: Assets): void {
+  namespaceComplianceValidator(capability, webhook.alwaysIgnore?.namespaces);
+  namespaceComplianceValidator(
+    capability,
+    webhook.config.admission?.alwaysIgnore?.namespaces,
+    false,
+  );
+  namespaceComplianceValidator(capability, webhook.config.watch?.alwaysIgnore?.namespaces, true);
 }


### PR DESCRIPTION
## Description

`buildAndDeployModule` in src/cli has a complexity warning after adding logic to ensure namespaces do not have violations. This PR reduces the complexity in order to remove the warning

![image](https://github.com/user-attachments/assets/acedd504-93dc-4627-891f-3996e33138b0)


## Related Issue

Fixes #2166 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
