### PR TITLE
chore: uds core smoke test with most recent stable node version

### DIFF
--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -28,7 +28,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -96,7 +96,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: uds-core
 

--- a/journey/pepr-upgrade.test.ts
+++ b/journey/pepr-upgrade.test.ts
@@ -58,7 +58,7 @@ export function peprUpgrade() {
 
   it(
     "should prepare, build, and deploy hello-pepr with pepr@pr-candidate",
-    { timeout: 1000 * 5 * 60 },
+    { timeout: 1000 * 10 * 60 },
     async () => {
       try {
         const image = process.env.PEPR_IMAGE || "pepr:dev";


### PR DESCRIPTION
## Description

UDS Smoke test has been failing consistently for the last [2 weeks](https://github.com/defenseunicorns/pepr/actions/workflows/uds.yml). We need to fix this test to ensure we are not breaking UDS Core. That [PR](https://github.com/defenseunicorns/uds-core/pull/1699) is ready for review on their side. For now we should make sure we are testing with the latest stable node version.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
