### PR TITLE
chore: set exit code during error instead of forcing termination during `npx pepr update`

### DIFF
--- a/src/cli/update/index.ts
+++ b/src/cli/update/index.ts
@@ -56,7 +56,7 @@ export default function (program: RootCmd): void {
         console.log(`✅ Module updated successfully`);
       } catch (e) {
         console.error(`Error updating Pepr module:`, e);
-        process.exit(1);
+        process.exitCode = 1;
       }
     });
 
@@ -87,9 +87,10 @@ export default function (program: RootCmd): void {
             await write(tsPath, helloPepr.data);
           }
         }
+        throw new Error("another error, for testing");
       } catch (e) {
         console.error(`Error updating template files:`, e);
-        process.exit(1);
+        process.exitCode = 1;
       }
     });
 }


### PR DESCRIPTION
## Description

This PR applies guidance from the [node docs](https://nodejs.org/api/process.html#processexitcode_1) regarding the use of `process.exit()` vs setting `process.exitCode` for the command `npx pepr update`.

## Related Issue

Fixes #1795 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
