### PR TITLE
chore: rapidfort journey fix

### DIFF
--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -45,5 +45,6 @@ jobs:
 
       - run: npm ci
       - run: |
+          PEPR_IMAGE=pepr/private:dev
           npm run test:journey:unicorn
           npm run test:journey-wasm:unicorn

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -45,6 +45,6 @@ jobs:
 
       - run: npm ci
       - run: |
-          PEPR_IMAGE=pepr/private:dev
+          export PEPR_IMAGE=pepr/private:dev
           npm run test:journey:unicorn
           npm run test:journey-wasm:unicorn

--- a/journey/pepr-deploy.ts
+++ b/journey/pepr-deploy.ts
@@ -33,7 +33,8 @@ export function peprDeploy() {
      * when controller starts up, it will migrate the store
      * and later on the keys will be tested to validate the migration
      */
-    execSync("npx pepr deploy -i pepr:dev --confirm", { cwd, stdio: "inherit" });
+    const image = process.env.PEPR_IMAGE || "pepr:dev";
+    execSync(`npx pepr deploy -i ${image} --confirm`, { cwd, stdio: "inherit" });
 
     // Wait for the deployments to be ready
     await Promise.all([

--- a/journey/pepr-upgrade.test.ts
+++ b/journey/pepr-upgrade.test.ts
@@ -56,8 +56,9 @@ export function peprUpgrade() {
 
   it("should prepare, build, and deploy hello-pepr with pepr@pr-candidate", async () => {
     try {
+      const image = process.env.PEPR_IMAGE || "pepr:dev";
       // Re-generate manifests with pepr@pr-candidate
-      execSync("npx --yes ts-node ../src/cli.ts build -i pepr:dev", {
+      execSync(`npx --yes ts-node ../src/cli.ts build -i ${image}`, {
         cwd: "pepr-upgrade-test",
         stdio: "inherit",
       });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:journey-wasm": "npm run test:journey:k3d && npm run build && npm run test:journey:image && npm run test:journey:run-wasm",
     "test:journey-wasm:unicorn": "npm run test:journey:k3d && npm run build && npm run test:journey:image:unicorn && npm run test:journey:run-wasm",
     "test:journey:image": "docker buildx build --output type=docker --tag pepr:dev . && k3d image import pepr:dev -c pepr-dev",
-    "test:journey:image:unicorn": "npm run build && docker buildx build --output type=docker --tag pepr:dev $(node scripts/read-unicorn-build-args.mjs) . && k3d image import pepr:dev -c pepr-dev",
+    "test:journey:image:unicorn": "npm run build && docker buildx build --output type=docker --tag pepr/private:dev $(node scripts/read-unicorn-build-args.mjs) . && k3d image import pepr/private:dev -c pepr-dev",
     "test:journey:k3d": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0' --wait && kubectl rollout status deployment -n kube-system",
     "test:journey:run": "jest --detectOpenHandles journey/entrypoint.test.ts && npm run test:journey:upgrade",
     "test:journey:run-wasm": "jest --detectOpenHandles journey/entrypoint-wasm.test.ts",


### PR DESCRIPTION
## Description

RapidFort journey tests are using `pepr:dev` which does not set the correct securityContext on the Kubernetes manifests.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
