### PR TITLE
chore: bump timeouts to 8 min

### DIFF
--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 6
+          timeout_minutes: 8
           command: |
             cd $PEPR_EXCELLENT_EXAMPLES_PATH
 

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -204,7 +204,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 6
+          timeout_minutes: 8
           command: |
             cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
             npm run --workspace=${{ matrix.name }} test:e2e -- \

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -196,7 +196,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 6
+          timeout_minutes: 8
           command: |
             cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
             npm run --workspace=${{ matrix.name }} test:e2e -- \


### PR DESCRIPTION
## Description

We are trying 8 min timeouts to see if we get less ci flakes in PEXEX

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
