### PR TITLE
chore: Dependabot/GitHub actions/actions/download artifact 5.0.0 with trufflehog scan fix

### DIFF
--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo "PEPR_EXCELLENT_EXAMPLES_PATH=${GITHUB_WORKSPACE}/pepr-excellent-examples" >> "$GITHUB_ENV"
         
       - name: download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pepr-package-and-controller-image
           path: ${{ github.workspace }}

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -160,7 +160,7 @@ jobs:
         shell: bash
 
       - name: download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pepr-package-and-controller-image
           path: ${{ github.workspace }}

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -144,7 +144,7 @@ jobs:
         shell: bash
 
       - name: download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pepr-package-and-controller-image
           path: ${{ github.workspace }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,4 +25,38 @@ jobs:
     - name: Default Secret Scanning
       uses: trufflesecurity/trufflehog@ed6d045b46642d0d94a60bdf9b1246aefbcf3d35 # main
       with:
-        extra_args: --debug --only-verified
+        extra_args: --debug --only-verified --json
+      continue-on-error: true
+
+    - name: Filter Results by Date
+      shell: bash
+      run: |
+        mkdir -p /tmp/trufflehog
+        
+        # Process each line of the output
+        ${{ steps.scan.outputs.command }} | while read -r line; do
+          # Extract timestamp from each JSON object
+          timestamp=$(echo "$line" | jq -r '.SourceMetadata.Data.Github.timestamp // empty')
+          
+          # Check if timestamp exists and is after Aug 1, 2025
+          if [ -n "$timestamp" ]; then
+            # Convert timestamp to epoch seconds for comparison
+            ts_seconds=$(date -d "$timestamp" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S %z" "$timestamp" +%s 2>/dev/null)
+            cutoff_seconds=$(date -d "2025-08-01" +%s 2>/dev/null || date -j -f "%Y-%m-%d" "2025-08-01" +%s 2>/dev/null)
+            
+            # If timestamp is after cutoff, output the result
+            if [ "$ts_seconds" -gt "$cutoff_seconds" ]; then
+              echo "$line" >> /tmp/trufflehog/filtered_results.json
+            fi
+          fi
+        done
+        
+        # Display and handle results
+        if [ -s /tmp/trufflehog/filtered_results.json ]; then
+          echo "=== Secrets found after August 1, 2025 ==="
+          cat /tmp/trufflehog/filtered_results.json
+          echo "::error ::Found secrets after August 1, 2025!"
+          exit 1
+        else
+          echo "No secrets found after August 1, 2025"
+        fi

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Default Secret Scanning
       uses: trufflesecurity/trufflehog@ed6d045b46642d0d94a60bdf9b1246aefbcf3d35 # main
       with:
-        extra_args: --debug --no-verification # Warn on potential violations
+        extra_args: --debug --only-verified

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
 
       - name: dowload image tar artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pepr-img.tar
           path: ${{ github.workspace }}

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -119,13 +119,13 @@ jobs:
           uds version
 
       - name: download image tar artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pepr-img.tar
           path: ${{ github.workspace }}
 
       - name: download tgz artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pepr-0.0.0-development.tgz
           path: ${{ github.workspace }}


### PR DESCRIPTION
## Description

Related to #2509. This PR attempts to ignore unverified trufflehog results from early in the project's history.

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
