### PR TITLE
chore: cgr image updates

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.15.0@sha256:886cb29e11b35f89448cd859371cc321d96fd773978e629ce8ed7f6333df8cc8 AS build
+FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.16.0@sha256:ecc71005908276ea1c625fa4a00829484d3ff760540cc1919dccbc38977e4af3 AS build
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.15.0-slim@sha256:80f43f7a53733029448de10ab810a1669e1feeb3fa5f34eb64a7d75e476afd45
+FROM cgr.dev/du-uds-defenseunicorns/node-fips:22.16.0-slim@sha256:1f2fb710f35199224ecc43c686b1eae21a62a0fdac68d6b5824e2aab46fa88a5
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Updates the cgr images to node-fips `22.16.0`

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
