### PR TITLE
chore: faq around pepr_watch_mode

### DIFF
--- a/docs/080_faq/README.md
+++ b/docs/080_faq/README.md
@@ -1,5 +1,9 @@
 # Frequently Asked Questions
 
+## What is the `PEPR_WATCH_MODE` environment variable?
+
+The `PEPR_WATCH_MODE` environment variable is used to determine if Pepr binds Admission Endpoints and runs as an Admission Controller or sets up the watch processor and runs as a Kubernetes Controller. For greater availability the Admission Controller runs with two replicas. The variable is set during `npx pepr build` when the manifests are generated. This variable should not be set by the user.
+
 ## Difference between `.Watch()` vs. `.Reconcile()` in Pepr
 
 `.Watch()` and `.Reconcile()` are two distinct mechanisms in Pepr used to handle Kubernetes events. The core difference is **when** and **how** they process events:


### PR DESCRIPTION
## Description

We got a question recently around the `PEPR_WATCH_MODE` environment variable. This PR aims to clarify what that variable is, how it is used internally, and when it is set.


## Related Issue

Fixes #2337
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
