### PR TITLE
chore: remove duplicate log messages caused by controller builds

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,9 +21,6 @@ if (process.env.npm_lifecycle_event !== "npx") {
   console.info("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
 
-process.env.PEPR_BUILD_LOGS_CALLED = "false";
-process.env.PEPR_DEPLOY_LOGS_CALLED = "false";
-
 const program = new Command();
 if (!process.env.PEPR_NODE_WARNINGS) {
   process.removeAllListeners("warning");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,9 @@ if (process.env.npm_lifecycle_event !== "npx") {
   console.info("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
 
+process.env.PEPR_BUILD_LOGS_CALLED = "false";
+process.env.PEPR_DEPLOY_LOGS_CALLED = "false";
+
 const program = new Command();
 if (!process.env.PEPR_NODE_WARNINGS) {
   process.removeAllListeners("warning");

--- a/src/lib/assets/assets.ts
+++ b/src/lib/assets/assets.ts
@@ -27,7 +27,7 @@ import { storeRole, storeRoleBinding, clusterRoleBinding, serviceAccount } from 
 import { tlsSecret, apiPathSecret } from "./networking";
 import { WebhookType } from "../enums";
 import { kind } from "kubernetes-fluent-client";
-
+import Log from "../telemetry/logger";
 export function norWatchOrAdmission(capabilities: CapabilityExport[]): boolean {
   return !isAdmission(capabilities) && !isWatcher(capabilities);
 }
@@ -134,6 +134,10 @@ export class Assets {
     imagePullSecret?: string,
   ): Promise<string> => {
     this.capabilities = await loadCapabilities(this.path);
+    this.capabilities.flatMap(capability => {
+      Log.info(`Module ${this.config.uuid} has capability: ${capability.name}`);
+      Log.info(`Registered Pepr Capability "${capability.name}"`);
+    });
     // give error if namespaces are not respected
     for (const capability of this.capabilities) {
       // until deployment, Pepr does not distinguish between watch and admission

--- a/src/lib/assets/loader.test.ts
+++ b/src/lib/assets/loader.test.ts
@@ -18,7 +18,7 @@ describe("loadCapabilities", () => {
       on: vi.fn(),
       send: vi.fn(),
     };
-
+    process.env.PEPR_DEPLOY_LOGS_CALLED = "false";
     (fork as vi.Mock).mockReturnValue(mockProcess);
     vi.spyOn(console, "info").mockImplementation(() => {});
   });

--- a/src/lib/assets/loader.test.ts
+++ b/src/lib/assets/loader.test.ts
@@ -18,7 +18,6 @@ describe("loadCapabilities", () => {
       on: vi.fn(),
       send: vi.fn(),
     };
-    process.env.PEPR_DEPLOY_LOGS_CALLED = "false";
     (fork as vi.Mock).mockReturnValue(mockProcess);
     vi.spyOn(console, "info").mockImplementation(() => {});
   });
@@ -57,8 +56,6 @@ describe("loadCapabilities", () => {
     const result = await loadCapabilities("/fake/path");
 
     expect(result).toEqual(mockCapabilities);
-    expect(console.info).toHaveBeenCalledWith('Registered Pepr Capability "TestCapability1"');
-    expect(console.info).toHaveBeenCalledWith('Registered Pepr Capability "TestCapability2"');
   });
 
   it("should reject with an error when the process encounters an error", async () => {

--- a/src/lib/assets/loader.ts
+++ b/src/lib/assets/loader.ts
@@ -27,14 +27,6 @@ export function loadCapabilities(path: string): Promise<CapabilityExport[]> {
       // Cast the message to the ModuleCapabilities type
       const capabilities = message.valueOf() as CapabilityExport[];
 
-      // Iterate through the capabilities and generate the rules
-      if (process.env.PEPR_DEPLOY_LOGS_CALLED === "false") {
-        for (const capability of capabilities) {
-          console.info(`Registered Pepr Capability "${capability.name}"`);
-        }
-      }
-      process.env.PEPR_DEPLOY_LOGS_CALLED = "true";
-
       resolve(capabilities);
     });
 

--- a/src/lib/assets/loader.ts
+++ b/src/lib/assets/loader.ts
@@ -28,9 +28,12 @@ export function loadCapabilities(path: string): Promise<CapabilityExport[]> {
       const capabilities = message.valueOf() as CapabilityExport[];
 
       // Iterate through the capabilities and generate the rules
-      for (const capability of capabilities) {
-        console.info(`Registered Pepr Capability "${capability.name}"`);
+      if (process.env.PEPR_DEPLOY_LOGS_CALLED === "false") {
+        for (const capability of capabilities) {
+          console.info(`Registered Pepr Capability "${capability.name}"`);
+        }
       }
+      process.env.PEPR_DEPLOY_LOGS_CALLED = "true";
 
       resolve(capabilities);
     });

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
-import { it, describe, expect, beforeEach, vi, beforeAll } from "vitest";
+import { it, describe, expect, beforeEach, vi } from "vitest";
 import {
   peprIgnoreNamespaces,
   validateRule,
@@ -13,7 +13,6 @@ import { Binding, CapabilityExport, ModuleConfig } from "../types";
 import { WebhookIgnore } from "../k8s";
 import { TLSOut } from "../tls";
 import { Assets } from "./assets";
-import Log from "../telemetry/logger";
 
 export type AssetsType = {
   name: string;
@@ -350,18 +349,6 @@ describe("Webhook Management", () => {
         assets.capabilities = [];
         const result = await generateWebhookRules(assets, true);
         expect(result).toEqual([]);
-      });
-    });
-
-    describe("when capabilities are present", () => {
-      beforeAll(() => {
-        process.env.PEPR_BUILD_LOGS_CALLED = "false";
-      });
-      it("should log information about module capabilities", async () => {
-        assets.capabilities = [...loseAssets.capabilities];
-        await generateWebhookRules(assets, true);
-        expect(Log.info).toHaveBeenCalledOnce();
-        expect(Log.info).toHaveBeenCalledWith("Module static-test has capability: hello-pepr");
       });
     });
   });

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -355,6 +355,7 @@ describe("Webhook Management", () => {
 
     describe("when capabilities are present", () => {
       it("should log information about module capabilities", async () => {
+        process.env.PEPR_BUILD_LOGS_CALLED = "false"; // Reset for test
         assets.capabilities = [...loseAssets.capabilities];
         await generateWebhookRules(assets, true);
         expect(Log.info).toHaveBeenCalledOnce();

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
-import { it, describe, expect, beforeEach, vi } from "vitest";
+import { it, describe, expect, beforeEach, vi, beforeAll } from "vitest";
 import {
   peprIgnoreNamespaces,
   validateRule,
@@ -354,8 +354,10 @@ describe("Webhook Management", () => {
     });
 
     describe("when capabilities are present", () => {
+      beforeAll(() => {
+        process.env.PEPR_BUILD_LOGS_CALLED = "false";
+      });
       it("should log information about module capabilities", async () => {
-        process.env.PEPR_BUILD_LOGS_CALLED = "false"; // Reset for test
         assets.capabilities = [...loseAssets.capabilities];
         await generateWebhookRules(assets, true);
         expect(Log.info).toHaveBeenCalledOnce();

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -50,12 +50,15 @@ export async function generateWebhookRules(
   const { config, capabilities } = assets;
 
   const rules = capabilities.flatMap(capability => {
-    Log.info(`Module ${config.uuid} has capability: ${capability.name}`);
+    if (process.env.PEPR_BUILD_LOGS_CALLED === "false") {
+      Log.info(`Module ${config.uuid} has capability: ${capability.name}`);
+    }
 
     return capability.bindings
       .map(binding => validateRule(binding, isMutateWebhook))
       .filter((rule): rule is V1RuleWithOperations => !!rule);
   });
+  process.env.PEPR_BUILD_LOGS_CALLED = "true";
 
   return uniqWith(equals, rules);
 }

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -12,7 +12,6 @@ import { resolveIgnoreNamespaces } from "./ignoredNamespaces";
 import { Assets } from "./assets";
 import { Event, WebhookType } from "../enums";
 import { Binding } from "../types";
-import Log from "../telemetry/logger";
 
 export const peprIgnoreNamespaces: string[] = ["kube-system", "pepr-system"];
 
@@ -47,18 +46,13 @@ export async function generateWebhookRules(
   assets: Assets,
   isMutateWebhook: boolean,
 ): Promise<V1RuleWithOperations[]> {
-  const { config, capabilities } = assets;
+  const { capabilities } = assets;
 
-  const rules = capabilities.flatMap(capability => {
-    if (process.env.PEPR_BUILD_LOGS_CALLED === "false") {
-      Log.info(`Module ${config.uuid} has capability: ${capability.name}`);
-    }
-
-    return capability.bindings
+  const rules = capabilities.flatMap(capability =>
+    capability.bindings
       .map(binding => validateRule(binding, isMutateWebhook))
-      .filter((rule): rule is V1RuleWithOperations => !!rule);
-  });
-  process.env.PEPR_BUILD_LOGS_CALLED = "true";
+      .filter((rule): rule is V1RuleWithOperations => !!rule),
+  );
 
   return uniqWith(equals, rules);
 }


### PR DESCRIPTION
## Description

The problems: 
- We have multiple controller builds (Watch and Admission) which use the same classes to build and deploy.
- We cannot move the logs further up in the class hierarchy  because we need to read the [capabilities first](https://github.com/defenseunicorns/pepr/blob/478192d9521bec13109bc98bdc0c182faef3df00/src/lib/assets/yaml/generateAllYaml.ts#L52) from the module secret.

This solution ensures that logs will be called for _all_ capabilities only once. 

```bash
> npx pepr build 
...
  dist/pepr-static-test.js.LEGAL.txt                                    256b   100.0%

Registered Pepr Capability "hello-pepr"
{"level":30,"time":1753885599771,"pid":98130,"hostname":"C2WY6FCQVX","msg":"Module static-test has capability: hello-pepr"}
K8s resource for the module saved to /Users/cmwylie19/pepr/pepr-test-module/dist/pepr-module-static-test.yaml

> npx tsx ../src/cli.ts deploy --yes
...
Registered Pepr Capability "hello-pepr"
...
{"level":30,"time":1753885627488,"pid":98305,"hostname":"C2WY6FCQVX","msg":"Module static-test has capability: hello-pepr"}
```

## Related Issue

Fixes #2487 
Fixes #2491
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
