### PR TITLE
chore: remove unnecessary commands to fix iron bank pexex

### DIFF
--- a/hack/build-iron-bank.sh
+++ b/hack/build-iron-bank.sh
@@ -30,26 +30,6 @@ echo "PEPR_AMD_TAR=${PEPR_AMD_TAR}"
 # Build Pepr
 npm run build
 
-# Copy original package
-cp pepr-0.0.0-development.tgz pepr-0.0.0-development.tar.gz
-
-# Decompress, rename, and clean up
-tar -zxvf pepr-0.0.0-development.tar.gz
-mv package pepr
-rm pepr-0.0.0-development.tar.gz
-
-# Prepare package-lock.json and build-template-data.json
-cd pepr
-mkdir -p hack
-cp "$PEPR/hack/build-template-data.js" hack/
-cp "$PEPR/build.mjs" .
-cp "$PEPR/config/tsconfig.root.json" ./config/tsconfig.root.json
-npm i
-cd ..
-
-# Repackage
-tar -zcvf pepr-0.0.0-development.tar.gz pepr
-mv pepr-0.0.0-development.tgz "${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz"
 
 # Build Docker images
 export PEPR_BUILD_VERSION

--- a/hack/build-iron-bank.sh
+++ b/hack/build-iron-bank.sh
@@ -29,7 +29,7 @@ echo "PEPR_AMD_TAR=${PEPR_AMD_TAR}"
 
 # Build Pepr
 npm run build
-
+mv pepr-0.0.0-development.tgz "${GITHUB_WORKSPACE}/pepr-0.0.0-development.tgz"
 
 # Build Docker images
 export PEPR_BUILD_VERSION


### PR DESCRIPTION
## Description

Since we have simplified the IronBank image we do not need to have these config files for the build since it does not build. We just need to extract the pepr library and build the image.

[Our IronBank runs have failed for the last 4 days.](https://github.com/defenseunicorns/pepr/actions/workflows/pepr-excellent-examples-ironbank-amd.yml)

## Related Issue

Fixes #2352 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
