### PR TITLE
chore: remove console logs and add SPDX comments

### DIFF
--- a/src/build-artifact.test.ts
+++ b/src/build-artifact.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
 import { describe, beforeAll, it, expect } from "vitest";
 import { execSync } from "child_process";
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,9 +16,9 @@ import { Command } from "commander";
 import update from "./cli/update";
 import kfc from "./cli/kfc";
 import crd from "./cli/crd";
-
+import Log from "./lib/telemetry/logger";
 if (process.env.npm_lifecycle_event !== "npx") {
-  console.info("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
+  Log.info("Pepr should be run via `npx pepr <command>` instead of `pepr <command>`.");
 }
 
 const program = new Command();
@@ -33,10 +33,10 @@ program
   .addCommand(init())
   .action(() => {
     if (program.args.length < 1) {
-      console.log(banner);
+      Log.info(banner);
       program.help();
     } else {
-      console.error(`Invalid command '${program.args.join(" ")}'\n`);
+      Log.error(`Invalid command '${program.args.join(" ")}'\n`);
       program.outputHelp();
       process.exitCode = 1;
     }

--- a/src/cli/dev.test.ts
+++ b/src/cli/dev.test.ts
@@ -7,6 +7,16 @@ import { promises as fs } from "fs";
 import prompts from "prompts";
 import devCommand from "./dev";
 import { EventEmitter } from "events";
+import Log from "../lib/telemetry/logger";
+
+vi.mock("../lib/telemetry/logger", () => ({
+  __esModule: true,
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 vi.mock("fs", async () => {
   const actual = await vi.importActual<typeof import("fs")>("fs");
@@ -125,7 +135,7 @@ describe("dev command", () => {
   });
 
   it("should log error if buildModule has errors", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(Log, "error").mockImplementation(() => {});
     const { buildModule } = await import("./build/buildModule");
     (buildModule as Mock).mockImplementationOnce(async (_, cb) => {
       await cb({ errors: ["error"] });
@@ -142,7 +152,7 @@ describe("dev command", () => {
       throw new Error("validation failed");
     });
 
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(Log, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("exit");
     });
@@ -158,7 +168,7 @@ describe("dev command", () => {
     const { validateCapabilityNames } = await import("../lib/helpers");
     (validateCapabilityNames as Mock).mockImplementation(() => {});
 
-    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(Log, "debug").mockImplementation(() => {});
     const processOnSpy = vi.spyOn(process, "on");
 
     await program.parseAsync(["dev", "--yes"], { from: "user" });

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -12,6 +12,7 @@ import { loadModule } from "./build/loadModule";
 import { deployWebhook } from "../lib/assets/deploy";
 import { promises as fs } from "fs";
 import { validateCapabilityNames } from "../lib/helpers";
+import Log from "../lib/telemetry/logger";
 
 export default function (program: Command): void {
   program
@@ -61,7 +62,7 @@ export default function (program: Command): void {
 
         // Run the processed javascript file
         const runFork = async (): Promise<void> => {
-          console.info(`Running module ${path}`);
+          Log.info(`Running module ${path}`);
 
           // Deploy the webhook with a 30 second timeout for debugging, don't force
           await webhook.deploy(deployWebhook, false, 30);
@@ -70,7 +71,7 @@ export default function (program: Command): void {
             // wait for capabilities to be loaded and test names
             validateCapabilityNames(webhook.capabilities);
           } catch (error) {
-            console.error(
+            Log.error(
               `CapabilityValidation Error - Unable to valide capability name(s) in: '${webhook.capabilities.map(item => item.name)}'\n${error}`,
             );
             process.exit(1);
@@ -100,13 +101,13 @@ export default function (program: Command): void {
 
           // listen for CTRL+C and remove webhooks
           process.on("SIGINT", () => {
-            console.debug(`Received SIGINT, removing webhooks`);
+            Log.debug(`Received SIGINT, removing webhooks`);
           });
         };
 
         await buildModule("dist", async r => {
           if (r.errors.length > 0) {
-            console.error(`Error compiling module: ${r.errors}`);
+            Log.error(`Error compiling module: ${r.errors}`);
             return;
           }
 
@@ -118,7 +119,7 @@ export default function (program: Command): void {
           }
         });
       } catch (e) {
-        console.error(`Error deploying module:`, e);
+        Log.error(`Error deploying module:`, e);
         process.exit(1);
       }
     });

--- a/src/cli/init/createProjectFiles.ts
+++ b/src/cli/init/createProjectFiles.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
 import { resolve } from "path/posix";
 import {
   peprPackageJSON,

--- a/src/cli/init/doPostInitActions.ts
+++ b/src/cli/init/doPostInitActions.ts
@@ -1,5 +1,8 @@
-import { execSync } from "child_process";
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
+import { execSync } from "child_process";
+import Log from "../../lib/telemetry/logger";
 export const doPostInitActions = (dirName: string): void => {
   // run npm install from the new directory
   process.chdir(dirName);
@@ -18,6 +21,6 @@ export const doPostInitActions = (dirName: string): void => {
       stdio: "inherit",
     });
   } catch {
-    console.warn("VSCode was not found, IDE will not automatically open.");
+    Log.warn("VSCode was not found, IDE will not automatically open.");
   }
 };

--- a/src/cli/kfc.test.ts
+++ b/src/cli/kfc.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Command } from "commander";
 import kfcCommand from "./kfc";
+import Log from "../lib/telemetry/logger";
 
 vi.mock("child_process", () => ({
   execSync: vi.fn(),
@@ -11,7 +12,12 @@ vi.mock("child_process", () => ({
 vi.mock("prompts", () => ({
   default: vi.fn(),
 }));
-
+vi.mock("../lib/telemetry/logger", () => ({
+  __esModule: true,
+  default: {
+    error: vi.fn(),
+  },
+}));
 import { execSync } from "child_process";
 import prompts from "prompts";
 
@@ -95,7 +101,7 @@ describe("kfc CLI command", () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");
     });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(Log, "error").mockImplementation(() => {});
 
     const command = program.commands.find(c => c.name() === "kfc");
 

--- a/src/cli/kfc.ts
+++ b/src/cli/kfc.ts
@@ -3,7 +3,7 @@
 
 import { execSync } from "child_process";
 import prompt from "prompts";
-
+import Log from "../lib/telemetry/logger";
 import { Command } from "commander";
 
 export default function (program: Command): void {
@@ -42,7 +42,7 @@ export default function (program: Command): void {
           stdio: "inherit",
         });
       } catch (e) {
-        console.error(`Error creating CRD generated class:`, e);
+        Log.error(`Error creating CRD generated class:`, e);
         process.exit(1);
       }
     });

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -6,7 +6,7 @@ import { K8s, kind } from "kubernetes-fluent-client";
 import stream from "stream";
 import { ResponseItem } from "../lib/types";
 import { Command } from "commander";
-
+import Log from "../lib/telemetry/logger";
 interface LogPayload {
   namespace: string;
   name: string;
@@ -39,7 +39,7 @@ export default function (program: Command): void {
       const podNames: string[] = pods.items.flatMap(pod => pod.metadata!.name || "");
 
       if (podNames.length < 1) {
-        console.error(errorMessage);
+        Log.error(errorMessage);
         process.exit(1);
       }
 
@@ -122,9 +122,9 @@ export function processMutateLog(payload: LogPayload, name: string, uid: string)
   const patchType = payload.res.patchType || payload.res.warnings || "";
   const allowOrDeny = payload.res.allowed ? "🔀" : "🚫";
 
-  console.log(`\n${allowOrDeny}  MUTATE     ${name} (${uid})`);
+  Log.info(`\n${allowOrDeny}  MUTATE     ${name} (${uid})`);
   if (patchType.length > 0) {
-    console.log(`\n\u001b[1;34m${patch}\u001b[0m`);
+    Log.info(`\n\u001b[1;34m${patch}\u001b[0m`);
   }
 }
 
@@ -135,8 +135,8 @@ export function processValidateLog(payload: LogPayload, name: string, uid: strin
     .filter((r: ResponseItem) => !r.allowed)
     .map((r: ResponseItem) => r.status?.message || "");
 
-  console.log(`\n${filteredFailures.length > 0 ? "❌" : "✅"}  VALIDATE   ${name} (${uid})`);
+  Log.info(`\n${filteredFailures.length > 0 ? "❌" : "✅"}  VALIDATE   ${name} (${uid})`);
   if (filteredFailures.length > 0) {
-    console.log(`\u001b[1;31m${filteredFailures}\u001b[0m`);
+    Log.info(`\u001b[1;31m${filteredFailures}\u001b[0m`);
   }
 }


### PR DESCRIPTION
## Description

Switches the console logs to Pino logger for standardization across the project. The console.table needs to stay because there is not an equivalent pino command. 


```bash
> grep "console.*(" src/cli/*.ts --exclude=\*.test.ts
src/cli/uuid.ts:      console.table(uuidTableEntries)
```

## Related Issue

Fixes #2537
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
