### PR TITLE
chore: update logging before `pepr dev` exits

### DIFF
--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -29,7 +29,8 @@ export default function (program: RootCmd): void {
 
         // Exit if the user doesn't confirm
         if (!confirm.confirm) {
-          process.exit(0);
+          process.exitCode = 0;
+          return;
         }
       }
 
@@ -67,9 +68,11 @@ export default function (program: RootCmd): void {
           try {
             // wait for capabilities to be loaded and test names
             validateCapabilityNames(webhook.capabilities);
-          } catch (e) {
-            console.error(`Error validating capability names:`, e);
-            process.exitCode = 1;
+          } catch (error) {
+            console.error(
+              `CapabilityValidation Error - Unable to valide capability name(s) in: '${webhook.capabilities.map(item => item.name)}'\n${error}`,
+            );
+            process.exit(1);
           }
 
           program = fork(path, {
@@ -115,7 +118,7 @@ export default function (program: RootCmd): void {
         });
       } catch (e) {
         console.error(`Error deploying module:`, e);
-        process.exitCode = 1;
+        process.exit(1);
       }
     });
 }

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -69,7 +69,7 @@ export default function (program: RootCmd): void {
             validateCapabilityNames(webhook.capabilities);
           } catch (e) {
             console.error(`Error validating capability names:`, e);
-            process.exit(1);
+            process.exitCode = 1;
           }
 
           program = fork(path, {
@@ -115,7 +115,7 @@ export default function (program: RootCmd): void {
         });
       } catch (e) {
         console.error(`Error deploying module:`, e);
-        process.exit(1);
+        process.exitCode = 1;
       }
     });
 }


### PR DESCRIPTION
## Description

This PR updates logging before calling `process.exit()`, which seems to have a legitimate case for staying in the `pepr dev` command.

## Related Issue

Fixes #1793 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
