### PR TITLE
chore: set appropriate logging levels so the info log-level is module-level logs

### DIFF
--- a/docs/120_contribute/README.md
+++ b/docs/120_contribute/README.md
@@ -73,6 +73,7 @@ Please follow the coding conventions and style used in the project. Use ESLint a
 - Check formatting: `npm run format:check`
 - Fix formatting: `npm run format:fix`
 - If regex is used, provide a link to regex101.com with an explanation of the regex pattern.
+- Do not use emoji in logs or comments, as it can be distracting and is not consistent with the project's style.
 
 ### Git Hooks
 

--- a/integration/cli/format.format.test.ts
+++ b/integration/cli/format.format.test.ts
@@ -70,7 +70,7 @@ describe("build", () => {
           expect(formatOutput.stderr.join("").trim()).toMatch(/File .* is not formatted correctly/);
           expect(formatOutput.stdout.join("").trim()).toContain("");
         },
-        time.toMs("15s"),
+        time.toMs("25s"),
       );
 
       it(
@@ -81,7 +81,7 @@ describe("build", () => {
           expect(formatOutput.stderr.join("").trim()).toMatch(/File .* is not formatted correctly/);
           expect(formatOutput.stdout.join("").trim()).toContain("");
         },
-        time.toMs("15s"),
+        time.toMs("25s"),
       );
     });
   });

--- a/src/lib/assets/deploy.ts
+++ b/src/lib/assets/deploy.ts
@@ -100,7 +100,7 @@ export async function deployWebhook(
   // Create the validating webhook configuration if it is needed
   await handleWebhookConfiguration(assets, WebhookType.VALIDATE, webhookTimeout, force);
 
-  Log.info("Applying the Pepr Store CRD if it doesn't exist");
+  Log.debug("Applying the Pepr Store CRD if it doesn't exist");
   await K8s(kind.CustomResourceDefinition).Apply(peprStoreCRD, { force });
 
   if (assets.host) return; // Skip resource deployment if a host is already specified

--- a/src/lib/assets/environment.test.ts
+++ b/src/lib/assets/environment.test.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect } from "vitest";
 import { ModuleConfig } from "../types";
-import { genEnv } from "./environment";
+import { genEnv, getLogLevel } from "./environment";
+
+describe("getLogLevel", () => {
+  it("returns the log level from environment variable if set", () => {
+    process.env.LOG_LEVEL = "debug";
+    const config: ModuleConfig = { uuid: "12345", alwaysIgnore: { namespaces: [] } };
+    const logLevel = getLogLevel(config);
+    expect(logLevel).toBe("debug");
+    delete process.env.LOG_LEVEL; // Clean up after test
+  });
+
+  it("returns the log level from config if environment variable is not set", () => {
+    const config: ModuleConfig = {
+      uuid: "12345",
+      logLevel: "info",
+      alwaysIgnore: { namespaces: [] },
+    };
+    const logLevel = getLogLevel(config);
+    expect(logLevel).toBe("info");
+  });
+});
 
 describe("genEnv", () => {
   it("generates default environment variables without watch mode", () => {

--- a/src/lib/assets/environment.ts
+++ b/src/lib/assets/environment.ts
@@ -1,6 +1,13 @@
 import { V1EnvVar } from "@kubernetes/client-node";
 import { ModuleConfig } from "../types";
 
+export function getLogLevel(config: ModuleConfig): string {
+  const fromEnv = process.env.LOG_LEVEL;
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return config.logLevel || "info";
+}
 export function genEnv(
   config: ModuleConfig,
   watchMode = false,
@@ -8,7 +15,7 @@ export function genEnv(
 ): V1EnvVar[] {
   const noWatchDef = {
     PEPR_PRETTY_LOG: "false",
-    LOG_LEVEL: config.logLevel || "info",
+    LOG_LEVEL: getLogLevel(config),
   };
 
   const def = {

--- a/src/lib/assets/loader.test.ts
+++ b/src/lib/assets/loader.test.ts
@@ -20,7 +20,7 @@ describe("loadCapabilities", () => {
     };
 
     (fork as vi.Mock).mockReturnValue(mockProcess);
-    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "debug").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -57,8 +57,8 @@ describe("loadCapabilities", () => {
     const result = await loadCapabilities("/fake/path");
 
     expect(result).toEqual(mockCapabilities);
-    expect(console.info).toHaveBeenCalledWith('Registered Pepr Capability "TestCapability1"');
-    expect(console.info).toHaveBeenCalledWith('Registered Pepr Capability "TestCapability2"');
+    expect(console.debug).toHaveBeenCalledWith('Registered Pepr Capability "TestCapability1"');
+    expect(console.debug).toHaveBeenCalledWith('Registered Pepr Capability "TestCapability2"');
   });
 
   it("should reject with an error when the process encounters an error", async () => {

--- a/src/lib/assets/loader.ts
+++ b/src/lib/assets/loader.ts
@@ -29,7 +29,7 @@ export function loadCapabilities(path: string): Promise<CapabilityExport[]> {
 
       // Iterate through the capabilities and generate the rules
       for (const capability of capabilities) {
-        console.info(`Registered Pepr Capability "${capability.name}"`);
+        console.debug(`Registered Pepr Capability "${capability.name}"`);
       }
 
       resolve(capabilities);

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -57,10 +57,10 @@ export class Controller {
       if (typeof onReady === "function") {
         onReady();
       }
-      Log.info("✅ Controller startup complete");
+      Log.debug("Controller startup complete");
       // Initialize the schedule store for each capability
       new StoreController(capabilities, `pepr-${config.uuid}-schedule`, () => {
-        Log.info("✅ Scheduling processed");
+        Log.debug("Scheduling processed");
       });
     });
 
@@ -112,7 +112,7 @@ export class Controller {
 
     // Handle server listening event
     server.on("listening", () => {
-      Log.info(`Server listening on port ${port}`);
+      Log.debug(`Server listening on port ${port}`);
       // Track that the server is running
       this.#running = true;
     });

--- a/src/lib/controller/store.test.ts
+++ b/src/lib/controller/store.test.ts
@@ -40,8 +40,10 @@ describe("StoreController", () => {
   };
 
   beforeEach(() => {
+    process.env.PEPR_LOG_LEVEL = "debug";
     vi.clearAllMocks(); // Clear all mocks before each test
     mockLog.info.mockClear(); // Explicitly clear the logger mock
+    mockLog.debug.mockClear();
     testCapability = new Capability(capabilityConfig);
     const mockImplementation = createMockImplementation();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -100,11 +102,12 @@ describe("StoreController", () => {
       vi.advanceTimersToNextTimer();
       await Promise.resolve();
 
-      const mockLogCalls = mockLog.info.mock.calls.flatMap(call => call);
-      expect(mockLogCalls).toEqual([
-        "Capability test-capability registered",
+      const mockLogCalls = mockLog.debug.mock.calls.flatMap(call => call);
+      expect(mockLogCalls[0]).toEqual("Capability test-capability registered");
+      expect(mockLogCalls[2]).toEqual(
         `Registering ${withSchedule ? "schedule " : ""}store for test-capability`,
-      ]);
+      );
+
       expect(mockK8s).toHaveBeenCalled();
       expect(controllerStore).toBeDefined();
       expect(mockLog.debug).toHaveBeenCalledWith(capabilityConfig);
@@ -117,8 +120,9 @@ describe("StoreController", () => {
       vi.advanceTimersToNextTimer();
       await Promise.resolve();
 
-      const mockLogCalls = mockLog.info.mock.calls.flatMap(call => call);
-      expect(mockLogCalls).toEqual(["Capability test-capability registered"]);
+      const mockLogCalls = mockLog.debug.mock.calls.flatMap(call => call);
+      expect(mockLogCalls[0]).toEqual("Capability test-capability registered");
+      expect(mockLogCalls[1].name).toEqual("test-capability");
       // K8s API calls verification
       expect(mockK8s).toHaveBeenCalled();
       // K8s(Store).Watch() mock - setupWatch

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -138,7 +138,7 @@ export class StoreController {
   };
 
   #createStoreResource = async (e: unknown): Promise<void> => {
-    Log.info(`Pepr store not found, creating...`);
+    Log.debug(`Pepr store not found, creating...`);
     Log.debug(e);
 
     try {

--- a/src/lib/core/capability.test.ts
+++ b/src/lib/core/capability.test.ts
@@ -110,7 +110,7 @@ describe("Capability", () => {
     expect(capability.name).toBe(capabilityConfig.name);
     expect(capability.description).toBe(capabilityConfig.description);
     expect(capability.namespaces).toEqual(capabilityConfig.namespaces);
-    expect(mockLog.info).toHaveBeenCalledWith(`Capability ${capabilityConfig.name} registered`);
+    expect(mockLog.debug).toHaveBeenCalledWith(`Capability ${capabilityConfig.name} registered`);
   });
 
   it("should register store and schedule store", () => {
@@ -118,11 +118,11 @@ describe("Capability", () => {
 
     const storeResult = capability.registerStore();
     expect(storeResult).toBeDefined();
-    expect(mockLog.info).toHaveBeenCalledWith(`Registering store for ${capabilityConfig.name}`);
+    expect(mockLog.debug).toHaveBeenCalledWith(`Registering store for ${capabilityConfig.name}`);
 
     const scheduleStoreResult = capability.registerScheduleStore();
     expect(scheduleStoreResult.onReady).toBeDefined();
-    expect(mockLog.info).toHaveBeenCalledWith(
+    expect(mockLog.debug).toHaveBeenCalledWith(
       `Registering schedule store for ${capabilityConfig.name}`,
     );
   });

--- a/src/lib/core/capability.ts
+++ b/src/lib/core/capability.ts
@@ -133,7 +133,7 @@ export class Capability implements CapabilityExport {
     this.#namespaces = cfg.namespaces;
     this.hasSchedule = false;
 
-    Log.info(`Capability ${this.#name} registered`);
+    Log.debug(`Capability ${this.#name} registered`);
     Log.debug(cfg);
   }
 
@@ -141,7 +141,7 @@ export class Capability implements CapabilityExport {
    * Register the store with the capability. This is called automatically by the Pepr controller.
    */
   registerScheduleStore = (): Storage => {
-    Log.info(`Registering schedule store for ${this.#name}`);
+    Log.debug(`Registering schedule store for ${this.#name}`);
 
     if (this.#scheduleRegistered) {
       throw new Error(`Schedule store already registered for ${this.#name}`);
@@ -159,7 +159,7 @@ export class Capability implements CapabilityExport {
    * @param store
    */
   registerStore = (): Storage => {
-    Log.info(`Registering store for ${this.#name}`);
+    Log.debug(`Registering store for ${this.#name}`);
 
     if (this.#registered) {
       throw new Error(`Store already registered for ${this.#name}`);

--- a/src/lib/core/module.test.ts
+++ b/src/lib/core/module.test.ts
@@ -128,7 +128,7 @@ describe("PeprModule", () => {
       process.send = vi.fn();
       const sendMock = vi.spyOn(process, "send");
       new PeprModule(mockPackageJSON, [capability]);
-      expect(Log.info).toHaveBeenCalledWith("Capability test registered");
+      expect(Log.debug).toHaveBeenCalledWith("Capability test registered");
       expect(sendMock).toHaveBeenCalledWith([expectedExport]);
     });
   });

--- a/src/runtime/controller.test.ts
+++ b/src/runtime/controller.test.ts
@@ -38,7 +38,7 @@ vi.mock("../lib/assets/store", () => ({
 }));
 vi.mock("../lib/telemetry/logger", () => ({
   default: {
-    info: vi.fn(),
+    debug: vi.fn(),
     error: vi.fn(),
   },
 }));

--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -38,7 +38,6 @@ function runModule(expectedHash: string): void {
     if (!crypto.timingSafeEqual(Buffer.from(expectedHash, "hex"), Buffer.from(actualHash, "hex"))) {
       throw new Error(`File hash does not match, expected ${expectedHash} but got ${actualHash}`);
     }
-
     Log.debug(`File hash matches, running module`);
 
     // Write the code to a file
@@ -55,7 +54,6 @@ export const startup = async (hash: string): Promise<void> => {
   try {
     Log.debug(`Pepr Controller (v${version})`);
     Log.debug("Applying the Pepr Store CRD if it doesn't exist");
-
     await K8s(kind.CustomResourceDefinition).Apply(peprStoreCRD, { force: true });
 
     validateHash(hash);

--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -41,7 +41,6 @@ function runModule(expectedHash: string): void {
 
     Log.debug(`File hash matches, running module`);
 
-
     // Write the code to a file
     fs.writeFileSync(jsPath, code);
 

--- a/src/runtime/controller.ts
+++ b/src/runtime/controller.ts
@@ -27,7 +27,7 @@ function runModule(expectedHash: string): void {
   }
 
   try {
-    Log.info(`Loading module ${gzPath}`);
+    Log.debug(`Loading module ${gzPath}`);
 
     // Extract the code from the file
     const codeGZ = fs.readFileSync(gzPath);
@@ -43,7 +43,7 @@ function runModule(expectedHash: string): void {
       throw new Error(`File hash does not match, expected ${expectedHash} but got ${actualHash}`);
     }
 
-    Log.info(`File hash matches, running module`);
+    Log.debug(`File hash matches, running module`);
 
     // Write the code to a file
     fs.writeFileSync(jsPath, code);
@@ -61,7 +61,7 @@ const hash = process.argv[2];
 
 const startup = async (): Promise<void> => {
   try {
-    Log.info("Applying the Pepr Store CRD if it doesn't exist");
+    Log.debug("Applying the Pepr Store CRD if it doesn't exist");
     await K8s(kind.CustomResourceDefinition).Apply(peprStoreCRD, { force: true });
 
     validateHash(hash);


### PR DESCRIPTION
## Description

The logs feel polluted with too much information when you are running a Pepr module which makes it hard to find the relevant information about watches, mutates, validates. 

I want to know what my _module_ is doing when I am running at LOG_LEVEL info, but I am not interested in the behavior or implementation details about the controllers themselves. If I feel like there is a problem in the controller, i would naturally turn the log level to debug. 

PEXEX PR -https://github.com/defenseunicorns/pepr-excellent-examples/pull/360

```bash
 ✓ capabilities/onschedule.e2e.test.ts (4 tests) 90964ms
   ✓ schedule.ts (4)
     ✓ runs forever  26347ms
     ✓ runs n times  15413ms
     ✓ runs once, asap  335ms
     ✓ runs once, delayed  317ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  10:32:01
```
## Related Issue

Fixes #2493 
Fixes #2495 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
