### PR TITLE
chore: exclude build-artifacts test in unit tests

### DIFF
--- a/config/vitest.root.config.ts
+++ b/config/vitest.root.config.ts
@@ -3,7 +3,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts", "hack/**/*.test.ts"],
-    exclude: ["node_modules", "dist", "pepr/**", "src/templates/**", "coverage"],
+    exclude: [
+      "node_modules",
+      "dist",
+      "pepr/**",
+      "src/templates/**",
+      "coverage",
+      "src/build-artifact.test.ts",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
## Description

The `build-artifacts` test runs during unit tests and constantly fails. This is because there must be an `npm run build` first to ensure the artifacts that the test is asserting against are present. The CI flow for running build artifacts tests does the build first but this test should be excluded from unit tests.

This came up when looking to address some PR comments in [2430](https://github.com/defenseunicorns/pepr/pull/2430)

```bash
> npm test 

> pepr@0.0.0-development test
> npm run test:unit && npm run test:journey && npm run test:journey-wasm


> pepr@0.0.0-development test:unit
> npm run gen-data-json && NODE_OPTIONS=--no-deprecation vitest --config config/vitest.root.config.ts run --coverage


> pepr@0.0.0-development gen-data-json
> node hack/build-template-data.js


 RUN  v3.2.4 /Users/cmwylie19/not-pepr/pepr
      Coverage enabled with v8

 ✓ src/lib/telemetry/metrics.test.ts (10 tests) 334ms
 ✓ src/lib/telemetry/logger.test.ts (7 tests) 192ms
 ✓ src/lib/core/queue.test.ts (6 tests) 127ms
 ✓ src/lib/core/storage.test.ts (17 tests) 101ms
 ✓ src/lib/tls.test.ts (1 test) 1613ms
   ✓ tls > genTLS should generate a valid TLSOut object  1612ms
 ✓ src/lib/filter/filter.test.ts (52 tests) 92ms
 ✓ src/lib/helpers.test.ts (60 tests) 308ms
 ✓ src/lib/filter/adjudication.test.ts (90 tests) 170ms
 ✓ src/lib/errors.test.ts (6 tests) 20ms
 ✓ src/lib/assets/loader.test.ts (3 tests) 33ms
 ❯ src/build-artifact.test.ts (4 tests | 3 failed) 2312ms
   ✓ Published package does not include unintended files > should not include files outside known paths 1ms
   × Published package does not include unintended files > when creating declaration files > should include declaration (.d.ts) files for each .ts file in dist/ 6ms
     → expected [ 'dist/cli.d.ts', …(84) ] to deeply equal []
   × Published package does not include unintended files > when creating declaration files > should include source map (.d.ts.map) files for each .ts file in dist/ 1ms
     → expected [ 'dist/cli.d.ts.map', …(84) ] to deeply equal []
   × Published package does not include unintended files > should warn the developer when lots of files are added to the build 200ms
     → [WARN] Expected file count to be within 15 of the last build, but got difference of 178 (this build: 101, latest: 279).
      If this is intentional, increase the 'warnThreshold' in this unit test.
      This test is a backstop to ensure developers do not accidentaly include unrelated build artifacts.

```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
