### PR TITLE
chore: ignore pino 9.8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "pino"
+        versions: ["9.8.0"]
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Description


This version of dependabot has breaking changes. There was not breaking changes in the release notes which leads us to believe this is a false positive. We need this rule so we get other production dependencies merged into the code without having to manually create PRs

## Related Issue

Fixes #2528 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
