### PR TITLE
chore: curl with retries and backoff

### DIFF
--- a/.github/actions/ironbank-setup/action.yaml
+++ b/.github/actions/ironbank-setup/action.yaml
@@ -21,7 +21,7 @@ runs:
 
     - name: Install k3d
       shell: bash
-      run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+      run: curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
     - name: Iron Bank Login
       if: ${{ inputs.registry1Username != '' }}

--- a/.github/workflows/deploy-helm.yml
+++ b/.github/workflows/deploy-helm.yml
@@ -24,7 +24,7 @@ jobs:
           version: 'latest'
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: clone pepr

--- a/.github/workflows/deploy-zarf.yml
+++ b/.github/workflows/deploy-zarf.yml
@@ -27,7 +27,7 @@ jobs:
           version: 'latest'
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: Install The Latest Release Version of Zarf

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -17,7 +17,7 @@ jobs:
           egress-policy: audit
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: clone pepr

--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -95,7 +95,7 @@ jobs:
           node-version: 22
           cache: "npm"
       - name: "Install K3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
       - name: Setup Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: Clone Pepr Excellent Examples

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -156,7 +156,7 @@ jobs:
           egress-policy: audit
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: download artifacts

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -140,7 +140,7 @@ jobs:
           egress-policy: audit
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: download artifacts

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: dowload image tar artifact

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -82,7 +82,7 @@ jobs:
           egress-policy: audit
 
       - name: "install k3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/upgrade-unicorn.yml
+++ b/.github/workflows/upgrade-unicorn.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "npm"
 
       - name: "Install K3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - name: Rapidfort Login

--- a/.github/workflows/upgrade-upstream.yml
+++ b/.github/workflows/upgrade-upstream.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "npm"
 
       - name: "Install K3d"
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
         shell: bash
 
       - run: npm ci


### PR DESCRIPTION
## Description

Yesterday we realized the test flakes were not actually running the tests, they were failing to install k3d. This PR adds exponential backoff to the curl command that installs k3d

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
