### PR TITLE
fix: update dockerfile container images

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -37,7 +37,6 @@ jobs:
         run: |
           mkdir -p ~/.grype
           echo "ignore:" > ~/.grype.yaml
-          echo "  - vulnerability: CVE-2025-0395" >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # v6.2.0
         with:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           mkdir -p ~/.grype
           echo "ignore:" > ~/.grype.yaml
+          echo "  - vulnerability: CVE-2025-4802" >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # v6.2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Any other changes to Dockerfile should be reflected in Publish
 
 ARG BUILD_IMAGE=docker.io/library/node@sha256:c29271c7f2b4788fe9b90a7506d790dc8f2ff46132e1b70e71bf0c0679c8451c
-ARG BASE_IMAGE=gcr.io/distroless/nodejs22-debian12:nonroot@sha256:894873fc72ea5731e38cf3cfa75a6a3b1985a9330e46bb4d81162e6a184f212e
+ARG BASE_IMAGE=gcr.io/distroless/nodejs22-debian12:nonroot@sha256:595dcd85af33b16450868993ec48992c82d90a692fb0d5c6f435bca16edb85d6
 
 FROM ${BUILD_IMAGE} AS build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-ARG BUILD_IMAGE=docker.io/library/node@sha256:c29271c7f2b4788fe9b90a7506d790dc8f2ff46132e1b70e71bf0c0679c8451c
+ARG BUILD_IMAGE=docker.io/library/node@sha256:37c7b4cd8867313fc17ba76c1a6676414c61e2aac113694072bb8e3ef6d0a4c8
 ARG BASE_IMAGE=gcr.io/distroless/nodejs22-debian12:nonroot@sha256:595dcd85af33b16450868993ec48992c82d90a692fb0d5c6f435bca16edb85d6
 
 FROM ${BUILD_IMAGE} AS build


### PR DESCRIPTION
## Description

This PR resolves issues with grype scans in CI by updating the images used to build Pepr.

Current state on `main` for a `grype` scan is:
```
❯ grype --fail-on high pepr:dev
 ✔ Loaded image                                                                                                                                                  pepr:dev 
 ✔ Parsed image                                                                                   sha256:4e37a4e37b9bc194e83535d8aed27e74e366b5460c7a17768d4388e2d471a2b3 
 ✔ Cataloged contents                                                                                    77f829c3d032a8aae52ada925b8f55ed2c2850a54f1af6cca8f2500fabfbefa8 
   ├── ✔ Packages                        [321 packages]  
   ├── ✔ File metadata                   [1,568 locations]  
   ├── ✔ Executables                     [282 executables]  
   └── ✔ File digests                    [1,568 files]  
 ✘ Scan for vulnerabilities        [20 vulnerability matches]  
   ├── by severity: 0 critical, 3 high, 1 medium, 1 low, 15 negligible
   └── by status:   8 fixed, 12 not-fixed, 0 ignored 
[0005] ERROR discovered vulnerabilities at or above the severity threshold
```

This PR mitigates 8 CVEs:

```
❯ grype --fail-on high pepr:dev
 ✔ Loaded image                                                                                                                                                  pepr:dev 
 ✔ Parsed image                                                                                   sha256:d1382ec8285a94c7c99c6e14efc36eabedfa4c2501a060866e37d25ff59f5684 
 ✔ Cataloged contents                                                                                    284d83c1ad54f04b01824c5753e998437a66e507c6f26638c307bcccfc16fe83 
   ├── ✔ Packages                        [321 packages]  
   ├── ✔ Executables                     [282 executables]  
   ├── ✔ File metadata                   [1,570 locations]  
   └── ✔ File digests                    [1,570 files]  
 ✘ Scan for vulnerabilities        [12 vulnerability matches]  
   ├── by severity: 0 critical, 1 high, 0 medium, 0 low, 11 negligible
   └── by status:   0 fixed, 12 not-fixed, 0 ignored 
[0005] ERROR discovered vulnerabilities at or above the severity threshold
```

CVE-2025-4802 is resolved in [`glibc-2.39`](https://security-tracker.debian.org/tracker/CVE-2025-4802). However, I haven't seen a container image for `nodejs22-debian12:nonroot` that uses that version as of 21 May 2025. As we've done in the past (see #1777), let's ignore the CVE for now since it's an upstream issue and create an issue in the backlog so we don't forget about this (see #2184).

## Related Issue

Hotfix to unblock CI.

Fixes #1778 
Relates to #2184 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
