### PR TITLE
chore: release patch - npm i

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Push package to UDS OCI registry
         run: |
+          npm install
           npm run set:version
           npm run build
           VERSION=${{ github.ref_name }}


### PR DESCRIPTION
## Description

We are still having problems with the release into the UDS Registry. Which is strange because it works on nightlies. This is the latest release where it [failed](https://github.com/defenseunicorns/pepr/actions/runs/16472833346/job/46566498451) (seemingly no npm install). I'm going to do a little more research before taking this out of draft

**Update**
The only difference that I am seeing between the `release.yml` and the nightlies is an `npm install`

`nightlies.sh`
```bash
npm install 
npm run build

npm publish --tag "nightly"

# UDS Registry
oras push registry.defenseunicorns.com/pepr-dev/npm/pepr:"$FULL_VERSION" \
    --artifact-type application/vnd.pepr.module.layer.v1 pepr-"$FULL_VERSION".tgz
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
