### PR TITLE
chore: dependabot for rapidfort

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,19 +22,17 @@ updates:
     directory: /
     schedule:
       interval: daily
-    registries:
-      - chainguard
 
   - package-ecosystem: docker
     directory: /config
     schedule:
       interval: daily
     registries:
-      - chainguard
+      - rapidfort
 
 registries:
-  chainguard:
+  rapidfort:
     type: "docker-registry"
-    url: "https://cgr.dev"
-    username: "{{ secrets.CHAINGUARD_PEPR_USERNAME }}"
-    password: "{{ secrets.CHAINGUARD_PEPR_PASSWORD }}"
+    url: "https://quay.io"
+    username: "{{ secrets.RAPIDFORT_USERNAME }}"
+    password: "{{ secrets.RAPIDFORT_PASSWORD }}"

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:2531c87bc936fd72fd5a55d9d97e6dfc0729780ee679783e51f518eedfa3225b AS build
+FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:a7311436e74681b98c3a1bb193b32f55fb4f658b6422c06659baa0f3d58ca678 AS build
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:2531c87bc936fd72fd5a55d9d97e6dfc0729780ee679783e51f518eedfa3225b
+FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:a7311436e74681b98c3a1bb193b32f55fb4f658b6422c06659baa0f3d58ca678
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Adds credentials to `dependabot.yaml` for RapidFort

## Related Issue

Fixes #2213
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
