### PR TITLE
fix: variable-width table output for pepr uuid

### DIFF
--- a/journey/pepr-deploy.ts
+++ b/journey/pepr-deploy.ts
@@ -125,9 +125,11 @@ function testUUID() {
 
     // Check if the expected lines are in the output
     const expected = [
-      "UUID\t\tDescription",
-      "--------------------------------------------",
-      "static-test\t",
+      "┌─────────┬───────────────┬──────────────────────────┐",
+      "│ (index) │ UUID          │ Description              │",
+      "├─────────┼───────────────┼──────────────────────────┤",
+      "│ 0       │ 'static-test' │ 'A test module for Pepr' │",
+      "└─────────┴───────────────┴──────────────────────────┘",
     ].join("\n");
     expect(stdout).toMatch(expected);
   });
@@ -142,9 +144,11 @@ function testUUID() {
 
     // Check if the expected lines are in the output
     const expected = [
-      "UUID\t\tDescription",
-      "--------------------------------------------",
-      "static-test\t",
+      "┌─────────┬───────────────┬──────────────────────────┐",
+      "│ (index) │ UUID          │ Description              │",
+      "├─────────┼───────────────┼──────────────────────────┤",
+      "│ 0       │ 'static-test' │ 'A test module for Pepr' │",
+      "└─────────┴───────────────┴──────────────────────────┘",
     ].join("\n");
     expect(stdout).toMatch(expected);
   });

--- a/src/cli/uuid.test.ts
+++ b/src/cli/uuid.test.ts
@@ -127,29 +127,27 @@ describe("getPeprDeploymentsByUUID", () => {
 
 describe("uuid CLI command", () => {
   let program: Command;
-  let logSpy: ReturnType<typeof vi.spyOn>;
+  let tableSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     program = new Command();
     uuid(program);
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    tableSpy = vi.spyOn(console, "table").mockImplementation(() => {});
   });
 
-  it("should log UUID and description of all deployments with a UUID", async () => {
+  it("should display UUID table for all deployments with a UUID", async () => {
     await program.parseAsync(["uuid"], { from: "user" });
 
-    expect(logSpy).toHaveBeenCalledWith("UUID\t\tDescription");
-    expect(logSpy).toHaveBeenCalledWith("--------------------------------------------");
-    expect(logSpy).toHaveBeenCalledWith("1234\tTest annotation");
-    expect(logSpy).toHaveBeenCalledWith("asdf\tAnother annotation");
+    expect(tableSpy).toHaveBeenCalledWith([
+      { UUID: "1234", Description: "Test annotation" },
+      { UUID: "asdf", Description: "Another annotation" },
+    ]);
   });
 
-  it("should log UUID and description of a specific deployment with a matching UUID", async () => {
+  it("should display UUID table for a specific deployment with a matching UUID", async () => {
     await program.parseAsync(["uuid", "asdf"], { from: "user" });
-    expect(logSpy).toHaveBeenCalledWith("UUID\t\tDescription");
-    expect(logSpy).toHaveBeenCalledWith("--------------------------------------------");
-    expect(logSpy).toHaveBeenCalledWith("asdf\tAnother annotation");
-    expect(logSpy).not.toHaveBeenCalledWith("1234\tTest annotation");
+
+    expect(tableSpy).toHaveBeenCalledWith([{ UUID: "asdf", Description: "Another annotation" }]);
   });
 });

--- a/src/cli/uuid.ts
+++ b/src/cli/uuid.ts
@@ -13,12 +13,11 @@ export default function (program: Command): void {
       const deployments = await getPeprDeploymentsByUUID(uuid);
       const uuidTable = buildUUIDTable(deployments);
 
-      console.log("UUID\t\tDescription");
-      console.log("--------------------------------------------");
-
-      Object.entries(uuidTable).forEach(([uuid, description]) => {
-        console.log(`${uuid}\t${description}`);
-      });
+      const uuidTableEntries = Object.entries(uuidTable).map(([uuid, description]) => ({
+        UUID: uuid,
+        Description: description,
+      }));
+      console.table(uuidTableEntries);
     });
 }
 


### PR DESCRIPTION
## Description

Use `console.table()` to print the UUIDs for `pepr uuid`. Closes

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes  #2455  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
