### PR TITLE
chore: replaces-bases in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,4 @@ registries:
     url: "quay.io"
     username: "{{ secrets.RAPIDFORT_USERNAME }}"
     password: "{{ secrets.RAPIDFORT_PASSWORD }}"
+    replaces-base: true


### PR DESCRIPTION
## Description

**hotfix** - Add `replaces-base` to `dependabot.yml` to try and get dependabot updates on the rf images

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
