### PR TITLE
chore(docs): remove deprecated CLI option

### DIFF
--- a/docs/030_user-guide/150_generating_custom_metrics.md
+++ b/docs/030_user-guide/150_generating_custom_metrics.md
@@ -39,10 +39,10 @@ When(a.Pod)
   });
 ```
 
-You can access these metrics through the `/metrics` endpoint of your module. For example, if you are running `npx pepr dev --confirm`, you can create some pods and then query the metrics like this:
+You can access these metrics through the `/metrics` endpoint of your module. For example, if you are running `npx pepr dev --yes`, you can create some pods and then query the metrics like this:
 
 ```bash
-terminal_a > npx pepr dev --confirm
+terminal_a > npx pepr dev --yes
 terminal_b > curl -k http://localhost:3000/metrics
 ...
 # HELP pepr_label_counter example counter for counting number of times hello-pepr label has been applied


### PR DESCRIPTION
## Description

This PR removes the last references to Pepr commands that use `--confirm` from the project.

## Related Issue

Fixes #2244

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
