### PR TITLE
feat: export metric collector into library

### DIFF
--- a/docs/030_user-guide/150_generating_custom_metrics.md
+++ b/docs/030_user-guide/150_generating_custom_metrics.md
@@ -1,0 +1,67 @@
+# Generating Custom Metrics
+
+Pepr provides a `metricCollector` utility that lets you define custom metrics such as counters and gauges for your module.
+
+For example, to track how often a specific event occurs, you can create a custom counter and gauge like this:
+
+```typescript
+import { Capability, a, metricsCollector } from "pepr";
+
+export const HelloPepr = new Capability({
+  name: "hello-pepr",
+  description: "An example using the metric collector.",
+});
+
+// Register a metric collector to count the number of times the hello-pepr label has been applied
+metricsCollector.addCounter(
+  "label_counter",
+  "example counter for counting number of times hello-pepr label has been applied",
+);
+
+// Register a gauge to count how many times a given label has been applied
+metricsCollector.addGauge(
+  "label_guage",
+  "example gauge for counting how times times a given label has been applied",
+  ["label"],
+);
+
+const { When } = HelloPepr;
+When(a.Pod)
+  .IsCreatedOrUpdated()
+  .Mutate(po => {
+    po.SetLabel("hello-pepr", "true");
+    po.SetLabel("blue", "true");
+    po.SetLabel("green", "true");
+    metricsCollector.incCounter("label_counter");
+    metricsCollector.incGauge("label_guage", { label: "blue" }, 1);
+    metricsCollector.incGauge("label_guage", { label: "green" }, 1);
+    metricsCollector.incGauge("label_guage", { label: "hello-pepr" }, 1);
+  });
+```
+
+You can access these metrics through the `/metrics` endpoint of your module. For example, if you are running `npx pepr dev --confirm`, you can create some pods and then query the metrics like this:
+
+```bash
+terminal_a > npx pepr dev --confirm
+terminal_b > curl -k http://localhost:3000/metrics
+...
+# HELP pepr_label_counter example counter for counting number of times hello-pepr label has been applied
+# TYPE pepr_label_counter counter
+pepr_label_counter 0
+
+# HELP pepr_label_guage example gauge for counting how times times a given label has been applied
+# TYPE pepr_label_guage gauge
+terminal_b > kubectl run a --image=nginx 
+terminal_b > kubectl run b --image=nginx
+terminal_b > kubectl run c --image=nginx
+terminal_b > curl -k http://localhost:3000/metrics
+...
+# TYPE pepr_label_counter counter
+pepr_label_counter 3
+
+# HELP pepr_label_guage example gauge for counting how times times a given label has been applied
+# TYPE pepr_label_guage gauge
+pepr_label_guage{label="blue"} 3
+pepr_label_guage{label="green"} 3
+pepr_label_guage{label="hello-pepr"} 3
+```

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -105,6 +105,9 @@ export function genPkgJSON(opts: InitOptions, pgkVerOverride?: string): peprPack
     devDependencies: {
       typescript,
     },
+    overrides: {
+      "brace-expansion": "1.1.11",
+    },
   };
 
   return {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,8 +8,10 @@ import { PeprMutateRequest } from "./lib/mutate-request";
 import * as PeprUtils from "./lib/utils";
 import { PeprValidateRequest } from "./lib/validate-request";
 import * as sdk from "./sdk/sdk";
+import { metricsCollector } from "./lib/telemetry/metrics";
 
 export {
+  metricsCollector,
   Capability,
   K8s,
   Log,


### PR DESCRIPTION
## Description

Module authors need the ability to generate metrics that are specific to their modules. We are now allowing them to by exporting the metric collector and adding documentation around how to achieve this. 

## Related Issue

Fixes #2238 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
