### PR TITLE
fix: pepr format returning success on eslint errors

### DIFF
--- a/src/cli/format/index.test.ts
+++ b/src/cli/format/index.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { peprFormat } from "./index";
+import { formatWithPrettier } from "./format.helpers";
+import { ESLint } from "eslint";
+
+// Mock ESLint
+vi.mock("eslint", () => {
+  return {
+    ESLint: vi.fn(() => ({
+      lintFiles: vi.fn(),
+      loadFormatter: vi.fn(),
+    })),
+  };
+});
+
+// Mock formatWithPrettier
+vi.mock("./format.helpers", () => ({
+  formatWithPrettier: vi.fn(),
+}));
+
+describe("peprFormat", () => {
+  const mockLintFiles = vi.fn();
+  const mockLoadFormatter = vi.fn();
+  const mockOutputFixes = vi.fn();
+  const mockFormatFn = vi.fn();
+  const mockFormatWithPrettier = vi.mocked(formatWithPrettier);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup ESLint mock implementation
+    (ESLint as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      lintFiles: mockLintFiles,
+      loadFormatter: mockLoadFormatter,
+    }));
+
+    // Mock static method
+    ESLint.outputFixes = mockOutputFixes;
+
+    // Setup formatter mock
+    mockLoadFormatter.mockResolvedValue({
+      format: mockFormatFn,
+    });
+  });
+
+  it("should return true when there are no linting errors and formatting succeeds", async () => {
+    // Setup mock results with no errors
+    const mockResults = [
+      { filePath: "file1.ts", errorCount: 0, fatalErrorCount: 0 },
+      { filePath: "file2.ts", errorCount: 0, fatalErrorCount: 0 },
+    ];
+
+    mockLintFiles.mockResolvedValue(mockResults);
+    mockFormatFn.mockResolvedValue(""); // No output means no errors
+    mockFormatWithPrettier.mockResolvedValue(false); // No formatting errors
+
+    const result = await peprFormat(false);
+
+    expect(result).toBe(true);
+    expect(mockOutputFixes).toHaveBeenCalledWith(mockResults);
+    expect(mockFormatWithPrettier).toHaveBeenCalledWith(mockResults, false);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("should return false when there are only linting errors", async () => {
+    // Setup mock results with errors
+    const mockResults = [
+      { filePath: "file1.ts", errorCount: 2, fatalErrorCount: 0 },
+      { filePath: "file2.ts", errorCount: 0, fatalErrorCount: 0 },
+    ];
+
+    mockLintFiles.mockResolvedValue(mockResults);
+    mockFormatFn.mockResolvedValue("Some linting errors"); // Output indicates errors
+    mockFormatWithPrettier.mockResolvedValue(false); // No formatting errors
+
+    const result = await peprFormat(false);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when there are only formatting errors", async () => {
+    // Setup mock results with no linting errors but formatting errors
+    const mockResults = [
+      { filePath: "file1.ts", errorCount: 0, fatalErrorCount: 0 },
+      { filePath: "file2.ts", errorCount: 0, fatalErrorCount: 0 },
+    ];
+
+    mockLintFiles.mockResolvedValue(mockResults);
+    mockFormatFn.mockResolvedValue("");
+    mockFormatWithPrettier.mockResolvedValue(true); // Formatting errors
+
+    const result = await peprFormat(false);
+
+    expect(result).toBe(false);
+    expect(mockFormatWithPrettier).toHaveBeenCalledWith(mockResults, false);
+  });
+});

--- a/src/cli/format/index.ts
+++ b/src/cli/format/index.ts
@@ -55,7 +55,7 @@ export async function peprFormat(validateOnly: boolean): Promise<boolean> {
         await ESLint.outputFixes(results);
       }
 
-      hasFailure = await formatWithPrettier(results, validateOnly);
+      hasFailure = hasFailure || (await formatWithPrettier(results, validateOnly));
 
       return !hasFailure;
     } catch (e) {


### PR DESCRIPTION
## Description

Pepr format was returning a success even when there was eslint errors if there were not formatting errors from prettier. There is a small bug that is fixed.  Added tests to catch this in the future.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
