### PR TITLE
chore: support last 3 stable versions of node - drop 18

### DIFF
--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ When(a.ConfigMap)
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/en/) v18.0.0+ (even-numbered releases only)
+- [Node.js](https://nodejs.org/en/) v20.0.0+ (even-numbered releases only)
   - To ensure compatability and optimal performance, it is recommended to use even-numbered releases of Node.js as they are stable releases and receive long-term support for three years. Odd-numbered releases are experimental and may not be supported by certain libraries utilized in Pepr.
 
 - [npm](https://www.npmjs.com/) v10.1.0+

--- a/docs/040_pepr-tutorials/030_create-pepr-operator.md
+++ b/docs/040_pepr-tutorials/030_create-pepr-operator.md
@@ -27,7 +27,7 @@ All resources will include `ownerReferences`, triggering cascading deletion when
 - Access to the `curl` command
 - Basic understanding of Kubernetes concepts
 - Familiarity with TypeScript
-- Node.js ≥ 18.0
+- Node.js ≥ 20.0
 
 [Back to top](#building-a-kubernetes-operator-with-pepr)
 

--- a/docs/120_contribute/README.md
+++ b/docs/120_contribute/README.md
@@ -27,7 +27,7 @@ Please follow our [Code of Conduct](../../CODE_OF_CONDUCT.md) to maintain a resp
 
 - **Repository**: [https://github.com/defenseunicorns/pepr/](https://github.com/defenseunicorns/pepr/)
 - **npm package**: [https://www.npmjs.com/package/pepr](https://www.npmjs.com/package/pepr)
-- **Required Node version**: `>=18.0.0`
+- **Required Node version**: `>=20.0.0`
 
 ### Setup
 

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -68,7 +68,7 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string): peprPack
     description: opts.description,
     keywords: ["pepr", "k8s", "policy-engine", "pepr-module", "security"],
     engines: {
-      node: ">=18.0.0",
+      node: ">=20.0.0",
     },
     pepr: {
       uuid: pgkVerOverride ? "static-test" : uuid,


### PR DESCRIPTION
## Description

We need to drop support for Node.js v18 due to some dependencies potentially not being able to use a Node.js that old. Also, this creates a liability having such an old version. This PR updates to only supporting the last 3 stable versions and updates the tests



## Related Issue

Fixes #2191 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
