### PR TITLE
chore: complexity in `checkDeploymentStatus`

### DIFF
--- a/src/lib/deploymentChecks.ts
+++ b/src/lib/deploymentChecks.ts
@@ -18,14 +18,18 @@ export async function checkDeploymentStatus(namespace: string): Promise<boolean>
   let allReady = true;
 
   for (const deployment of deployments.items) {
-    if (deployment.status?.readyReplicas !== deployment.spec?.replicas) {
+    const name = deployment.metadata?.name ?? "unknown";
+    const specReplicas = deployment.spec?.replicas ?? 0;
+    const readyReplicas = deployment.status?.readyReplicas ?? 0;
+
+    if (readyReplicas !== specReplicas) {
       Log.info(
-        `Waiting for deployment ${deployment.metadata?.name} rollout to finish: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
+        `Waiting for deployment ${name} rollout to finish: ${readyReplicas} of ${specReplicas} replicas are available`,
       );
       allReady = false;
     } else {
       Log.info(
-        `Deployment ${deployment.metadata?.name} rolled out: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
+        `Deployment ${name} rolled out: ${readyReplicas} of ${specReplicas} replicas are available`,
       );
     }
   }

--- a/src/lib/deploymentChecks.ts
+++ b/src/lib/deploymentChecks.ts
@@ -19,17 +19,15 @@ export async function checkDeploymentStatus(namespace: string): Promise<boolean>
 
   for (const deployment of deployments.items) {
     const name = deployment.metadata?.name ?? "unknown";
-    const specReplicas = deployment.spec?.replicas ?? 0;
-    const readyReplicas = deployment.status?.readyReplicas ?? 0;
 
-    if (readyReplicas !== specReplicas) {
+    if (deployment.status?.readyReplicas !== deployment.spec?.replicas) {
       Log.info(
-        `Waiting for deployment ${name} rollout to finish: ${readyReplicas} of ${specReplicas} replicas are available`,
+        `Waiting for deployment ${name} rollout to finish: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
       );
       allReady = false;
     } else {
       Log.info(
-        `Deployment ${name} rolled out: ${readyReplicas} of ${specReplicas} replicas are available`,
+        `Deployment ${name} rolled out: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
       );
     }
   }

--- a/src/lib/deploymentChecks.ts
+++ b/src/lib/deploymentChecks.ts
@@ -18,16 +18,14 @@ export async function checkDeploymentStatus(namespace: string): Promise<boolean>
   let allReady = true;
 
   for (const deployment of deployments.items) {
-    const name = deployment.metadata?.name ?? "unknown";
-
     if (deployment.status?.readyReplicas !== deployment.spec?.replicas) {
       Log.info(
-        `Waiting for deployment ${name} rollout to finish: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
+        `Waiting for deployment ${deployment.metadata?.name} rollout to finish: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
       );
       allReady = false;
     } else {
       Log.info(
-        `Deployment ${name} rolled out: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
+        `Deployment ${deployment.metadata?.name} rolled out: ${deployment.status?.readyReplicas} of ${deployment.spec?.replicas} replicas are available`,
       );
     }
   }


### PR DESCRIPTION
## Description

Removes ESLint complexity warning while keeping behavior the same in `checkDeploymentStatus`

## Related Issue

Fixes #2168 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
