### PR TITLE
fix: use proper group for private image

### DIFF
--- a/src/lib/assets/k8sObjects.ts
+++ b/src/lib/assets/k8sObjects.ts
@@ -85,9 +85,9 @@ export function getWatcher(
           serviceAccountName: name,
           securityContext: {
             runAsUser: image.includes("private") ? 1000 : 65532,
-            runAsGroup: 65532,
+            runAsGroup: image.includes("private") ? 1000 : 65532,
             runAsNonRoot: true,
-            fsGroup: 65532,
+            fsGroup: image.includes("private") ? 1000 : 65532,
           },
           containers: [
             {
@@ -128,7 +128,7 @@ export function getWatcher(
               },
               securityContext: {
                 runAsUser: image.includes("private") ? 1000 : 65532,
-                runAsGroup: 65532,
+                runAsGroup: image.includes("private") ? 1000 : 65532,
                 runAsNonRoot: true,
                 allowPrivilegeEscalation: false,
                 capabilities: {
@@ -228,9 +228,9 @@ export function getDeployment(
           serviceAccountName: name,
           securityContext: {
             runAsUser: image.includes("private") ? 1000 : 65532,
-            runAsGroup: 65532,
+            runAsGroup: image.includes("private") ? 1000 : 65532,
             runAsNonRoot: true,
-            fsGroup: 65532,
+            fsGroup: image.includes("private") ? 1000 : 65532,
           },
           containers: [
             {
@@ -272,7 +272,7 @@ export function getDeployment(
               env: genEnv(config),
               securityContext: {
                 runAsUser: image.includes("private") ? 1000 : 65532,
-                runAsGroup: 65532,
+                runAsGroup: image.includes("private") ? 1000 : 65532,
                 runAsNonRoot: true,
                 allowPrivilegeEscalation: false,
                 capabilities: {

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -60,9 +60,9 @@ export async function overridesFile(
       },
       securityContext: {
         runAsUser: image.includes("private") ? 1000 : 65532,
-        runAsGroup: 65532,
+        runAsGroup: image.includes("private") ? 1000 : 65532,
         runAsNonRoot: true,
-        fsGroup: 65532,
+        fsGroup: image.includes("private") ? 1000 : 65532,
       },
       readinessProbe: {
         httpGet: {
@@ -92,7 +92,7 @@ export async function overridesFile(
       },
       containerSecurityContext: {
         runAsUser: image.includes("private") ? 1000 : 65532,
-        runAsGroup: 65532,
+        runAsGroup: image.includes("private") ? 1000 : 65532,
         runAsNonRoot: true,
         allowPrivilegeEscalation: false,
         capabilities: {
@@ -128,9 +128,9 @@ export async function overridesFile(
       },
       securityContext: {
         runAsUser: image.includes("private") ? 1000 : 65532,
-        runAsGroup: 65532,
+        runAsGroup: image.includes("private") ? 1000 : 65532,
         runAsNonRoot: true,
-        fsGroup: 65532,
+        fsGroup: image.includes("private") ? 1000 : 65532,
       },
       readinessProbe: {
         httpGet: {
@@ -160,7 +160,7 @@ export async function overridesFile(
       },
       containerSecurityContext: {
         runAsUser: image.includes("private") ? 1000 : 65532,
-        runAsGroup: 65532,
+        runAsGroup: image.includes("private") ? 1000 : 65532,
         runAsNonRoot: true,
         allowPrivilegeEscalation: false,
         capabilities: {


### PR DESCRIPTION
## Description

Currently the group used for the Pepr image is invalid (not present by default in the base image). While this doesn't appear to affect functionality, it seems easy enough to fix:
```console
groups: cannot find name for group ID 65532
node@pepr-uds-core-79fdd9ddb5-sxfrc:/app$ id
uid=1000(node) gid=65532 groups=65532
```

```console
❯ docker run -it --entrypoint id quay.io/rfcurated/node:24.5.0-jammy-fips-rfcurated
uid=1000(node) gid=1000(node) groups=1000(node)
```

As far as I can tell this should be a harmless change?

## Related Issue

Can open one if needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
