### PR TITLE
chore: use pepr@latest in upgrade test

### DIFF
--- a/integration/cluster/upgrade.test.ts
+++ b/integration/cluster/upgrade.test.ts
@@ -31,18 +31,18 @@ describe("build", () => {
         "--yes",
         "--skip-post-init",
       ].join(" ");
-      execSync(`npx pepr@nightly init ${argz}`, {
+      execSync(`npx pepr@latest init ${argz}`, {
         cwd: workdir.path(),
         stdio: "inherit",
       });
     }, time.toMs("2m"));
 
     it(
-      "should prepare, build, and deploy hello-pepr with pepr@nightly",
+      "should prepare, build, and deploy hello-pepr with pepr@latest",
       { timeout: 1000 * 5 * 60 },
       async () => {
         await runWithErrorHandling(async () => {
-          await installPepr(testModule, "pepr@nightly");
+          await installPepr(testModule, "pepr@latest");
           await buildModule(testModule);
           await applyKubernetesManifest(testModule, id, "create");
           await waitForModuleDeployments(id);
@@ -111,10 +111,14 @@ async function applyKubernetesManifest(
   id: string,
   operation: "apply" | "create",
 ): Promise<void> {
-  execFileSync("kubectl", [operation, `--filename=${path.join(moduleDir, "dist", `pepr-module-${id}.yaml`)}`], {
-    cwd: moduleDir,
-    stdio: "inherit",
-  });
+  execFileSync(
+    "kubectl",
+    [operation, `--filename=${path.join(moduleDir, "dist", `pepr-module-${id}.yaml`)}`],
+    {
+      cwd: moduleDir,
+      stdio: "inherit",
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

Now that the CLI changes have landed, let's use `@latest` for tests again.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
