### PR TITLE
chore: use latest in journey tests

### DIFF
--- a/journey/pepr-upgrade.test.ts
+++ b/journey/pepr-upgrade.test.ts
@@ -26,8 +26,7 @@ export function peprUpgrade() {
 
   it("should prepare, build, and deploy hello-pepr with pepr@latest", async () => {
     try {
-      // Install pepr@nightly
-      execSync("npm i pepr@nightly", { cwd: "pepr-upgrade-test", stdio: "inherit" });
+      execSync("npm i pepr@latest", { cwd: "pepr-upgrade-test", stdio: "inherit" });
 
       // Generate manifests with pepr@latest
       execSync("node ./node_modules/pepr/dist/cli.js build", {


### PR DESCRIPTION
## Description

This PR uses the latest version of Pepr now that the eslint migration has been released in 0.51.0.

## Related Issue

Fixes #2155 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
