### PR TITLE
chore: retry on failure for rapidfort login

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -35,11 +35,13 @@ jobs:
           cache: "npm"
 
       - name: Rapidfort Login
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          registry: "quay.io"
-          username: ${{ secrets.RAPIDFORT_USERNAME }}
-          password: ${{ secrets.RAPIDFORT_PASSWORD }}
+          max_attempts: 5
+          retry_on: error
+          timeout_minutes: 1
+          command: |
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - name: "Pepr Controller: Login to GHCR"
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -37,11 +37,13 @@ jobs:
         shell: bash
 
       - name: Rapidfort Login
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          registry: "quay.io"
-          username: ${{ secrets.RAPIDFORT_USERNAME }}
-          password: ${{ secrets.RAPIDFORT_PASSWORD }}
+          max_attempts: 5
+          retry_on: error
+          timeout_minutes: 1
+          command: |
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - run: npm ci
       - run: |

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -70,11 +70,15 @@ jobs:
 
       - name: build pepr package and container image
         if: ${{ (github.event.inputs.kfcBranch || 'none') == 'none' }}
-        run: |
-          cd "$PEPR"
-          npm run build:image:unicorn
-          mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
-          ls -l ${GITHUB_WORKSPACE}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 10
+          command: |
+            cd "$PEPR"
+            npm run build:image:unicorn
+            mv pepr-0.0.0-development.tgz ${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz
           
       - name: build pepr package and kfc dev container image
         if: ${{ (github.event.inputs.kfcBranch || 'none') != 'none' }}

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -60,11 +60,13 @@ jobs:
           npm ci
 
       - name: Rapidfort Login
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          registry: "quay.io"
-          username: ${{ secrets.RAPIDFORT_USERNAME }}
-          password: ${{ secrets.RAPIDFORT_PASSWORD }}
+          max_attempts: 5
+          retry_on: error
+          timeout_minutes: 1
+          command: |
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - name: build pepr package and container image
         if: ${{ (github.event.inputs.kfcBranch || 'none') == 'none' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,13 @@ jobs:
           cache: "npm"
 
       - name: Rapidfort Login
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          registry: "quay.io"
-          username: ${{ secrets.RAPIDFORT_USERNAME }}
-          password: ${{ secrets.RAPIDFORT_PASSWORD }}
+          max_attempts: 5
+          retry_on: error
+          timeout_minutes: 1
+          command: |
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - name: "Pepr Controller: Login to GHCR"
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:e4ae092858703375259f48ffc14dd3318a025275ed351196cdeccf22ca74c937 AS build
+FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:a21f0def4843c5fb3194be2c21053f48b711dc69eca00f7ed86d0035d9b6342b AS build
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:e4ae092858703375259f48ffc14dd3318a025275ed351196cdeccf22ca74c937
+FROM quay.io/rfcurated/node:22.16.0-jammy-fips-rfcurated@sha256:a21f0def4843c5fb3194be2c21053f48b711dc69eca00f7ed86d0035d9b6342b
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

We are getting failures around logging into RapidFort. This is an attempt to reduce our error rate a bit in CI and get more tests to pass without needing to re-run them

## Related Issue

Fixes #2241 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
