### PR TITLE
chore: optimize performance of `Assets` unit tests

### DIFF
--- a/src/lib/assets/assets.test.ts
+++ b/src/lib/assets/assets.test.ts
@@ -22,6 +22,25 @@ vi.mock("./yaml/overridesFile", () => ({
   overridesFile: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../lib/tls.ts", async () => {
+  // Crypto operations take time, so we mock for unit tests. See pepr/#2515
+  return {
+    ...vi.importActual("../../lib/tls.ts"),
+    genTLS: vi.fn().mockImplementation(() => {
+      return {
+        ca: "some-ca",
+        crt: "some-crt",
+        key: "some-key",
+        pem: {
+          ca: "some-ca",
+          crt: "some-crt",
+          key: "some-key",
+        },
+      };
+    }),
+  };
+});
+
 vi.mock("fs", async () => {
   const actualFs = await vi.importActual<typeof import("fs")>("fs");
 


### PR DESCRIPTION
## Description

This PR mocks the calls to `genTLS()` which adds extra execution time to unit tests without providing additional confidence in our code.

### Current state, local machine

Tests for the `Assets` class:
```
 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  10:57:00
   Duration  7.09s (transform 71ms, setup 0ms, collect 343ms, tests 6.14s, environment 0ms, prepare 42ms)
```
All unit tests:
```
 Test Files  73 passed | 2 skipped (75)
      Tests  1174 passed | 2 skipped (1176)
   Start at  11:00:00
   Duration  19.48s (transform 3.00s, setup 0ms, collect 62.69s, tests 31.97s, environment 34ms, prepare 11.95s)
```


### Proposed state, local machine

Tests for the `Assets` class:
```
 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  10:54:00
   Duration  311ms
```
All unit tests:
```
 Test Files  73 passed | 2 skipped (75)
      Tests  1174 passed | 2 skipped (1176)
   Start at  10:58:52
   Duration  7.05s (transform 2.78s, setup 0ms, collect 46.11s, tests 11.15s, environment 16ms, prepare 5.93s)
```

## Related Issue

Fixes #2515 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, [Journey](https://github.com/defenseunicorns/pepr/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/pepr-excellent-examples), [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
