### PR TITLE
fix: dependabot secrets ref

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,6 @@ registries:
   rapidfort:
     type: "docker-registry"
     url: "quay.io"
-    username: "{{ secrets.RAPIDFORT_USERNAME }}"
-    password: "{{ secrets.RAPIDFORT_PASSWORD }}"
+    username: "${{ secrets.RAPIDFORT_USERNAME }}"
+    password: "${{ secrets.RAPIDFORT_PASSWORD }}"
     replaces-base: true


### PR DESCRIPTION
## Description

Adds missing $ for secrets references.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
