### PR TITLE
chore: update flag name in help menu text

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -54,7 +54,7 @@ export function validateImagePullSecretDetails(details: ImagePullSecretDetails):
   if (missing.length > 0) {
     return {
       valid: false,
-      error: `Error: Must provide ${missing.join(", ")} when providing --pullSecret`,
+      error: `Error: Must provide ${missing.join(", ")} when providing --pull-secret`,
     };
   }
 


### PR DESCRIPTION
## Description

When users provide invalid input, the suggest help menu name is incorrect in our manually-crafted help message.

## Related Issue

Relates to #2281

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
