### PR TITLE
fix: remove hardcoded error during pepr update

### DIFF
--- a/src/cli/update/index.test.ts
+++ b/src/cli/update/index.test.ts
@@ -85,10 +85,7 @@ describe("Pepr CLI Update Command", () => {
 
     expect(writeMock).toHaveBeenCalled();
     expect(fs.unlinkSync).toHaveBeenCalled();
-    expect(spyErr).toHaveBeenCalledWith(
-      expect.stringContaining("Error updating template files:"),
-      expect.anything(),
-    );
+    expect(spyErr).not.toHaveBeenCalled();
 
     spy.mockRestore();
     spyErr.mockRestore();

--- a/src/cli/update/index.ts
+++ b/src/cli/update/index.ts
@@ -87,7 +87,6 @@ export default function (program: Command): void {
             await write(tsPath, helloPepr.data);
           }
         }
-        throw new Error("another error, for testing");
       } catch (e) {
         console.error(`Error updating template files:`, e);
         process.exitCode = 1;


### PR DESCRIPTION
## Description

This PR removes an error that is always thrown during `pepr update`.

## Related Issue

Fixes #2439

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
