### PR TITLE
chore: improve 'pepr build' unit tests

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -36,7 +36,7 @@ Build a Pepr Module for deployment.
 - `-i, --custom-image <image>` - Specify a custom image with version for deployments. Conflicts with --registry-info and --registry. Example: 'docker.io/username/custom-pepr-controller:v1.0.0'
 - `-n, --no-embed` - Disable embedding of deployment files into output module. Useful when creating library modules intended solely for reuse/distribution via NPM.
 - `-o, --output <directory>` - Set output directory. (default: "dist")
-- `-r, --registry <GitHub|Iron Bank>` - Container registry: Choose container registry for deployment manifests. Conflicts with --custom-image and --registry-info. (choices: "GitHub", "Iron Bank")
+- `-r, --registry <registry>` - Container registry: Choose container registry for deployment manifests. Conflicts with --custom-image and --registry-info. (choices: "GitHub", "Iron Bank")
 - `-t, --timeout <seconds>` - How long the API server should wait for a webhook to respond before treating the call as a failure.
 - `-z, --zarf <manifest|chart>` - Set Zarf package type (choices: "manifest", "chart", default: "manifest")
 - `-h, --help` - display help for command

--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -113,15 +113,9 @@ export function checkIronBankImage(registry: string, image: string, peprVersion:
  * @param imagePullSecret
  * @returns boolean
  */
-export function validImagePullSecret(imagePullSecretName: string): void {
-  if (imagePullSecretName) {
-    const error = "Invalid imagePullSecret. Please provide a valid name as defined in RFC 1123.";
-    if (sanitizeResourceName(imagePullSecretName) !== imagePullSecretName) {
-      // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-      console.error(error);
-      process.exit(1);
-    }
-  }
+export function validImagePullSecret(imagePullSecretName: string): boolean {
+  // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+  return sanitizeResourceName(imagePullSecretName) === imagePullSecretName;
 }
 
 /**

--- a/src/cli/build/build.test.ts
+++ b/src/cli/build/build.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./build.helpers";
 
 import { createDirectoryIfNotExists } from "../../lib/filesystemService";
-import { expect, describe, it, vi, beforeEach, type MockInstance, afterEach } from "vitest";
+import { expect, describe, it, vi, beforeEach, type MockInstance } from "vitest";
 import { createDockerfile } from "../../lib/included-files";
 import { execSync } from "child_process";
 import { CapabilityExport } from "../../lib/types";
@@ -161,37 +161,20 @@ describe("checkIronBankImage", () => {
 });
 
 describe("validImagePullSecret", () => {
-  let consoleErrorSpy: MockInstance<(message?: unknown, ...optionalParams: unknown[]) => void>;
-  let mockExit: MockInstance<(code?: number | string | null | undefined) => never>;
-
-  beforeEach(() => {
-    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      return undefined as never;
-    });
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
   it("should not throw an error if the imagePullSecret is valid", () => {
     const imagePullSecret = "valid-secret";
-    validImagePullSecret(imagePullSecret);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-    expect(mockExit).not.toHaveBeenCalled();
+    const result = validImagePullSecret(imagePullSecret);
+    expect(result).toBe(true);
   });
   it("should not throw an error if the imagePullSecret is empty", () => {
     const imagePullSecret = "";
-    validImagePullSecret(imagePullSecret);
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-    expect(mockExit).not.toHaveBeenCalled();
+    const result = validImagePullSecret(imagePullSecret);
+    expect(result).toBe(true);
   });
   it("should throw an error if the imagePullSecret is invalid", () => {
     const imagePullSecret = "invalid name";
-    const error = "Invalid imagePullSecret. Please provide a valid name as defined in RFC 1123.";
-    validImagePullSecret(imagePullSecret);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
-    expect(mockExit).toHaveBeenCalled();
+    const result = validImagePullSecret(imagePullSecret);
+    expect(result).toBe(false);
   });
 });
 

--- a/src/cli/build/buildModule.ts
+++ b/src/cli/build/buildModule.ts
@@ -11,7 +11,7 @@ import { PeprConfig, Reloader } from "../types";
 import { BuildContext } from "esbuild";
 import { loadModule } from "./loadModule";
 
-type BuildModuleReturn = {
+export type BuildModuleReturn = {
   ctx: BuildContext<BuildOptions>;
   path: string;
   cfg: PeprConfig;

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -51,10 +51,11 @@ vi.mock("./build.helpers.ts", async () => {
 });
 
 describe("build CLI command", () => {
-  const program = new Command();
+  let program: Command;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    program = new Command();
     build(program);
   });
 
@@ -66,6 +67,21 @@ describe("build CLI command", () => {
     expect(generateYamlAndWriteToDisk).toBeCalled();
     expect(handleCustomImageBuild).not.toBeCalled();
     expect(handleValidCapabilityNames).toBeCalled();
+  });
+  describe("when conflicting options are used", () => {
+    it("should log an error and exit", async () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+      try {
+        await program.parseAsync(
+          ["build", "--custom-image", "some-image", "--registry", "some-registry"],
+          { from: "user" },
+        );
+      } catch {
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      }
+    });
   });
 });
 

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -134,23 +134,12 @@ describe("build CLI command", () => {
         "reject an invalid pull secret (%s)",
         async invalidSecret => {
           const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-          const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-            throw new Error("process.exit called");
-          });
-          try {
-            await expect(
-              program.parseAsync(["build", withPullSecretFlag, invalidSecret], { from: "user" }),
-            ).rejects.toThrowError(
-              "Invalid imagePullSecret. Please provide a valid name as defined in RFC 1123.",
-            );
-          } catch {
-            expect(stderrSpy).toHaveBeenCalledWith(
-              expect.stringContaining(
-                "Invalid imagePullSecret. Please provide a valid name as defined in RFC 1123.",
-              ),
-            );
-            expect(exitSpy).toHaveBeenCalledWith(1);
-          }
+          await expect(
+            program.parseAsync(["build", withPullSecretFlag, invalidSecret], { from: "user" }),
+          ).rejects.toThrowError('process.exit unexpectedly called with "1"');
+          expect(stderrSpy).toHaveBeenCalledWith(
+            "Invalid imagePullSecret. Please provide a valid name as defined in RFC 1123.",
+          );
         },
       );
     },
@@ -276,7 +265,7 @@ describe("build CLI command", () => {
     },
   ];
 
-  describe.only.each(flagTestCases)(
+  describe.each(flagTestCases)(
     "when the $name flag is set",
     ({
       name,

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -255,7 +255,7 @@ describe("build CLI command", () => {
   ];
 
   describe.each(flagTestCases)(
-    "when an option has a list of choices ($name)",
+    "when options are enumerated ($name)",
     ({ name, shortFlag, longFlag, validOptions, additionalInvalidInput }) => {
       describe.each([{ flag: shortFlag }, { flag: longFlag }])("$flag", ({ flag }) => {
         it.each(validOptions.map(opt => [opt]))(
@@ -271,7 +271,7 @@ describe("build CLI command", () => {
           expectMissingArgument(stderrSpy);
         });
 
-        it.only.each([
+        it.each([
           ["unsupported"],
           ...additionalInvalidInput.map(invalidOpt => [invalidOpt] as string[]),
         ])(`should reject unsupported ${name} values ('%s')`, async invalidInput => {
@@ -310,7 +310,7 @@ describe("build CLI command", () => {
     ],
   ];
   describe.each(conflictingOptions)(
-    "when $option and $conflict are set",
+    "when options conflict ($option and $conflict)",
     ({ option, optionValue, conflict, conflictValue }) => {
       it("should exit with code 1", async () => {
         await runProgramWithError([option, optionValue, conflict, conflictValue]);

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -6,9 +6,6 @@ import build from ".";
 import { it, expect, beforeEach, describe, vi, MockInstance } from "vitest";
 import { BuildContext, BuildOptions } from "esbuild";
 import { buildModule, BuildModuleReturn } from "./buildModule";
-// Import the module itself for spying
-import * as buildHelpers from "./build.helpers";
-// Destructure for convenience in the rest of the code
 import {
   createOutputDirectory,
   generateYamlAndWriteToDisk,
@@ -39,8 +36,6 @@ vi.mock("./buildModule.ts", async () => {
   } as unknown as BuildModuleReturn;
 });
 
-const assignImage = vi.spyOn(buildHelpers, "assignImage");
-
 vi.mock("./build.helpers.ts", async () => {
   const actual = await vi.importActual("./build.helpers.ts");
   return {
@@ -66,7 +61,6 @@ describe("build CLI command", () => {
 
   it("should call the Build command with default values", async () => {
     await runProgramWithArgs([]);
-    expect(assignImage).toHaveBeenCalledWith(expect.objectContaining({ customImage: undefined })); // This isn't the default?
     expect(buildModule).toBeCalled();
     expect(createOutputDirectory).toBeCalled();
     expect(generateYamlAndWriteToDisk).toBeCalled();
@@ -92,12 +86,6 @@ describe("build CLI command", () => {
       it("should include zero additional files in build", async () => {
         vi.spyOn(console, "info").mockImplementation(() => {});
         await runProgramWithArgs([registryInfoFlag, "organization/username"]);
-        expect(assignImage).toHaveBeenCalledWith(
-          expect.objectContaining({
-            customImage: undefined,
-            registryInfo: "organization/username",
-          }),
-        );
         expect(buildModule).toBeCalled();
         expect(createOutputDirectory).toBeCalled();
         expect(generateYamlAndWriteToDisk).toBeCalled();
@@ -115,9 +103,6 @@ describe("build CLI command", () => {
     withPullSecretFlag => {
       it("should do something", async () => {
         await runProgramWithArgs([withPullSecretFlag, "secret"]);
-        expect(assignImage).toHaveBeenCalledWith(
-          expect.objectContaining({ customImage: undefined }),
-        );
         expect(buildModule).toBeCalled();
         expect(createOutputDirectory).toBeCalled();
         expect(generateYamlAndWriteToDisk).toHaveBeenCalledWith(
@@ -141,7 +126,6 @@ describe("build CLI command", () => {
     it("should exit after building", async () => {
       vi.spyOn(console, "info").mockImplementation(() => {});
       await runProgramWithArgs([noEmbedFlag]);
-      expect(assignImage).toHaveBeenCalledWith(expect.objectContaining({ customImage: undefined }));
       expect(buildModule).toBeCalled();
       expect(createOutputDirectory).toBeCalled();
       expect(generateYamlAndWriteToDisk).not.toBeCalled();
@@ -154,7 +138,7 @@ describe("build CLI command", () => {
     customImageFlag => {
       it.each([["some-image"]])("should set the image to '%s'", async image => {
         await runProgramWithArgs([customImageFlag, image]);
-        expect(assignImage).toHaveBeenCalledWith(expect.objectContaining({ customImage: image }));
+        //TODO check this in assets instead?
         expect(buildModule).toBeCalled();
         expect(createOutputDirectory).toBeCalled();
         expect(generateYamlAndWriteToDisk).toBeCalled();
@@ -168,12 +152,12 @@ describe("build CLI command", () => {
   describe.each(["--timeout", "-t"])("when the timeout flag is set (%s)", timeoutFlag => {
     it("should accept a timeout in the supported range", async () => {
       await runProgramWithArgs([timeoutFlag, "10"]);
-      expect(assignImage).toBeCalled();
       expect(buildModule).toBeCalled();
       expect(createOutputDirectory).toBeCalled();
       expect(generateYamlAndWriteToDisk).toBeCalled();
       expect(handleCustomImageBuild).not.toBeCalled();
     });
+
     it.each([
       {
         value: "-1",

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -74,6 +74,33 @@ describe("build CLI command", () => {
     expect(handleValidCapabilityNames).toBeCalled();
   });
 
+  describe.each([["-I"], ["--registry-info"]])(
+    "when the registry info flag is set (%s)",
+    registryInfoFlag => {
+      // Does this actually do anything??
+      it("should include zero additional files in build", async () => {
+        vi.spyOn(console, "info").mockImplementation(() => {});
+        await program.parseAsync(["build", registryInfoFlag, "organization/username"], {
+          from: "user",
+        });
+        expect(assignImage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            customImage: undefined,
+            registryInfo: "organization/username",
+          }),
+        );
+        expect(buildModule).toBeCalled();
+        expect(createOutputDirectory).toBeCalled();
+        expect(generateYamlAndWriteToDisk).toBeCalled();
+        expect(handleCustomImageBuild).toBeCalled();
+        expect(handleValidCapabilityNames).toBeCalled();
+        expect(console.info).toHaveBeenCalledWith(
+          expect.stringContaining("Including 0 files in controller image."),
+        );
+      });
+    },
+  );
+
   describe.each([["-n"], ["--no-embed"]])("when the no embed flag is set (%s)", noEmbedFlag => {
     it("should exit after building", async () => {
       vi.spyOn(console, "info").mockImplementation(() => {});
@@ -211,7 +238,6 @@ describe("build CLI command", () => {
 // -I is not in "registry/username" format, can we validate it in .option()?
 // -P Can we validate in .option()? Or do earlier in the .action()?
 // When validImagePullSecret passes/fails
-// With and without -n for embed flag (log or not)
 // Needs package.json AND pepr.ts (entrypoint)
 
 // Mock Assets()

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -72,7 +72,20 @@ describe("build CLI command", () => {
     expect(generateYamlAndWriteToDisk).toBeCalled();
     expect(handleCustomImageBuild).not.toBeCalled();
     expect(handleValidCapabilityNames).toBeCalled();
+    expect(process.env.PEPR_CUSTOM_BUILD_NAME).toBeUndefined();
   });
+
+  describe.each([["-c"], ["--custom-name"]])(
+    "when the custom name flag is set (%s)",
+    customNameFlag => {
+      it("should set the PEPR_CUSTOM_BUILD_NAME envar", async () => {
+        await program.parseAsync(["build", customNameFlag, "name"], {
+          from: "user",
+        });
+        expect(process.env.PEPR_CUSTOM_BUILD_NAME).toBe("name");
+      });
+    },
+  );
 
   describe.each([["-I"], ["--registry-info"]])(
     "when the registry info flag is set (%s)",

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -138,7 +138,7 @@ describe("build CLI command", () => {
     customImageFlag => {
       it.each([["some-image"]])("should set the image to '%s'", async image => {
         await runProgramWithArgs([customImageFlag, image]);
-        //TODO check this in assets instead?
+        //TODO check this in assets instead of that the assignImage() function was called?
         expect(buildModule).toBeCalled();
         expect(createOutputDirectory).toBeCalled();
         expect(generateYamlAndWriteToDisk).toBeCalled();

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -1,8 +1,69 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { it, expect } from "vitest";
+import { Command } from "commander";
+import build from ".";
+import { it, expect, beforeEach, describe, vi } from "vitest";
+import { BuildContext, BuildOptions } from "esbuild";
+import { BuildModuleReturn } from "./buildModule";
 
-it.skip("should placeholder", () => {
-  expect(true).toBe(true);
+vi.mock("./buildModule", async () => {
+  return {
+    buildModule: vi.fn().mockResolvedValue({
+      path: "some/path",
+      uuid: "some-uuid",
+      ctx: {} as BuildContext<BuildOptions>,
+      cfg: {
+        description: "some description",
+        version: "some version",
+        pepr: {
+          uuid: "some-uuid",
+          peprVersion: "some version",
+          includedFiles: [],
+          alwaysIgnore: {
+            namespaces: [],
+          },
+          webhookTimeout: 30,
+          rbacMode: "admin",
+        },
+      },
+    }),
+  } as unknown as BuildModuleReturn;
 });
+
+describe("build CLI command", () => {
+  const program = new Command();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    build(program);
+  });
+
+  it("should call the Build command", async () => {
+    program.parseAsync(["build"], { from: "user" });
+    expect(build).toBeCalled();
+  });
+});
+
+// --custom-image AND --registry
+// --custom-image AND --registry-info
+// --registry AND --registry-info
+// -I is not in "registry/username" format, can we validate it in .option()?
+// -M is not "admin" or "scoped"
+// -P Can we validate in .option()? Or do earlier in the .action()?
+// When image is not ""
+// When timeout it less than 0 or more than 30 seconds (see src/lib/helpers:parseTimeout())
+// When validImagePullSecret passes/fails
+// With and without -n for embed flag (log or not)
+// Needs package.json AND pepr.ts (entrypoint)
+
+// Mock  buildModule()
+// Mock Assets()
+// Mock assignImage()
+// Mock generateYamlAndWriteToDisk()
+// Mock handleCustomImageBuild()
+// Mock handleValidCapabilityNames()
+
+// Entrypoint validation for non-file input? E.g., a directory -> Could have nicer error handling, not critical
+// Probably don't want to use PEPR_CUSTOM_BUILD_NAME envar
+// Use Log for logging instead of console

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -188,12 +188,7 @@ describe("build CLI command", () => {
       { value: "not-a-number", error: "Not a number.", description: "reject non-numeric values" },
       { value: "5.2", error: "Value must be an integer.", description: "reject float values" },
     ])("should $description: $value", async ({ value, error }) => {
-      try {
-        await expect(runProgramWithArgs([timeoutFlag, value])).rejects.toThrowError(error);
-        // await runProgramWithError([timeoutFlag, value], error);
-      } catch {
-        //TODO
-      }
+      await runProgramWithError([timeoutFlag, value], error);
     });
     // it("should reject float timeouts", async () => {
     //   await expect(program.parseAsync(["build", timeoutFlag, "5.0"], { from: "user" })).rejects.toThrowError("Value must be an integer.")

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -258,6 +258,23 @@ describe("build CLI command", () => {
     },
   );
 
+  describe.each([["-o"], ["--output"]])("when the output flag is set (%s)", outputFlag => {
+    it("should create the output directory", async () => {
+      await program.parseAsync(["build", outputFlag, "some-directory"], { from: "user" });
+      expect(createOutputDirectory).toBeCalled();
+    });
+
+    it("should require a value", async () => {
+      try {
+        await program.parseAsync(["build", outputFlag], { from: "user" });
+      } catch {
+        expect(stderrSpy).toHaveBeenCalledWith(
+          "error: option '-o, --output <directory>' argument missing\n",
+        );
+      }
+    });
+  });
+
   describe.each([["-z"], ["--zarf"]])("when the zarf flag is set (%s)", zarfFlag => {
     it.each([["manifest"], ["chart"]])(
       "should allow '%s' as the zarf package type",

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -12,6 +12,24 @@ import {
   handleCustomImageBuild,
 } from "./build.helpers";
 
+vi.mock("../../lib/tls.ts", async () => {
+  return {
+    ...vi.importActual("../../lib/tls.ts"),
+    genTLS: vi.fn().mockImplementation(() => {
+      return {
+        ca: "some-ca",
+        crt: "some-crt",
+        key: "some-key",
+        pem: {
+          ca: "some-ca",
+          crt: "some-crt",
+          key: "some-key",
+        },
+      };
+    }),
+  };
+});
+
 vi.mock("./buildModule.ts", async () => {
   return {
     buildModule: vi.fn().mockResolvedValue({

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -3,7 +3,7 @@
 
 import { Command } from "commander";
 import build from ".";
-import { it, expect, beforeEach, describe, vi } from "vitest";
+import { it, expect, beforeEach, describe, vi, MockInstance } from "vitest";
 import { BuildContext, BuildOptions } from "esbuild";
 import { buildModule, BuildModuleReturn } from "./buildModule";
 // Import the module itself for spying
@@ -198,11 +198,7 @@ describe("build CLI command", () => {
       try {
         await program.parseAsync(["build", rbacModeFlag, "unsupported"], { from: "user" });
       } catch {
-        expect(stderrSpy).toHaveBeenCalledWith(
-          expect.stringMatching(
-            /error: option .* argument .* is invalid\. Allowed choices are admin, scoped/,
-          ),
-        );
+        expectInvalidOption(stderrSpy, ["admin", "scoped"]);
         expect(exitSpy).toHaveBeenCalledWith(1);
       }
     });
@@ -292,11 +288,7 @@ describe("build CLI command", () => {
         try {
           await program.parseAsync(["build", registryFlag, registryName], { from: "user" });
         } catch {
-          expect(stderrSpy).toHaveBeenCalledWith(
-            expect.stringMatching(
-              /error: option .* argument .* is invalid\. Allowed choices are GitHub, Iron Bank\./,
-            ),
-          );
+          expectInvalidOption(stderrSpy, ["GitHub", "Iron Bank"]);
         }
       },
     );
@@ -312,11 +304,7 @@ describe("build CLI command", () => {
       try {
         await program.parseAsync(["build", registryFlag, "unsupported"], { from: "user" });
       } catch {
-        expect(stderrSpy).toHaveBeenCalledWith(
-          expect.stringMatching(
-            /error: option .* argument .* is invalid\. Allowed choices are GitHub, Iron Bank\./,
-          ),
-        );
+        expectInvalidOption(stderrSpy, ["GitHub", "Iron Bank"]);
       }
     });
   });
@@ -340,11 +328,7 @@ describe("build CLI command", () => {
       try {
         await program.parseAsync(["build", zarfFlag, "unsupported"], { from: "user" });
       } catch {
-        expect(stderrSpy).toHaveBeenCalledWith(
-          expect.stringMatching(
-            /error: option .* argument .* is invalid\. Allowed choices are manifest, chart\./,
-          ),
-        );
+        expectInvalidOption(stderrSpy, ["manifest", "chart"]);
       }
     });
   });
@@ -398,6 +382,15 @@ describe("build CLI command", () => {
       }
     });
   });
+  const expectInvalidOption = (outputSpy: MockInstance, options: string[]) => {
+    expect(outputSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(
+          `error: option .* argument .* is invalid. Allowed choices are ${options.join(", ")}.`,
+        ),
+      ),
+    );
+  };
   const expectMissingArgument = (outputSpy: MockInstance) => {
     expect(outputSpy).toHaveBeenCalledWith(
       expect.stringMatching(/error: option .* argument missing/),

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -232,7 +232,6 @@ describe("build CLI command", () => {
   describe.each([["-I"], ["--registry-info"]])(
     "when the registry info flag is set (%s)",
     registryInfoFlag => {
-      // Does this actually do anything??
       it("should include zero additional files in build", async () => {
         vi.spyOn(console, "info").mockImplementation(() => {});
         await runProgramWithArgs([registryInfoFlag, "organization/username"]);

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -5,9 +5,16 @@ import { Command } from "commander";
 import build from ".";
 import { it, expect, beforeEach, describe, vi } from "vitest";
 import { BuildContext, BuildOptions } from "esbuild";
-import { BuildModuleReturn } from "./buildModule";
+import { buildModule, BuildModuleReturn } from "./buildModule";
+import {
+  assignImage,
+  createOutputDirectory,
+  generateYamlAndWriteToDisk,
+  handleCustomImageBuild,
+  handleValidCapabilityNames,
+} from "./build.helpers";
 
-vi.mock("./buildModule", async () => {
+vi.mock("./buildModule.ts", async () => {
   return {
     buildModule: vi.fn().mockResolvedValue({
       path: "some/path",
@@ -31,8 +38,8 @@ vi.mock("./buildModule", async () => {
   } as unknown as BuildModuleReturn;
 });
 
-vi.mock("./build.helpers", async () => {
-  const actual = await vi.importActual("./build.helpers");
+vi.mock("./build.helpers.ts", async () => {
+  const actual = await vi.importActual("./build.helpers.ts");
   return {
     ...actual,
     assignImage: vi.fn().mockReturnValue("some-image"),
@@ -52,8 +59,13 @@ describe("build CLI command", () => {
   });
 
   it("should call the Build command", async () => {
-    program.parseAsync(["build"], { from: "user" });
-    expect(build).toBeCalled();
+    await program.parseAsync(["build"], { from: "user" });
+    expect(assignImage).toBeCalled();
+    expect(buildModule).toBeCalled();
+    expect(createOutputDirectory).toBeCalled();
+    expect(generateYamlAndWriteToDisk).toBeCalled();
+    expect(handleCustomImageBuild).not.toBeCalled();
+    expect(handleValidCapabilityNames).toBeCalled();
   });
 });
 

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -258,6 +258,34 @@ describe("build CLI command", () => {
     },
   );
 
+  describe.each([["-z"], ["--zarf"]])("when the zarf flag is set (%s)", zarfFlag => {
+    it.each([["manifest"], ["chart"]])(
+      "should allow '%s' as the zarf package type",
+      async zarfPackageType => {
+        await program.parseAsync(["build", zarfFlag, zarfPackageType], { from: "user" });
+        expect(generateYamlAndWriteToDisk).toBeCalled();
+      },
+    );
+    it("should require a value", async () => {
+      try {
+        await program.parseAsync(["build", zarfFlag], { from: "user" });
+      } catch {
+        expect(stderrSpy).toHaveBeenCalledWith(
+          "error: option '-z, --zarf <manifest|chart>' argument missing\n",
+        );
+      }
+    });
+    it("should reject unsupported zarf package types", async () => {
+      try {
+        await program.parseAsync(["build", zarfFlag, "unsupported"], { from: "user" });
+      } catch {
+        expect(stderrSpy).toHaveBeenCalledWith(
+          "error: option '-z, --zarf <manifest|chart>' argument 'unsupported' is invalid. Allowed choices are manifest, chart.\n",
+        );
+      }
+    });
+  });
+
   describe.each([
     [
       {
@@ -310,7 +338,6 @@ describe("build CLI command", () => {
 });
 // Add tests for -o, --output
 // Add tests for -r, --registry
-// Add tests for -z, --zarf
 
 // -I is not in "registry/username" format, can we validate it in .option()? We don't validate it at all
 // -P Can we validate in .option()? Or do earlier in the .action()?

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -239,6 +239,25 @@ describe("build CLI command", () => {
     // });
   });
 
+  describe.each([["-e"], ["--entry-point"]])(
+    "when the entry point flag is set (%s)",
+    entryPointFlag => {
+      it("should attempt to build the module", async () => {
+        await program.parseAsync(["build", entryPointFlag, "pepr.ts"], { from: "user" });
+        expect(buildModule).toBeCalled();
+      });
+      it("should require a value", async () => {
+        try {
+          await program.parseAsync(["build", entryPointFlag], { from: "user" });
+        } catch {
+          expect(stderrSpy).toHaveBeenCalledWith(
+            "error: option '-e, --entry-point <file>' argument missing\n",
+          );
+        }
+      });
+    },
+  );
+
   describe.each([
     [
       {
@@ -289,6 +308,9 @@ describe("build CLI command", () => {
     });
   });
 });
+// Add tests for -o, --output
+// Add tests for -r, --registry
+// Add tests for -z, --zarf
 
 // -I is not in "registry/username" format, can we validate it in .option()? We don't validate it at all
 // -P Can we validate in .option()? Or do earlier in the .action()?

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -64,7 +64,7 @@ describe("build CLI command", () => {
     stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
-  it("should call the Build command", async () => {
+  it("should call the Build command with default values", async () => {
     await program.parseAsync(["build"], { from: "user" });
     expect(assignImage).toHaveBeenCalledWith(expect.objectContaining({ customImage: undefined })); // This isn't the default?
     expect(buildModule).toBeCalled();
@@ -74,6 +74,19 @@ describe("build CLI command", () => {
     expect(handleValidCapabilityNames).toBeCalled();
   });
 
+  describe.each([["-n"], ["--no-embed"]])("when the no embed flag is set (%s)", noEmbedFlag => {
+    it("should exit after building", async () => {
+      vi.spyOn(console, "info").mockImplementation(() => {});
+      await program.parseAsync(["build", noEmbedFlag], { from: "user" });
+      expect(assignImage).toHaveBeenCalledWith(expect.objectContaining({ customImage: undefined }));
+      expect(buildModule).toBeCalled();
+      expect(createOutputDirectory).toBeCalled();
+      expect(generateYamlAndWriteToDisk).not.toBeCalled();
+      expect(handleCustomImageBuild).not.toBeCalled();
+      expect(handleValidCapabilityNames).not.toBeCalled();
+      expect(console.info).toHaveBeenCalledWith("Module built successfully at some/path");
+    });
+  });
   describe.each([["-i"], ["--custom-image"]])(
     "when the custom image flag is set (%s)",
     customImageFlag => {

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -31,6 +31,18 @@ vi.mock("./buildModule", async () => {
   } as unknown as BuildModuleReturn;
 });
 
+vi.mock("./build.helpers", async () => {
+  const actual = await vi.importActual("./build.helpers");
+  return {
+    ...actual,
+    assignImage: vi.fn().mockReturnValue("some-image"),
+    createOutputDirectory: vi.fn().mockReturnValue("some-output-dir"),
+    handleCustomImageBuild: vi.fn(),
+    handleValidCapabilityNames: vi.fn(),
+    generateYamlAndWriteToDisk: vi.fn(),
+  };
+});
+
 describe("build CLI command", () => {
   const program = new Command();
 
@@ -57,12 +69,7 @@ describe("build CLI command", () => {
 // With and without -n for embed flag (log or not)
 // Needs package.json AND pepr.ts (entrypoint)
 
-// Mock  buildModule()
 // Mock Assets()
-// Mock assignImage()
-// Mock generateYamlAndWriteToDisk()
-// Mock handleCustomImageBuild()
-// Mock handleValidCapabilityNames()
 
 // Entrypoint validation for non-file input? E.g., a directory -> Could have nicer error handling, not critical
 // Probably don't want to use PEPR_CUSTOM_BUILD_NAME envar

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -96,7 +96,7 @@ describe("build CLI command", () => {
         conflictValue: "value",
       },
     ],
-  ])("when %j are set", conflictingOptions => {
+  ])("when conflicting options are set %j", conflictingOptions => {
     it("should exit with code 1", async () => {
       const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
         throw new Error("process.exit called");

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -71,6 +71,25 @@ describe("build CLI command", () => {
     expect(handleValidCapabilityNames).toBeCalled();
   });
 
+  it.each([["-M"], ["--rbac-mode"]])(
+    "should reject unsupported RBAC modes (%s) ",
+    async rbacModeFlag => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+      try {
+        await program.parseAsync(["build", rbacModeFlag, "unsupported"], { from: "user" });
+      } catch {
+        expect(stderrSpy).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /error: option .* argument .* is invalid\. Allowed choices are admin, scoped/,
+          ),
+        );
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      }
+    },
+  );
+
   describe.each([
     [
       {

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -136,7 +136,11 @@ export default function (program: Command): void {
       if (image !== "") assets.image = image;
 
       // Ensure imagePullSecret is valid
-      validImagePullSecret(opts.withPullSecret);
+      if (!validImagePullSecret(opts.withPullSecret)) {
+        throw new Error(
+          "Invalid imagePullSecret. Please provide a valid name as defined in RFC 1123.",
+        );
+      }
 
       handleValidCapabilityNames(assets.capabilities);
       await generateYamlAndWriteToDisk({

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -15,6 +15,7 @@ import {
   generateYamlAndWriteToDisk,
 } from "./build.helpers";
 import { buildModule } from "./buildModule";
+import Log from "../../lib/telemetry/logger";
 
 export default function (program: Command): void {
   program
@@ -83,7 +84,7 @@ export default function (program: Command): void {
       const { cfg, path } = buildModuleResult!;
       // override the name if provided
       if (opts.customName) {
-        process.env.PEPR_CUSTOM_BUILD_NAME = opts.customName; // Would prefer to not use a random ENVAR
+        process.env.PEPR_CUSTOM_BUILD_NAME = opts.customName;
       }
 
       const image = assignImage({
@@ -99,7 +100,7 @@ export default function (program: Command): void {
       }
 
       if (opts.registryInfo !== undefined) {
-        console.info(`Including ${cfg.pepr.includedFiles.length} files in controller image.`);
+        Log.info(`Including ${cfg.pepr.includedFiles.length} files in controller image.`);
         // for journey test to make sure the image is built
 
         // only actually build/push if there are files to include
@@ -113,7 +114,7 @@ export default function (program: Command): void {
 
       // If building without embedding, exit after building
       if (!opts.embed) {
-        console.info(`Module built successfully at ${path}`);
+        Log.info(`Module built successfully at ${path}`);
         return;
       }
 

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -83,7 +83,7 @@ export default function (program: Command): void {
       const { cfg, path } = buildModuleResult!;
       // override the name if provided
       if (opts.customName) {
-        process.env.PEPR_CUSTOM_BUILD_NAME = opts.customName;
+        process.env.PEPR_CUSTOM_BUILD_NAME = opts.customName; // Would prefer to not use a random ENVAR
       }
 
       const image = assignImage({

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -53,7 +53,7 @@ export default function (program: Command): void {
     .option("-o, --output <directory>", "Set output directory.", "dist")
     .addOption(
       new Option(
-        "-r, --registry <GitHub|Iron Bank>",
+        "-r, --registry <registry>",
         "Container registry: Choose container registry for deployment manifests. Conflicts with --custom-image and --registry-info.",
       )
         .conflicts(["customImage", "registryInfo"])


### PR DESCRIPTION
## Description

This PR improves unit tests used in the `pepr build` command. In the interest of managing overall PR size, this is a partial improvement.

### Proposed State
```
 src/cli/build               |   51.85 |    95.45 |      75 |   51.85 |
  build.helpers.ts           |   60.16 |    96.55 |   77.77 |   60.16 | 92-94,163-220
  buildModule.ts             |       0 |      100 |     100 |       0 | 4-160
  index.ts                   |     100 |      100 |     100 |     100 |
  loadModule.ts              |       0 |        0 |       0 |       0 | 1-54
```
### Current state (`v0.52.3`)
```
 src/cli/build               |    21.1 |    93.33 |      75 |    21.1 |
  build.helpers.ts           |   62.01 |    96.29 |   77.77 |   62.01 | 92-94,169-226
  buildModule.ts             |       0 |      100 |     100 |       0 | 4-160
  index.ts                   |       0 |      100 |     100 |       0 | 4-150
  loadModule.ts              |       0 |        0 |       0 |       0 | 1-54
```

## Related Issue

Fixes #2394 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
