### PR TITLE
chore: in faq give explanation of module author

### DIFF
--- a/docs/080_faq/README.md
+++ b/docs/080_faq/README.md
@@ -1,5 +1,10 @@
 # Frequently Asked Questions
 
+## What is a module author?
+
+A module author is someone who creates a [Pepr Module](../030_user-guide/020_pepr-modules.md) , which defines capabilities to enforce or apply desired state in a Kubernetes cluster.
+If you’ve run npx pepr init to create a module, congratulations — you’re a module author.
+
 ## How do I remove the punycode warning?
 
 By default, warnings are removed. You can allow warnings by setting the `PEPR_NODE_WARNINGS` environment variable.

--- a/docs/080_faq/README.md
+++ b/docs/080_faq/README.md
@@ -3,7 +3,7 @@
 ## What is a module author?
 
 A module author is someone who creates a [Pepr Module](../030_user-guide/020_pepr-modules.md) , which defines capabilities to enforce or apply desired state in a Kubernetes cluster.
-If you’ve run npx pepr init to create a module, congratulations — you’re a module author.
+If you’ve run `npx pepr init` to create a module, congratulations — you’re a module author.
 
 ## How do I remove the punycode warning?
 


### PR DESCRIPTION
## Description

We have been reaching out to the [Pepr Community](https://kubernetes.slack.com/archives/C06DGH40UCB/p1747169572692789?thread_ts=1744212295.406759&cid=C06DGH40UCB) in slack for feedback on our docs. One piece of feedback was that it is not clear what a module author is. This PR adds to the faq an explanation of a module author

## Related Issue

Fixes #2172 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
