### PR TITLE
chore: build and tag the library in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,8 @@ jobs:
 
       - name: Push package to UDS OCI registry
         run: |
+          npm run set:version
+          npm run build
           VERSION=${{ github.ref_name }}
           oras push registry.defenseunicorns.com/pepr-dev/npm/pepr:${VERSION} \
             --artifact-type application/vnd.pepr.module.layer.v1 pepr-${VERSION:1}.tgz


### PR DESCRIPTION
## Description

Looks like the `npm pack` version of the Pepr cli and library was not available to push to the UDS Registry in the release.

This should fix it based on local testing, [initial error](https://github.com/defenseunicorns/pepr/actions/runs/16448564407/job/46487396991)

```bash
└─[0] <git:(main 75e0d99) > GITHUB_REF_NAME=v0.52.0 npm run set:version

> pepr@0.0.0-development set:version
> node scripts/set-version.js

┌─[cmwylie19@C2WY6FCQVX] - [~/pepr] - [2025-07-22 11:53:23]
└─[0] <git:(main 75e0d99) > npm run build

> pepr@0.52.0 prebuild
> rm -fr dist/* && npm run gen-data-json


> pepr@0.52.0 gen-data-json
> node hack/build-template-data.js


> pepr@0.52.0 build
> tsc -p config/tsconfig.root.json && node build.mjs && npm pack

npm notice total files: 316
npm notice
pepr-0.52.0.tgz
```
End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
