### PR TITLE
chore: use full flag in CI job

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -41,7 +41,7 @@ jobs:
           retry_on: error
           timeout_minutes: 1
           command: |
-            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io --username "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - name: "Pepr Controller: Login to GHCR"
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -43,7 +43,7 @@ jobs:
           retry_on: error
           timeout_minutes: 1
           command: |
-            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io --username "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - run: npm ci
       - run: |

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -66,7 +66,7 @@ jobs:
           retry_on: error
           timeout_minutes: 1
           command: |
-            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io --username "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - name: build pepr package and container image
         if: ${{ (github.event.inputs.kfcBranch || 'none') == 'none' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           retry_on: error
           timeout_minutes: 1
           command: |
-            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io -u "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
+            echo "${{ secrets.RAPIDFORT_PASSWORD }}" | docker login quay.io --username "${{ secrets.RAPIDFORT_USERNAME }}" --password-stdin
 
       - name: "Pepr Controller: Login to GHCR"
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
## Description

This PR attempts to resolve auth issues with the `quay.io` registry.

## Related Issue

hotfix

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
