### PR TITLE
chore: add --yes to pepr kfc command

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -11,16 +11,16 @@ Type safe K8s middleware for humans
 
 **Commands:**
 
-  init [options]         Initialize a new Pepr Module
-  build [options]        Build a Pepr Module for deployment
-  deploy [options]       Deploy a Pepr Module
-  dev [options]          Setup a local webhook development environment
-  update [options]       Update this Pepr module. Not recommended for prod as it may change files.
-  format [options]       Lint and format this Pepr module
-  monitor [module-uuid]  Monitor a Pepr Module
-  uuid [uuid]            Module UUID(s) currently deployed in the cluster
-  kfc [args...]          Execute Kubernetes Fluent Client commands
-  crd                    Scaffold and generate Kubernetes CRDs from structured TypeScript definitions
+  init [options]           Initialize a new Pepr Module
+  build [options]          Build a Pepr Module for deployment
+  deploy [options]         Deploy a Pepr Module
+  dev [options]            Setup a local webhook development environment
+  update [options]         Update this Pepr module. Not recommended for prod as it may change files.
+  format [options]         Lint and format this Pepr module
+  monitor [module-uuid]    Monitor a Pepr Module
+  uuid [uuid]              Module UUID(s) currently deployed in the cluster
+  kfc [options] [args...]  Execute Kubernetes Fluent Client commands
+  crd                      Scaffold and generate Kubernetes CRDs from structured TypeScript definitions
 
 ## `npx pepr build`
 
@@ -145,6 +145,7 @@ Execute a `kubernetes-fluent-client` command. This command is a wrapper around `
 
 **Options:**
 
+- `-y, --yes` - Skip confirmation prompt.
 - `-h, --help` - display help for command
 
 Usage:

--- a/integration/cli/docs/docs.test.ts
+++ b/integration/cli/docs/docs.test.ts
@@ -32,8 +32,8 @@ describe("Pepr CLI Help Menu", () => {
         try {
           const { stdout, stderr } = await command();
           expect(stdout).toBeTruthy();
-          expect(stdout).toContain("-V, --version          output the version number");
-          expect(stdout).toContain("-h, --help             display help for command");
+          expect(stdout).toContain("-V, --version            output the version number");
+          expect(stdout).toContain("-h, --help               display help for command");
           expect(stderr).toBeFalsy();
           expect(stdout).toContain("Type safe K8s middleware for humans");
         } catch (error) {

--- a/integration/cli/docs/markdown.helper.test.ts
+++ b/integration/cli/docs/markdown.helper.test.ts
@@ -12,7 +12,7 @@ describe("getDocsForCommand", () => {
     { command: "dev", optionsCount: 3, subcommands: 0 },
     { command: "format", optionsCount: 2, subcommands: 0 },
     { command: "init", optionsCount: 7, subcommands: 0 },
-    { command: "kfc", optionsCount: 1, subcommands: 0 },
+    { command: "kfc", optionsCount: 2, subcommands: 0 },
     { command: "monitor", optionsCount: 1, subcommands: 0 },
     { command: "update", optionsCount: 2, subcommands: 0 },
     { command: "uuid", optionsCount: 1, subcommands: 0 },

--- a/src/cli/kfc.ts
+++ b/src/cli/kfc.ts
@@ -10,18 +10,22 @@ export default function (program: Command): void {
   program
     .command("kfc [args...]")
     .description("Execute Kubernetes Fluent Client commands")
-    .action(async (args: string[]) => {
-      const { confirm } = await prompt({
-        type: "confirm",
-        name: "confirm",
-        message:
-          "For commands that generate files, this may overwrite any previously generated files.\n" +
-          "Are you sure you want to continue?",
-      });
+    .option("-y, --yes", "Skip confirmation prompt.")
+    .action(async (args: string[], options) => {
+      // Skip confirmation if yes flag is provided
+      if (!options.yes) {
+        const { confirm } = await prompt({
+          type: "confirm",
+          name: "confirm",
+          message:
+            "For commands that generate files, this may overwrite any previously generated files.\n" +
+            "Are you sure you want to continue?",
+        });
 
-      // If the user doesn't confirm, exit
-      if (!confirm) {
-        return;
+        // If the user doesn't confirm, exit
+        if (!confirm) {
+          return;
+        }
       }
 
       try {


### PR DESCRIPTION
## Description

The `pepr kfc` command will prompt for user input before proceeding with KFC commands. To be consistent with the rest of Pepr, we should add support for `--yes` so a user can pre-approve this prompt.

## Related Issue

Relates to #2281

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
