### PR TITLE
chore: list commander as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ramda": "0.30.2",
+        "commander": "14.0.0",
         "express": "5.1.0",
         "fast-json-patch": "3.1.1",
         "heredoc": "^1.3.1",
@@ -53,7 +54,6 @@
         "@types/prompts": "2.4.9",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "commander": "14.0.0",
         "esbuild": "0.25.0",
         "eslint": "^9.26.0",
         "node-forge": "1.3.1",
@@ -3987,7 +3987,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
       "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@types/ramda": "0.30.2",
+    "commander": "14.0.0",
     "express": "5.1.0",
     "fast-json-patch": "3.1.1",
     "heredoc": "^1.3.1",
@@ -91,7 +92,6 @@
     "@types/prompts": "2.4.9",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "commander": "14.0.0",
     "esbuild": "0.25.0",
     "eslint": "^9.26.0",
     "node-forge": "1.3.1",


### PR DESCRIPTION
## Description

`commander` is used by the CLI, so we're listing it as a direct dependency instead of as a `peerDependency`

## Related Issue

Fixes #2192 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
