### PR TITLE
chore: remove esbuild from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,12 @@ RUN npm run build && \
     npm cache clean --force && \
     # Remove @types
     rm -rf node_modules/@types && \
-    # Remove Ramda unused Ramda files
+    # Remove Ramda unused Ramda files and esbuild
     rm -rf node_modules/ramda/dist && \
     rm -rf node_modules/ramda/es && \ 
-    rm -rf app/node_modules/esbuild && \
-    rm -rf app/node_modules/@esbuild && \
-    rm -rf app/node_modules/.bin/esbuild && \
+    rm -rf node_modules/esbuild && \
+    rm -rf node_modules/@esbuild && \
+    rm -rf node_modules/.bin/esbuild && \
     find . -name "*.ts" -type f -delete && \
     mkdir node_modules/pepr && \
     cp -r dist node_modules/pepr/dist && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN npm run build && \
     rm -rf node_modules/@types && \
     # Remove Ramda unused Ramda files
     rm -rf node_modules/ramda/dist && \
-    rm -rf node_modules/ramda/es && \
+    rm -rf node_modules/ramda/es && \ 
+    rm -rf app/node_modules/esbuild && \
+    rm -rf app/node_modules/@esbuild && \
+    rm -rf app/node_modules/.bin/esbuild && \
     find . -name "*.ts" -type f -delete && \
     mkdir node_modules/pepr && \
     cp -r dist node_modules/pepr/dist && \

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -27,12 +27,12 @@ RUN npm run build && \
     npm cache clean --force && \
     # Remove @types
     rm -rf node_modules/@types && \
-    # Remove Ramda unused Ramda files
+    # Remove Ramda unused Ramda files and esbuild
     rm -rf node_modules/ramda/dist && \
     rm -rf node_modules/ramda/es && \
-    rm -rf app/node_modules/esbuild && \
-    rm -rf app/node_modules/@esbuild && \
-    rm -rf app/node_modules/.bin/esbuild && \
+    rm -rf node_modules/esbuild && \
+    rm -rf node_modules/@esbuild && \
+    rm -rf node_modules/.bin/esbuild && \
     find . -name "*.ts" -type f -delete && \
     mkdir node_modules/pepr && \
     cp -r dist node_modules/pepr/dist && \

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -30,6 +30,9 @@ RUN npm run build && \
     # Remove Ramda unused Ramda files
     rm -rf node_modules/ramda/dist && \
     rm -rf node_modules/ramda/es && \
+    rm -rf app/node_modules/esbuild && \
+    rm -rf app/node_modules/@esbuild && \
+    rm -rf app/node_modules/.bin/esbuild && \
     find . -name "*.ts" -type f -delete && \
     mkdir node_modules/pepr && \
     cp -r dist node_modules/pepr/dist && \


### PR DESCRIPTION
## Description

ESbuild has been showing up on security scans, this is a peerDep in Pepr that is not necessary for the prod env, only during building the code. Although we are not vulnerable to any esbuild CVEs, our security posture presents better by excluding it. This is a topic that came up during office hours.

Before this PR:

```bash
> docker export $(docker create pepr:dev) | tar -tvf - | grep esbuild
lrwxrwxrwx  0 0      0           0 Jul  8 15:22 app/node_modules/.bin/esbuild -> ../esbuild/bin/esbuild
drwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/@esbuild/
drwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/@esbuild/linux-arm64/
-rw-r--r--  0 0      0         145 Jul  8 15:22 app/node_modules/@esbuild/linux-arm64/README.md
drwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/@esbuild/linux-arm64/bin/
-rwxr-xr-x  0 0      0     9633944 Jul  8 15:22 app/node_modules/@esbuild/linux-arm64/bin/esbuild
-rw-r--r--  0 0      0         380 Jul  8 15:22 app/node_modules/@esbuild/linux-arm64/package.json
drwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/esbuild/
-rw-r--r--  0 0      0        1069 Jul  8 15:22 app/node_modules/esbuild/LICENSE.md
-rw-r--r--  0 0      0         175 Jul  8 15:22 app/node_modules/esbuild/README.md
drwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/esbuild/bin/
hrwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/esbuild/bin/esbuild link to app/node_modules/@esbuild/linux-arm64/bin/esbuild
-rw-r--r--  0 0      0       11037 Jul  8 15:22 app/node_modules/esbuild/install.js
drwxr-xr-x  0 0      0           0 Jul  8 15:22 app/node_modules/esbuild/lib/
-rw-r--r--  0 0      0       88353 Jul  8 15:22 app/node_modules/esbuild/lib/main.js
-rw-r--r--  0 0      0        1419 Jul  8 15:22 app/node_modules/esbuild/package.json
```

After this PR:

```bash
 > docker export $(docker create pepr:dev) | tar -tvf - | grep esbuild
┌─[cmwylie19@C2WY6FCQVX] - [~/pepr] - [2025-07-09 11:06:00]
```
## Related Issue

Fixes #2388 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
