### PR TITLE
fix: ensure user input is at least one character long for the module uuid

### DIFF
--- a/src/cli/init/walkthrough.ts
+++ b/src/cli/init/walkthrough.ts
@@ -33,6 +33,9 @@ async function setUUID(uuid?: string): Promise<Answers<string>> {
     name: "uuid",
     message: "Enter a unique identifier for the new Pepr module.\n",
     validate: (val: string) => {
+      if (typeof val === "undefined" || val === "") {
+        return "The UUID must be at least 1 character long";
+      }
       return (
         val.length <= UUID_LENGTH_LIMIT ||
         `The UUID must be ${UUID_LENGTH_LIMIT} characters or fewer.`


### PR DESCRIPTION
## Description

This PR fixes an issue where users could enter a zero-length UUID when running `pepr init` without the use of the `--uuid` flag.

Users will now experience this if they enter nothing for the UUID:
```
❯ npx -y pepr@file://./pepr-0.0.0-development.tgz init --name pepr-upgrade-test --description desc --error-behavior ignore --skip-post-init
? Enter a unique identifier for the new Pepr module.
 › 
› The UUID must be at least 1 character long
```


## Related Issue

Relates to #2399 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
