### PR TITLE
chore: mock the log info function in deployment checks

### DIFF
--- a/src/lib/deploymentChecks.test.ts
+++ b/src/lib/deploymentChecks.test.ts
@@ -3,6 +3,13 @@ import { K8s, GenericClass, KubernetesObject } from "kubernetes-fluent-client";
 import { K8sInit } from "kubernetes-fluent-client/dist/fluent/types";
 import { checkDeploymentStatus, namespaceDeploymentsReady } from "./deploymentChecks";
 
+vi.mock("./telemetry/logger", () => ({
+  __esModule: true,
+  default: {
+    info: vi.fn(),
+  },
+}));
+
 vi.mock("kubernetes-fluent-client", () => {
   return {
     K8s: vi.fn(),


### PR DESCRIPTION
## Description

The tests are very noisy and we are trying to make them more clear to the end user by removing the console logs

## Related Issue

Fixes #2293 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
