### PR TITLE
chore: mock the logs in controller

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -5,7 +5,7 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 
-FROM quay.io/rfcurated/node:24.3.0-jammy-fips-rfcurated@sha256:6577e7d9c3746d0839ff0132ad79147743303ff54835e355c40802c2aa2bd89b AS build
+FROM quay.io/rfcurated/node:24.3.0-jammy-fips-rfcurated@sha256:215c3c4a8ba2a6057a3017d48d2f0eee3a98bd4f2f7177521a3f9da0255a13fb AS build
 
 WORKDIR /app
 
@@ -36,7 +36,7 @@ RUN npm run build && \
     cp package.json node_modules/pepr
 
 ##### DELIVER #####
-FROM quay.io/rfcurated/node:24.3.0-jammy-fips-rfcurated@sha256:6577e7d9c3746d0839ff0132ad79147743303ff54835e355c40802c2aa2bd89b
+FROM quay.io/rfcurated/node:24.3.0-jammy-fips-rfcurated@sha256:215c3c4a8ba2a6057a3017d48d2f0eee3a98bd4f2f7177521a3f9da0255a13fb
 
 WORKDIR /app
 

--- a/src/lib/controller/index.test.ts
+++ b/src/lib/controller/index.test.ts
@@ -14,6 +14,13 @@ vi.mock("./store", () => {
     }),
   };
 });
+vi.mock("../telemetry/logger", () => ({
+  __esModule: true,
+  default: {
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe("Controller", () => {
   let mockConfig: ModuleConfig;

--- a/src/lib/controller/storeCache.test.ts
+++ b/src/lib/controller/storeCache.test.ts
@@ -14,7 +14,6 @@ vi.mock("../telemetry/logger", () => ({
   },
 }));
 
-
 /**
  * Helper function to set up K8s mock implementation
  * @param mockType - 'success' for resolved promise, 'error' for rejected promise
@@ -33,7 +32,6 @@ function setupK8sMock(mockType: "success" | "error", errorStatus = 400) {
 }
 
 describe("StoreCache", () => {
-  const mockK8s = vi.mocked(K8s);
   beforeEach(() => {
     vi.resetAllMocks();
   });


### PR DESCRIPTION
## Description

Mocks the log functions in controller to clean up our test, bumps the rapid fort images.

## Related Issue

Fixes #2365 
<!-- or -->
Relates to 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
