### PR TITLE
chore: remove resource limits

### DIFF
--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -479,6 +479,26 @@ program
     });
     log({ cmd: cmd.cmd, cwd: cmd.cwd, env });
     log(await cmd.run(), "");
+    await nap(lib.toMs("30s"));
+    log("Wait for Controller to become available");
+    cmd = new Cmd({
+      cmd: `kubectl wait --namespace pepr-system --for=condition=available deployment/pepr-pepr-load --timeout=5m`,
+      env,
+    });
+
+    log(`Patch Pepr controller deployment to remove resource limits`);
+    cmd = new Cmd({
+      cmd: `kubectl patch deployment pepr-pepr-load -n pepr-system --type=json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}]'`,
+      env,
+    });
+    log({ cmd: cmd.cmd, env });
+    log(await cmd.run(), "");
+    await nap(lib.toMs("30s"));
+    log("Wait for Controller to become available after patching");
+    cmd = new Cmd({
+      cmd: `kubectl wait --namespace pepr-system --for=condition=available deployment/pepr-pepr-load --timeout=5m`,
+      env,
+    });
 
     log(`Wait for metrics on the Pepr controller to become available`);
     const start = Date.now();

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -480,24 +480,26 @@ program
     log({ cmd: cmd.cmd, cwd: cmd.cwd, env });
     log(await cmd.run(), "");
     await nap(lib.toMs("30s"));
+
     log("Wait for Controller to become available");
     cmd = new Cmd({
-      cmd: `kubectl wait --namespace pepr-system --for=condition=available deployment/pepr-pepr-load --timeout=5m`,
+      cmd: `kubectl wait --namespace pepr-system --for=condition=ready deployment/pepr-pepr-load-watcher --timeout=5m`,
       env,
     });
     log(await cmd.run(), "");
 
     log(`Patch Pepr controller deployment to remove resource limits`);
     cmd = new Cmd({
-      cmd: `kubectl patch deployment pepr-pepr-load -n pepr-system --type=json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}]'`,
+      cmd: `kubectl patch deployment pepr-pepr-load-watcher -n pepr-system --type=json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}]'`,
       env,
     });
     log({ cmd: cmd.cmd, env });
     log(await cmd.run(), "");
     await nap(lib.toMs("30s"));
+
     log("Wait for Controller to become available after patching");
     cmd = new Cmd({
-      cmd: `kubectl wait --namespace pepr-system --for=condition=available deployment/pepr-pepr-load --timeout=5m`,
+      cmd: `kubectl wait --namespace pepr-system --for=condition=ready deploy/pepr-pepr-load-watcher --timeout=5m`,
       env,
     });
     log(await cmd.run(), "");

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -485,6 +485,7 @@ program
       cmd: `kubectl wait --namespace pepr-system --for=condition=available deployment/pepr-pepr-load --timeout=5m`,
       env,
     });
+    log(await cmd.run(), "");
 
     log(`Patch Pepr controller deployment to remove resource limits`);
     cmd = new Cmd({
@@ -499,6 +500,7 @@ program
       cmd: `kubectl wait --namespace pepr-system --for=condition=available deployment/pepr-pepr-load --timeout=5m`,
       env,
     });
+    log(await cmd.run(), "");
 
     log(`Wait for metrics on the Pepr controller to become available`);
     const start = Date.now();

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -802,7 +802,7 @@ program
           await audience();
         } catch (e) {
           console.error(e);
-          process.exit(1);
+          // process.exit(1);
         }
       }, opts.audInterval);
 


### PR DESCRIPTION
## Description

Upon further investigation it becomes obvious that the reason for the controller pod not reporting resources is do to a `CrashLoopBackoff`

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
