### PR TITLE
chore: load test hotfix

### DIFF
--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -473,7 +473,7 @@ program
     log(`Deploy Pepr controller into test cluster`);
     let env = { KUBECONFIG };
     cmd = new Cmd({
-      cmd: `npx --yes ${path.basename(worktgz)} deploy --image ${PEPR_TAG} --confirm`,
+      cmd: `npx --yes ${path.basename(worktgz)} deploy --image ${PEPR_TAG} --yes`,
       cwd: workdir,
       env,
     });


### PR DESCRIPTION
## Description

Load test failed last night because it is still using [confirm](https://github.com/defenseunicorns/pepr/actions/runs/16212324904/job/45774668148#step:15:147). This changes it to use --yes

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
