### PR TITLE
chore: lower warn threshold for changed files after release

### DIFF
--- a/src/build-artifact.test.ts
+++ b/src/build-artifact.test.ts
@@ -66,7 +66,7 @@ describe("Published package does not include unintended files", () => {
 
     const latestFileCount = await getPublishedFileCount("pepr");
     const diff = Math.abs(packedFiles.length - latestFileCount);
-    const warnThreshold = 18;
+    const warnThreshold = 15;
     if (diff > warnThreshold) {
       const message = `[WARN] Expected file count to be within ${warnThreshold} of the last build, but got difference of ${diff} (this build: ${packedFiles.length}, latest: ${latestFileCount}).
       If this is intentional, increase the 'warnThreshold' in this unit test.


### PR DESCRIPTION
## Description

This PR lowers the warn threshold back to 15 following a release of Pepr that included changes to lots of files.

We use this warning to prevent us from unintentionally including irrelevant files in the build and to encourage us to keep the scope of work small by default.

## Related Issue

None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
