### PR TITLE
chore: fix load test

### DIFF
--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -768,6 +768,16 @@ program
         // let res = await cmd.run();
         let res = await cmd.runRaw();
         if (res.exitcode !== 0) {
+          output = execSync(`kubectl top po -n pepr-system --no-headers`, {
+            encoding: "utf8",
+            env: { KUBECONFIG },
+          });
+          log(`kubectl top output:\n${output}`);
+          output = execSync(`kubectl get po -n pepr-system`, {
+            encoding: "utf8",
+            env: { KUBECONFIG },
+          });
+          log(`kubectl get po output:\n${output}`);
           log(`audience failed: ${res.stderr.join("\n")}`);
           return;
         }

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -463,22 +463,26 @@ program
     log({ cmd: cmd.cmd });
     log(await cmd.run(), "");
 
-    log(`Get test cluster credential`);
-    cmd = new Cmd({ cmd: `k3d kubeconfig write ${clusterName}` });
-    log({ cmd: cmd.cmd });
-    let result = await cmd.run();
-    let KUBECONFIG = result.stdout.join("").trim();
-    log(result, "");
+    try {
+      log(`Get test cluster credential`);
+      cmd = new Cmd({ cmd: `k3d kubeconfig write ${clusterName}` });
+      log({ cmd: cmd.cmd });
+      let result = await cmd.run();
+      let KUBECONFIG = result.stdout.join("").trim();
+      log(result, "");
 
-    log(`Deploy Pepr controller into test cluster`);
-    let env = { KUBECONFIG };
-    cmd = new Cmd({
-      cmd: `npx --yes ${path.basename(worktgz)} deploy --image ${PEPR_TAG} --yes`,
-      cwd: workdir,
-      env,
-    });
-    log({ cmd: cmd.cmd, cwd: cmd.cwd, env });
-    log(await cmd.run(), "");
+      log(`Deploy Pepr controller into test cluster`);
+      let env = { KUBECONFIG };
+      cmd = new Cmd({
+        cmd: `npx --yes ${path.basename(worktgz)} deploy --image ${PEPR_TAG} --yes`,
+        cwd: workdir,
+        env,
+      });
+      log({ cmd: cmd.cmd, cwd: cmd.cwd, env });
+      log(await cmd.run(), "");
+    } catch (e) {
+      console.error(`Failed to deploy image:`, e);
+    }
 
     log(`Wait for metrics on the Pepr controller to become available`);
     const start = Date.now();

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -9,7 +9,7 @@ import * as fs from "node:fs/promises";
 import * as R from "ramda";
 import { heredoc } from "../src/sdk/heredoc";
 import * as lib from "./load.lib";
-
+import { execSync } from "node:child_process";
 const TEST_CLUSTER_NAME_PREFIX = "pepr-load";
 const TEST_CLUSTER_NAME_DEFAULT = "cluster";
 const TEST_CLUSTER_NAME_MAX_LENGTH = 32;
@@ -482,18 +482,7 @@ program
 
     log(`Wait for metrics on the Pepr controller to become available`);
     const start = Date.now();
-    const max = lib.toMs("5m");
-    try {
-      const cmdDiag = new Cmd({ cmd: `kubectl top -n pepr-system`, env: { KUBECONFIG } });
-      const resultDiag = await cmdDiag.runRaw();
-      log("Diagnostic `kubectl top -n pepr-system` output:");
-      log(resultDiag.stdout.join("\n") || "(no stdout)");
-      log(resultDiag.stderr.join("\n") || "(no stderr)");
-      log(`Exit code: ${resultDiag.exitcode}`, "");
-    } catch (err) {
-      console.error("Error running `kubectl top -n pepr-system` diagnostic check:");
-      console.error(err);
-    }
+    const max = lib.toMs("2m");
     while (true) {
       const now = Date.now();
       const dur = now - start;
@@ -715,6 +704,23 @@ program
       const alpha = Date.now();
 
       log(`Load test start: ${new Date(alpha).toISOString()}`);
+      let output = execSync(`kubectl top po -n pepr-system`, {
+        encoding: "utf8",
+        env: { KUBECONFIG },
+      });
+      log(`kubectl top output:\n${output}`);
+
+      output = execSync(`kubectl top po -n pepr-system`, {
+        encoding: "utf8",
+        env: { KUBECONFIG },
+      });
+      log(`kubectl top output:\n${output}`);
+
+      output = execSync(`kubectl top po -n pepr-system`, {
+        encoding: "utf8",
+        env: { KUBECONFIG },
+      });
+      log(`kubectl top output:\n${output}`);
       log(args);
       const prettyOpts = Object.keys(opts).reduce(
         (acc, key) => {

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -768,6 +768,11 @@ program
         // let res = await cmd.run();
         let res = await cmd.runRaw();
         if (res.exitcode !== 0) {
+          output = execSync(`kubectl get po -n kube-system`, {
+            encoding: "utf8",
+            env: { KUBECONFIG },
+          });
+          log(`kubectl get po -n kube-system output:\n${output}`);
           output = execSync(`kubectl get po -n pepr-system`, {
             encoding: "utf8",
             env: { KUBECONFIG },

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -797,8 +797,9 @@ program
         try {
           await audience();
         } catch (e) {
+          log(`This comes from ticket`);
           console.error(e);
-          process.exit(1);
+          // process.exit(1);
         }
       }, opts.audInterval);
 

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -484,7 +484,7 @@ program
 
       log(`Wait for metrics on the Pepr controller to become available`);
       const start = Date.now();
-      const max = lib.toMs("2m");
+      const max = lib.toMs("5m");
       while (true) {
         const now = Date.now();
         const dur = now - start;

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -768,10 +768,10 @@ program
         // let res = await cmd.run();
         let res = await cmd.runRaw();
         if (res.exitcode !== 0) {
-          output = execSync(`kubectl top po -n pepr-system --no-headers`, {
-            encoding: "utf8",
-            env: { KUBECONFIG },
-          });
+          // output = execSync(`kubectl top po -n pepr-system --no-headers`, {
+          //   encoding: "utf8",
+          //   env: { KUBECONFIG },
+          // });
           log(`kubectl top output:\n${output}`);
           output = execSync(`kubectl get po -n pepr-system`, {
             encoding: "utf8",

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -9,6 +9,7 @@ import * as fs from "node:fs/promises";
 import * as R from "ramda";
 import { heredoc } from "../src/sdk/heredoc";
 import * as lib from "./load.lib";
+import { execSync } from "node:child_process";
 
 const TEST_CLUSTER_NAME_PREFIX = "pepr-load";
 const TEST_CLUSTER_NAME_DEFAULT = "cluster";
@@ -493,6 +494,12 @@ program
         }
 
         cmd = new Cmd({ cmd: `kubectl top --namespace pepr-system pod --no-headers`, env });
+        log(await cmd.run(), "");
+        const results = execSync(
+          `kubectl exec deploy/pepr-pepr-load-watcher -n pepr-system -- curl -k https://localhost:8080/metrics`,
+          { stdio: "inherit" },
+        );
+        console.log(results.toString());
         let res = await cmd.runRaw();
         if (res.exitcode === 0) {
           log({ max: lib.toHuman(max), actual: lib.toHuman(dur) }, "");

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -768,17 +768,17 @@ program
         // let res = await cmd.run();
         let res = await cmd.runRaw();
         if (res.exitcode !== 0) {
-          // output = execSync(`kubectl top po -n pepr-system --no-headers`, {
-          //   encoding: "utf8",
-          //   env: { KUBECONFIG },
-          // });
-          log(`kubectl top output:\n${output}`);
           output = execSync(`kubectl get po -n pepr-system`, {
             encoding: "utf8",
             env: { KUBECONFIG },
           });
           log(`kubectl get po output:\n${output}`);
           log(`audience failed: ${res.stderr.join("\n")}`);
+          output = execSync(`kubectl top po -n pepr-system --no-headers`, {
+            encoding: "utf8",
+            env: { KUBECONFIG },
+          });
+          log(`kubectl top output:\n${output}`);
           return;
         }
 

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -818,6 +818,11 @@ program
           await audience();
         } catch (e) {
           log(`This comes from ticket`);
+          output = execSync(`kubectl describe po -n pepr-system`, {
+            encoding: "utf8",
+            env: { KUBECONFIG },
+          });
+          log(`kubectl describe po output:\n${output}`);
           console.error(e);
           // process.exit(1);
         }

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -496,7 +496,7 @@ program
         log(await cmd.run(), "");
 
         execSync(
-          `kubectl run curler --image=nginx:alpine --rm -it --restart=Never -n pepr-system --labels=zarf.dev/agent=ignore -- curl -k https://${SERVICE_NAME}/metrics`,
+          `kubectl run curler --image=nginx:alpine --rm --restart=Never -n pepr-system --labels=zarf.dev/agent=ignore -- curl -k https://${SERVICE_NAME}/metrics`,
           { stdio: "inherit" },
         );
 

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -791,7 +791,7 @@ program
       };
       let audienceReady = false;
       const audienceRetryStart = Date.now();
-      const audienceRetryMax = lib.toMs("5m");
+      const audienceRetryMax = lib.toMs("2m");
 
       while (!audienceReady) {
         try {

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -757,15 +757,6 @@ program
         let res = await cmd.runRaw();
         if (res.exitcode !== 0) {
           log(`audience failed: ${res.stderr.join("\n")}`);
-          let output = execSync(`kubectl get po -n pepr-system`, {
-            encoding: "utf8",
-            env: { KUBECONFIG },
-          });
-          log(`kubectl get po -n pepr-system output:\n${output}`);
-          output = execSync(`kubectl top po -n pepr-system --no-headers`, {
-            encoding: "utf8",
-            env: { KUBECONFIG },
-          });
           return;
         }
 

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -823,6 +823,13 @@ program
             env: { KUBECONFIG },
           });
           log(`kubectl describe po output:\n${output}`);
+          log(`Patch Pepr controller deployment to remove resource limits`);
+          cmd = new Cmd({
+            cmd: `kubectl patch deployment pepr-pepr-load-watcher -n pepr-system --type=json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}]'`,
+            env,
+          });
+          log({ cmd: cmd.cmd, env });
+          log(await cmd.run(), "");
           console.error(e);
           // process.exit(1);
         }

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -765,7 +765,12 @@ program
 
         cmd = new Cmd({ cmd: `kubectl top --namespace pepr-system pod --no-headers`, env });
         let req = { cmd: cmd.cmd, env };
-        let res = await cmd.run();
+        // let res = await cmd.run();
+        let res = await cmd.runRaw();
+        if (res.exitcode !== 0) {
+          log(`audience failed: ${res.stderr.join("\n")}`);
+          return;
+        }
 
         let outlines = res.stdout
           .filter(f => f)

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -482,7 +482,18 @@ program
 
     log(`Wait for metrics on the Pepr controller to become available`);
     const start = Date.now();
-    const max = lib.toMs("2m");
+    const max = lib.toMs("5m");
+    try {
+      const cmdDiag = new Cmd({ cmd: `kubectl top -n pepr-system`, env: { KUBECONFIG } });
+      const resultDiag = await cmdDiag.runRaw();
+      log("Diagnostic `kubectl top -n pepr-system` output:");
+      log(resultDiag.stdout.join("\n") || "(no stdout)");
+      log(resultDiag.stderr.join("\n") || "(no stderr)");
+      log(`Exit code: ${resultDiag.exitcode}`, "");
+    } catch (err) {
+      console.error("Error running `kubectl top -n pepr-system` diagnostic check:");
+      console.error(err);
+    }
     while (true) {
       const now = Date.now();
       const dur = now - start;

--- a/hack/load.cli.ts
+++ b/hack/load.cli.ts
@@ -756,17 +756,12 @@ program
         let req = { cmd: cmd.cmd, env };
         let res = await cmd.runRaw();
         if (res.exitcode !== 0) {
-          let output = execSync(`kubectl get po -n kube-system`, {
-            encoding: "utf8",
-            env: { KUBECONFIG },
-          });
-          log(`kubectl get po -n kube-system output:\n${output}`);
-          output = execSync(`kubectl get po -n pepr-system`, {
-            encoding: "utf8",
-            env: { KUBECONFIG },
-          });
-          log(`kubectl get po output:\n${output}`);
           log(`audience failed: ${res.stderr.join("\n")}`);
+          let output = execSync(`kubectl get po -n pepr-system`, {
+            encoding: "utf8",
+            env: { KUBECONFIG },
+          });
+          log(`kubectl get po -n pepr-system output:\n${output}`);
           output = execSync(`kubectl top po -n pepr-system --no-headers`, {
             encoding: "utf8",
             env: { KUBECONFIG },
@@ -786,7 +781,6 @@ program
         try {
           await audience();
         } catch (e) {
-          log(`This comes from ticket`);
           const output = execSync(`kubectl describe po -n pepr-system`, {
             encoding: "utf8",
             env: { KUBECONFIG },


### PR DESCRIPTION
## Description

Fixes the load test by removing the resources on the watch deployment which is crashing due to OOM. This adds debuggability by showing pods in the pepr-system space for next time this may happen and corrects the issue

[Load test](https://github.com/defenseunicorns/pepr/actions/runs/16350581696)

## Related Issue

Fixes #2418
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
