### PR TITLE
chore: do not log about an alias when there is no alias

### DIFF
--- a/src/lib/core/capability.ts
+++ b/src/lib/core/capability.ts
@@ -249,8 +249,8 @@ export class Capability implements CapabilityExport {
           ...binding,
           isValidate: true,
           validateCallback: async (req, logger = aliasLogger) => {
-            Log.info(
-              `Executing validate action with alias: ${binding.alias || "no alias provided"}`,
+            binding.alias && Log.info(
+              `Executing validate action with alias: ${binding.alias}`,
             );
             return await validateCallback(req, logger);
           },
@@ -273,8 +273,8 @@ export class Capability implements CapabilityExport {
           ...binding,
           isMutate: true,
           mutateCallback: async (req, logger = aliasLogger) => {
-            Log.info(
-              `Executing mutation action with alias: ${binding.alias || "no alias provided"}`,
+            binding.alias && Log.info(
+              `Executing mutation action with alias: ${binding.alias}`,
             );
             await mutateCallback(req, logger);
           },
@@ -300,7 +300,7 @@ export class Capability implements CapabilityExport {
           ...binding,
           isWatch: true,
           watchCallback: async (update, phase, logger = aliasLogger) => {
-            Log.info(`Executing watch action with alias: ${binding.alias || "no alias provided"}`);
+            binding.alias && Log.info(`Executing watch action with alias: ${binding.alias}`);
             await watchCallback(update, phase, logger);
           },
         });
@@ -324,8 +324,8 @@ export class Capability implements CapabilityExport {
           isWatch: true,
           isQueue: true,
           watchCallback: async (update, phase, logger = aliasLogger) => {
-            Log.info(
-              `Executing reconcile action with alias: ${binding.alias || "no alias provided"}`,
+            binding.alias && Log.info(
+              `Executing reconcile action with alias: ${binding.alias}`,
             );
             await reconcileCallback(update, phase, logger);
           },
@@ -363,8 +363,8 @@ export class Capability implements CapabilityExport {
             update: InstanceType<T>,
             logger = aliasLogger,
           ): Promise<boolean | void> => {
-            Log.info(
-              `Executing finalize action with alias: ${binding.alias || "no alias provided"}`,
+            binding.alias && Log.info(
+              `Executing finalize action with alias: ${binding.alias}`,
             );
             return await finalizeCallback(update, logger);
           },

--- a/src/lib/core/capability.ts
+++ b/src/lib/core/capability.ts
@@ -249,9 +249,9 @@ export class Capability implements CapabilityExport {
           ...binding,
           isValidate: true,
           validateCallback: async (req, logger = aliasLogger) => {
-            binding.alias && Log.info(
-              `Executing validate action with alias: ${binding.alias}`,
-            );
+            if (binding.alias) {
+              Log.info(`Executing validate action with alias: ${binding.alias}`);
+            }
             return await validateCallback(req, logger);
           },
         });
@@ -273,9 +273,9 @@ export class Capability implements CapabilityExport {
           ...binding,
           isMutate: true,
           mutateCallback: async (req, logger = aliasLogger) => {
-            binding.alias && Log.info(
-              `Executing mutation action with alias: ${binding.alias}`,
-            );
+            if (binding.alias) {
+              Log.info(`Executing mutation action with alias: ${binding.alias}`);
+            }
             await mutateCallback(req, logger);
           },
         });
@@ -300,7 +300,9 @@ export class Capability implements CapabilityExport {
           ...binding,
           isWatch: true,
           watchCallback: async (update, phase, logger = aliasLogger) => {
-            binding.alias && Log.info(`Executing watch action with alias: ${binding.alias}`);
+            if (binding.alias) {
+              Log.info(`Executing watch action with alias: ${binding.alias}`);
+            }
             await watchCallback(update, phase, logger);
           },
         });
@@ -324,9 +326,9 @@ export class Capability implements CapabilityExport {
           isWatch: true,
           isQueue: true,
           watchCallback: async (update, phase, logger = aliasLogger) => {
-            binding.alias && Log.info(
-              `Executing reconcile action with alias: ${binding.alias}`,
-            );
+            if (binding.alias) {
+              Log.info(`Executing reconcile action with alias: ${binding.alias}`);
+            }
             await reconcileCallback(update, phase, logger);
           },
         });
@@ -363,9 +365,9 @@ export class Capability implements CapabilityExport {
             update: InstanceType<T>,
             logger = aliasLogger,
           ): Promise<boolean | void> => {
-            binding.alias && Log.info(
-              `Executing finalize action with alias: ${binding.alias}`,
-            );
+            if (binding.alias) {
+              Log.info(`Executing finalize action with alias: ${binding.alias}`);
+            }
             return await finalizeCallback(update, logger);
           },
         };


### PR DESCRIPTION
## Description

When debugging a Pepr module I noticed this useless log polluting the controller logs repeatedly.

```bash
Executing reconcile action with alias: no alias provided
```

For one, it is incorrect, there is no alias in the action, two it is pointless, three this is a `Log.info` instead of debug, that kind of verbosity is bad for debugging and user experience as it does not provide any useful information.

If there is an alias. we can use this and it could be useful for grepping logs but without an alias it just does not make sense

## Related Issue

Fixes #2202
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
