### PR TITLE
chore: adr directory is out of order and numbers do not make sense

### DIFF
--- a/adr/0008-named-callbacks.md
+++ b/adr/0008-named-callbacks.md
@@ -1,4 +1,4 @@
-# 7: Alias Function in Capability Class "Named Callbacks"
+# 8: Alias Function in Capability Class "Named Callbacks"
 
 Date: 2024-03-21
 

--- a/adr/0010-automated-releases.md
+++ b/adr/0010-automated-releases.md
@@ -1,4 +1,4 @@
-# 11. Automated Releases
+# 10. Automated Releases
 
 Date: 2024-07-17
 

--- a/adr/0012-e2e-testing.md
+++ b/adr/0012-e2e-testing.md
@@ -1,4 +1,4 @@
-# 13. End-to-end (E2E) Testing
+# 12. End-to-end (E2E) Testing
 
 Date: 2024-07-17
 

--- a/adr/0013-soak-testing.md
+++ b/adr/0013-soak-testing.md
@@ -1,4 +1,4 @@
-# 12. Soak Testing
+# 13. Soak Testing
 
 Date: 2024-07-17
 

--- a/adr/0015-kfc-watch-undici.md
+++ b/adr/0015-kfc-watch-undici.md
@@ -1,4 +1,4 @@
-# 14. Admission-time verification of image signatures
+# 15. Kubernetes Fluent Client Watch with Undici
 
 Date: 2024-11-20
 

--- a/adr/0016-store-key-sanitization.md
+++ b/adr/0016-store-key-sanitization.md
@@ -1,4 +1,4 @@
-# 8: Store Key Sanitization
+# 16: Store Key Sanitization
 
 Date: 2024-07-02
 

--- a/adr/0017-compliance-in-pepr.md
+++ b/adr/0017-compliance-in-pepr.md
@@ -1,4 +1,4 @@
-# 14. Compliance in Pepr 
+# 17. Compliance in Pepr 
 
 Date: 2025-02-13
 

--- a/adr/0018-cosign-poc-removal.md
+++ b/adr/0018-cosign-poc-removal.md
@@ -1,4 +1,4 @@
-# 16. Removal of Cosign Proof-of-Concept from Project
+# 18. Removal of Cosign Proof-of-Concept from Project
 
 Date: 2025-03-18
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-FROM quay.io/rfcurated/node:24.1.0-jammy-fips-rfcurated@sha256:5e83900cf5b3d3eba8efb8bfb0b7d4081e849bf388de61b52ff0ea76d3f25889 AS build
+FROM quay.io/rfcurated/node:24.3.0-jammy-fips-rfcurated@sha256:6577e7d9c3746d0839ff0132ad79147743303ff54835e355c40802c2aa2bd89b AS build
 
 WORKDIR /app
 
@@ -36,7 +36,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM quay.io/rfcurated/node:24.1.0-jammy-fips-rfcurated@sha256:5e83900cf5b3d3eba8efb8bfb0b7d4081e849bf388de61b52ff0ea76d3f25889
+FROM quay.io/rfcurated/node:24.3.0-jammy-fips-rfcurated@sha256:6577e7d9c3746d0839ff0132ad79147743303ff54835e355c40802c2aa2bd89b
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

I was looking at retroactively writing an ADR for the switch from Jest to Vitest and I realized the ADR directory is out of order and some titles did not correspond to the actual adrs.

I also manually updated our RapidFort base images for the Dockerfile since we are not getting dependabot updates still for some reason.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
