### PR TITLE
chore: add paths-ignore for e2e tests on a markdown update

### DIFF
--- a/.github/workflows/node.js-unicorn.yml
+++ b/.github/workflows/node.js-unicorn.yml
@@ -4,8 +4,12 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
   merge_group:
     paths-ignore:
     - "LICENSE"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,8 +3,12 @@ name: Node.js CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
   merge_group:
     paths-ignore:
     - "LICENSE"

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -21,8 +21,12 @@ on:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
 
 # refs
 # https://frontside.com/blog/2022-12-12-dynamic-github-action-jobs/

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -18,8 +18,12 @@ on:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+    - "**.md"
 
 # refs
 # https://frontside.com/blog/2022-12-12-dynamic-github-action-jobs/


### PR DESCRIPTION
## Description

In order to improve our CI flakes we should not be running end to end tests on changes to markdown files as they do not affect the code

## Related Issue

Fixes #2242
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
