### PR TITLE
chore: fix ci for rapidfort images

### DIFF
--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -73,7 +73,12 @@ jobs:
           npm run build:image:unicorn
           mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
           ls -l ${GITHUB_WORKSPACE}
-
+          if ! docker images | grep -q "pepr.*dev"; then
+            echo "pepr:dev image not found"
+            docker images
+            node -e "process.exit(1)"
+          fi
+          
       - name: build pepr package and kfc dev container image
         if: ${{ (github.event.inputs.kfcBranch || 'none') != 'none' }}
         run: |

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -73,12 +73,6 @@ jobs:
           npm run build:image:unicorn
           mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
           ls -l ${GITHUB_WORKSPACE}
-          docker images
-          if ! docker images | grep -q "pepr.*dev"; then
-            echo "pepr:dev image not found"
-            docker images
-            node -e "process.exit(1)"
-          fi
           
       - name: build pepr package and kfc dev container image
         if: ${{ (github.event.inputs.kfcBranch || 'none') != 'none' }}
@@ -97,7 +91,7 @@ jobs:
         run: |
           PEPR_TAR="${GITHUB_WORKSPACE}/pepr-img.tar"
           echo "PEPR_TAR=${PEPR_TAR}" >> "$GITHUB_ENV"
-          docker image save --output "$PEPR_TAR" pep/private:dev
+          docker image save --output "$PEPR_TAR" pepr/private:dev
 
       - name: upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           PEPR_TAR="${GITHUB_WORKSPACE}/pepr-img.tar"
           echo "PEPR_TAR=${PEPR_TAR}" >> "$GITHUB_ENV"
-          docker image save --output "$PEPR_TAR" pepr:dev
+          docker image save --output "$PEPR_TAR" pep/private:dev
 
       - name: upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -216,7 +216,7 @@ jobs:
           command: |
             cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
             npm run --workspace=${{ matrix.name }} test:e2e -- \
-              --image pepr:dev \
+              --image pepr/private:dev \
               --custom-package ../pepr-0.0.0-development.tgz
 
       - name: upload artifacts (troubleshooting)

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -73,6 +73,7 @@ jobs:
           npm run build:image:unicorn
           mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
           ls -l ${GITHUB_WORKSPACE}
+          docker images
           if ! docker images | grep -q "pepr.*dev"; then
             echo "pepr:dev image not found"
             docker images

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "build": "tsc && node build.mjs && npm pack",
     "build:image": "npm run build && docker buildx build --output type=docker --tag pepr:dev .",
-    "build:image:unicorn": "npm run build && docker buildx build --output type=docker --tag pepr:dev $(node scripts/read-unicorn-build-args.mjs) .",
+    "build:image:unicorn": "npm run build && docker buildx build --output type=docker --tag pepr/private:dev $(node scripts/read-unicorn-build-args.mjs) .",
     "set:version": "node scripts/set-version.js",
     "test": "npm run test:unit && npm run test:journey && npm run test:journey-wasm",
     "test:artifacts": "npm run build && jest src/build-artifact.test.ts",


### PR DESCRIPTION
## Description

The `RapidFort` base images run as user `1000`.  When we got the PR for the [new images](https://github.com/defenseunicorns/pepr/pull/2209/files#diff-12c7ba511e0e8e86979184020ac26ce153212e4ebe0f91c74c02e786d14b5da2) we baked in logic in around `build`  to adjust the securityContext of the Pod and Container if image string contained "private". This PR makes the unicorn PEXEX test use an image with "private" in the string.


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
