### PR TITLE
chore: update cli test

### DIFF
--- a/src/cli/update/index.test.ts
+++ b/src/cli/update/index.test.ts
@@ -24,7 +24,7 @@ describe("Pepr CLI Update Command", () => {
     vi.mocked(prompt).mockResolvedValue({ confirm: true });
     vi.mocked(child_process.execSync).mockImplementation(() => Buffer.from(""));
 
-    await program.parseAsync(["node", "test", "update"]);
+    await program.parseAsync(["update"], { from: "user" });
 
     expect(prompt).toHaveBeenCalled();
     expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
@@ -38,7 +38,7 @@ describe("Pepr CLI Update Command", () => {
   it("skips template update", async () => {
     vi.mocked(child_process.execSync).mockImplementation(() => Buffer.from(""));
 
-    await program.parseAsync(["node", "test", "update", "--skip-template-update"]);
+    await program.parseAsync(["update", "--skip-template-update"], { from: "user" });
 
     expect(prompt).not.toHaveBeenCalled();
     expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
@@ -53,7 +53,7 @@ describe("Pepr CLI Update Command", () => {
   it("aborts update if user declines prompt", async () => {
     vi.mocked(prompt).mockResolvedValue({ confirm: false });
 
-    await program.parseAsync(["node", "test", "update"]);
+    await program.parseAsync(["update"], { from: "user" });
 
     expect(child_process.execSync).not.toHaveBeenCalled();
   });
@@ -65,7 +65,7 @@ describe("Pepr CLI Update Command", () => {
     });
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await program.parseAsync(["node", "test", "update"]);
+    await program.parseAsync(["update"], { from: "user" });
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining("Error updating Pepr module:"),
       expect.anything(),
@@ -81,7 +81,7 @@ describe("Pepr CLI Update Command", () => {
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     const spyErr = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await program.parseAsync(["node", "test", "update-templates"]);
+    await program.parseAsync(["update-templates"], { from: "user" });
 
     expect(writeMock).toHaveBeenCalled();
     expect(fs.unlinkSync).toHaveBeenCalled();

--- a/src/cli/update/index.test.ts
+++ b/src/cli/update/index.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { Command } from "commander";
+import updateCommand from "./index";
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as utils from "../init/utils";
+import prompt from "prompts";
+
+vi.mock("prompts");
+vi.mock("child_process");
+vi.mock("fs");
+vi.mock("../init/utils");
+
+describe("Pepr CLI Update Command", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    program = new Command();
+    updateCommand(program);
+  });
+
+  it("runs update with confirmation", async () => {
+    vi.mocked(prompt).mockResolvedValue({ confirm: true });
+    vi.mocked(child_process.execSync).mockImplementation(() => Buffer.from(""));
+
+    await program.parseAsync(["node", "test", "update"]);
+
+    expect(prompt).toHaveBeenCalled();
+    expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
+      stdio: "inherit",
+    });
+    expect(child_process.execSync).toHaveBeenCalledWith("npx pepr update-templates", {
+      stdio: "inherit",
+    });
+  });
+
+  it("skips template update", async () => {
+    vi.mocked(child_process.execSync).mockImplementation(() => Buffer.from(""));
+
+    await program.parseAsync(["node", "test", "update", "--skip-template-update"]);
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
+      stdio: "inherit",
+    });
+    expect(child_process.execSync).not.toHaveBeenCalledWith(
+      "npx pepr update-templates",
+      expect.anything(),
+    );
+  });
+
+  it("aborts update if user declines prompt", async () => {
+    vi.mocked(prompt).mockResolvedValue({ confirm: false });
+
+    await program.parseAsync(["node", "test", "update"]);
+
+    expect(child_process.execSync).not.toHaveBeenCalled();
+  });
+
+  it("handles update error", async () => {
+    vi.mocked(prompt).mockResolvedValue({ confirm: true });
+    vi.mocked(child_process.execSync).mockImplementation(() => {
+      throw new Error("fail");
+    });
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await program.parseAsync(["node", "test", "update"]);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("Error updating Pepr module:"),
+      expect.anything(),
+    );
+    spy.mockRestore();
+  });
+
+  it("updates templates fully", async () => {
+    (fs.existsSync as Mock).mockImplementation(() => true);
+    const writeMock = vi.fn();
+    vi.mocked(utils.write).mockImplementation(writeMock);
+
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const spyErr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await program.parseAsync(["node", "test", "update-templates"]);
+
+    expect(writeMock).toHaveBeenCalled();
+    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(spyErr).toHaveBeenCalledWith(
+      expect.stringContaining("Error updating template files:"),
+      expect.anything(),
+    );
+
+    spy.mockRestore();
+    spyErr.mockRestore();
+  });
+});


### PR DESCRIPTION
## Description

add a unit test for `npx pepr update` to add coverage

```plaintext
 pepr/src/cli/update              |     100 |      100 |     100 |     100 |                   
  index.ts                        |     100 |      100 |     100 |     100 |    
```
## Related Issue

Fixes #2402 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
