### PR TITLE
chore: validate failurepolicy

### DIFF
--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -7,6 +7,7 @@ import {
   generateWebhookRules,
   webhookConfigGenerator,
   configureAdditionalWebhooks,
+  checkFailurePolicy,
 } from "./webhooks";
 import { Event, WebhookType } from "../enums";
 import { kind } from "kubernetes-fluent-client";
@@ -448,5 +449,18 @@ describe("configureAdditionalWebhooks", () => {
     );
     expect(result.webhooks![1].failurePolicy).toBe("Fail");
     expect(result.webhooks![2].failurePolicy).toBe("Ignore");
+  });
+});
+
+describe("checkFailurePolicy", () => {
+  it("should throw an error for invalid failure policies", () => {
+    expect(() => checkFailurePolicy("InvalidPolicy")).toThrowError(
+      "Invalid failure policy: InvalidPolicy. Must be either 'Fail' or 'Ignore'.",
+    );
+  });
+
+  it("should return the failure policy for valid policies", () => {
+    expect(checkFailurePolicy("Fail")).not.toThrowError();
+    expect(checkFailurePolicy("Ignore")).not.toThrowError();
   });
 });

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -460,7 +460,7 @@ describe("checkFailurePolicy", () => {
   });
 
   it("should return the failure policy for valid policies", () => {
-    expect(checkFailurePolicy("Fail")).not.toThrowError();
-    expect(checkFailurePolicy("Ignore")).not.toThrowError();
+    expect(() => checkFailurePolicy("Fail")).not.toThrowError();
+    expect(() => checkFailurePolicy("Ignore")).not.toThrowError();
   });
 });

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -142,6 +142,12 @@ export async function webhookConfigGenerator(
   return webhookConfig;
 }
 
+export function checkFailurePolicy(failurePolicy: string): void {
+  if (failurePolicy !== "Fail" && failurePolicy !== "Ignore") {
+    throw new Error(`Invalid failure policy: ${failurePolicy}. Must be either 'Fail' or 'Ignore'.`);
+  }
+}
+
 export function configureAdditionalWebhooks(
   webhookConfig: V1MutatingWebhookConfiguration | V1ValidatingWebhookConfiguration,
   additionalWebhooks: AdditionalWebhook[],
@@ -158,6 +164,7 @@ export function configureAdditionalWebhooks(
   expr.values!.push(...additionalWebhooks.map(w => w.namespace));
 
   additionalWebhooks.forEach(additionalWebhook => {
+    checkFailurePolicy(additionalWebhook.failurePolicy);
     webhooks.push({
       name: `${webhookConfig.metadata!.name}-${additionalWebhook.namespace}.pepr.dev`,
       admissionReviewVersions: ["v1", "v1beta1"],


### PR DESCRIPTION
## Description

validate that the user input failure policy complies with failurePolicy types

Example: 
```json
    "additionalWebhooks": [{"failurePolicy": "Wrong", "namespace": "example-namespace"}],
```

build result:
```plaintext
Error generating YAML: Error: Invalid failure policy: Wrong. Must be either 'Fail' or 'Ignore'.
[11:08:55.104] INFO (53365): Module uds-core has capability: uds-core-operator
[11:08:55.104] INFO (53365): Registered Pepr Capability "uds-core-operator"
[11:08:55.104] INFO (53365): Module uds-core has capability: uds-core-policies
[11:08:55.104] INFO (53365): Registered Pepr Capability "uds-core-policies"
[11:08:55.104] INFO (53365): Module uds-core has capability: prometheus
[11:08:55.104] INFO (53365): Registered Pepr Capability "prometheus"
[11:08:55.104] INFO (53365): Module uds-core has capability: patches
[11:08:55.104] INFO (53365): Registered Pepr Capability "patches"
┌─[cmwylie19@C2WY6FCQVX] - [~/uds-core] - [2025-08-21 11:08:56]
└─[1] <git:(main 1faae26e) > echo $?                                    
1
```
## Related Issue

Fixes #2568
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
