### PR TITLE
chore: add support for pod labels in helm chart

### DIFF
--- a/src/lib/assets/helm.ts
+++ b/src/lib/assets/helm.ts
@@ -93,6 +93,9 @@ export function watcherDeployTemplate(buildTimestamp: string, type: ControllerTy
             labels:
               app: {{ .Values.uuid }}-watcher
               pepr.dev/controller: watcher
+              {{- if .Values.watcher.podLabels }}
+              {{- toYaml .Values.watcher.podLabels | nindent 8 }}
+              {{- end }}
           spec:
             terminationGracePeriodSeconds: {{ .Values.watcher.terminationGracePeriodSeconds }}
             serviceAccountName: {{ .Values.uuid }}
@@ -189,6 +192,9 @@ export function admissionDeployTemplate(buildTimestamp: string, type: Controller
             labels:
               app: {{ .Values.uuid }}
               pepr.dev/controller: admission
+              {{- if .Values.admission.podLabels }}
+              {{- toYaml .Values.admission.podLabels | nindent 8 }}
+              {{- end }}
           spec:
             {{- if or .Values.admission.antiAffinity .Values.admission.affinity }}
             affinity:

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -100,6 +100,7 @@ export async function overridesFile(
         },
       },
       podAnnotations: {},
+      podLabels: {},
       nodeSelector: {},
       tolerations: [],
       extraVolumeMounts: [],
@@ -172,6 +173,7 @@ export async function overridesFile(
       extraVolumes: [],
       affinity: {},
       podAnnotations: {},
+      podLabels: {},
       serviceMonitor: {
         enabled: false,
         labels: {},


### PR DESCRIPTION
## Description

Adds support for specifying additional pod labels on the admission and watcher pods.

## Related Issue

Can open if necessary - this was a quick change just to allow some more flexibility with configuring other things that might require labelling pods (i.e. Istio configuration).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
