### PR TITLE
chore: mock info and debug which are used in capability.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format:src": "eslint 'src/**/*.ts' --ignore-pattern '**/*.test.ts' --ignore-pattern src/templates/eslint.config.mjs",
     "format:tests": "eslint --config eslint.test.config.mjs 'src/**/*.test.ts'",
     "test:journey:upgrade": "npm run test:journey:k3d && npm run test:journey:image && vitest run --config=journey/vitest.config.ts journey/pepr-upgrade.test.ts",
-    "test:unit": "npm run gen-data-json && vitest run --coverage",
+    "test:unit": "npm run gen-data-json && NODE_OPTIONS=--no-deprecation vitest run --coverage",
     "prepare": "if [ \"$NODE_ENV\" != 'production' ]; then husky; fi"
   },
   "dependencies": {

--- a/src/cli/build.test.ts
+++ b/src/cli/build.test.ts
@@ -18,6 +18,14 @@ import { execSync } from "child_process";
 import { CapabilityExport } from "../lib/types";
 import { Capability } from "../lib/core/capability";
 
+vi.mock("../lib/telemetry/logger", () => ({
+  __esModule: true,
+  default: {
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 vi.mock("child_process", () => ({
   execSync: vi.fn(),
 }));


### PR DESCRIPTION
## Description

The build calls the Capability class which does a `Log.info` and `Log.debug`. This mocks the logger in order to clean up our unit tests and suppresses frivolous warnings about the `punycode` deprecation 


```ts
 FAIL  src/cli/build.test.ts > handleValidCapabilityNames > should call validateCapabilityNames with capabilities
TypeError: default.debug is not a function
 ❯ new Capability src/lib/core/capability.ts:137:9
    135| 
    136|     Log.info(`Capability ${this.#name} registered`);
    137|     Log.debug(cfg);
       |         ^
    138|   }
    139| 
```

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #2294 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
