### PR TITLE
chore: only bump kfc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "heredoc": "^1.3.1",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "3.10.0",
+        "kubernetes-fluent-client": "3.10.1",
         "pino": "9.7.0",
         "pino-pretty": "13.1.1",
         "prom-client": "15.1.3",
@@ -5396,9 +5396,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.0.tgz",
-      "integrity": "sha512-bSN4eaoJ/AObg8ikglpgyyEgU+ruU11CyhoWn8KR+m0ERje/duIKmmYphXoSTvp3E3S8wf5laDXJJOhjM4pXSg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.1.tgz",
+      "integrity": "sha512-jz2p/nc9EX1egNZjdSUuSqj+Ux5gPgx3/3Cis+KBJ39eFKWBYnBEQSbjjm1irJH/UG/cdsJAy6C2nhGGlPobOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "heredoc": "^1.3.1",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "3.10.0",
+    "kubernetes-fluent-client": "3.10.1",
     "pino": "9.7.0",
     "pino-pretty": "13.1.1",
     "prom-client": "15.1.3",


### PR DESCRIPTION
## Description

Today is our release day and our production dependencies were bumped but it appears as though Pino still has breaking changes. However, we have not brought in a new version of KFC into Pepr for over 2 weeks so we need to jump bump KFC until more work can be done in Pino

## Related Issue

Fixes #
<!-- or -->
Relates to #https://github.com/defenseunicorns/pepr/pull/2558#pullrequestreview-3132309169

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
