### PR TITLE
chore: account for missing entrypoint

### DIFF
--- a/docs/030_user-guide/010_pepr-cli.md
+++ b/docs/030_user-guide/010_pepr-cli.md
@@ -32,7 +32,7 @@ Build a Pepr Module for deployment.
 - `-I, --registry-info <registry/username>` - Provide the image registry and username for building and pushing a custom WASM container. Requires authentication. Conflicts with --custom-image and --registry. Builds and pushes `'<registry/username>/custom-pepr-controller:<current-version>'`.
 - `-P, --with-pull-secret <name>` - Use image pull secret for controller Deployment. (default: "")
 - `-c, --custom-name <name>` - Set name for zarf component and service monitors in helm charts.
-- `-e, --entry-point <file>` - Specify the entry point file to build with. (default: "pepr.ts")
+- `-e, --entry-point <file>` - Specify the entry point file to build with. (default: pepr.ts)
 - `-i, --custom-image <image>` - Specify a custom image with version for deployments. Conflicts with --registry-info and --registry. Example: 'docker.io/username/custom-pepr-controller:v1.0.0'
 - `-n, --no-embed` - Disable embedding of deployment files into output module. Useful when creating library modules intended solely for reuse/distribution via NPM.
 - `-o, --output <directory>` - Set output directory. (default: "dist")

--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -30,7 +30,7 @@ export function fileExists(entryPoint: string = "pepr.ts"): string {
   try {
     accessSync(resolve(entryPoint), constants.F_OK);
   } catch {
-    console.error(
+    Log.error(
       `The entry-point option requires a file (e.g., pepr.ts), ${entryPoint} is not a file`,
     );
     process.exit(1);

--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -7,7 +7,7 @@ import { validateCapabilityNames } from "../../lib/helpers";
 import { BuildOptions, context, BuildContext } from "esbuild";
 import { Assets } from "../../lib/assets/assets";
 import { resolve } from "path";
-import { promises as fs } from "fs";
+import { promises as fs, accessSync, constants } from "fs";
 import { generateAllYaml } from "../../lib/assets/yaml/generateAllYaml";
 import { webhookConfigGenerator } from "../../lib/assets/webhooks";
 import { generateZarfYamlGeneric } from "../../lib/assets/yaml/generateZarfYaml";
@@ -19,6 +19,22 @@ import {
   watcherService,
 } from "../../lib/assets/k8sObjects";
 import { Reloader } from "../types";
+
+/**
+ * Check if a file exists at a given path.
+ *
+ * @param filePath - Path to the file (relative or absolute).
+ * @returns true if the file exists, false otherwise.
+ */
+export function fileExists(entryPoint: string = "pepr.ts"): string {
+  try {
+    accessSync(resolve(entryPoint), constants.F_OK);
+  } catch {
+    console.error(`The entry-point option requires a file (e.g., pepr.ts), ${entryPoint} is not a file`);
+    process.exit(1);
+  }
+  return entryPoint;
+}
 
 interface ImageOptions {
   customImage?: string;

--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -19,7 +19,7 @@ import {
   watcherService,
 } from "../../lib/assets/k8sObjects";
 import { Reloader } from "../types";
-
+import Log from "../../lib/telemetry/logger";
 /**
  * Check if a file exists at a given path.
  *

--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -30,7 +30,9 @@ export function fileExists(entryPoint: string = "pepr.ts"): string {
   try {
     accessSync(resolve(entryPoint), constants.F_OK);
   } catch {
-    console.error(`The entry-point option requires a file (e.g., pepr.ts), ${entryPoint} is not a file`);
+    console.error(
+      `The entry-point option requires a file (e.g., pepr.ts), ${entryPoint} is not a file`,
+    );
     process.exit(1);
   }
   return entryPoint;

--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -7,7 +7,7 @@ import { validateCapabilityNames } from "../../lib/helpers";
 import { BuildOptions, context, BuildContext } from "esbuild";
 import { Assets } from "../../lib/assets/assets";
 import { resolve } from "path";
-import { promises as fs, accessSync, constants } from "fs";
+import { promises as fs, accessSync, constants, statSync } from "fs";
 import { generateAllYaml } from "../../lib/assets/yaml/generateAllYaml";
 import { webhookConfigGenerator } from "../../lib/assets/webhooks";
 import { generateZarfYamlGeneric } from "../../lib/assets/yaml/generateZarfYaml";
@@ -27,8 +27,12 @@ import Log from "../../lib/telemetry/logger";
  * @returns true if the file exists, false otherwise.
  */
 export function fileExists(entryPoint: string = "pepr.ts"): string {
+  const fullPath = resolve(entryPoint);
   try {
     accessSync(resolve(entryPoint), constants.F_OK);
+    if (!statSync(fullPath).isFile()) {
+      throw new Error("Not a file");
+    }
   } catch {
     Log.error(
       `The entry-point option requires a file (e.g., pepr.ts), ${entryPoint} is not a file`,

--- a/src/cli/build/build.test.ts
+++ b/src/cli/build/build.test.ts
@@ -27,6 +27,9 @@ vi.mock("fs", async () => {
     ...actual,
     accessSync: vi.fn(),
     constants: { F_OK: 0 },
+    statSync: vi.fn(() => ({
+      isFile: () => true,
+    })),
   };
 });
 

--- a/src/cli/build/build.test.ts
+++ b/src/cli/build/build.test.ts
@@ -9,10 +9,10 @@ import {
   checkIronBankImage,
   validImagePullSecret,
   assignImage,
-  fileExists
+  fileExists,
 } from "./build.helpers";
 import { accessSync, constants } from "fs";
-import { resolve } from "path"
+import { resolve } from "path";
 import { createDirectoryIfNotExists } from "../../lib/filesystemService";
 import { expect, describe, it, vi, beforeEach, type MockInstance } from "vitest";
 import { createDockerfile } from "../../lib/included-files";
@@ -52,7 +52,7 @@ describe("fileExists", () => {
   const mockedAccessSync = vi.mocked(accessSync);
 
   beforeEach(() => {
-    vi.clearAllMocks(); 
+    vi.clearAllMocks();
   });
 
   it("returns the entry point when the file exists", () => {

--- a/src/cli/build/build.test.ts
+++ b/src/cli/build/build.test.ts
@@ -9,14 +9,25 @@ import {
   checkIronBankImage,
   validImagePullSecret,
   assignImage,
+  fileExists
 } from "./build.helpers";
-
+import { accessSync, constants } from "fs";
+import { resolve } from "path"
 import { createDirectoryIfNotExists } from "../../lib/filesystemService";
 import { expect, describe, it, vi, beforeEach, type MockInstance } from "vitest";
 import { createDockerfile } from "../../lib/included-files";
 import { execSync } from "child_process";
 import { CapabilityExport } from "../../lib/types";
 import { Capability } from "../../lib/core/capability";
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+    constants: { F_OK: 0 },
+  };
+});
 
 vi.mock("../../lib/telemetry/logger", () => ({
   __esModule: true,
@@ -37,7 +48,38 @@ vi.mock("../../lib/included-files", () => ({
 vi.mock("../../lib/filesystemService", () => ({
   createDirectoryIfNotExists: vi.fn(),
 }));
+describe("fileExists", () => {
+  const mockedAccessSync = vi.mocked(accessSync);
 
+  beforeEach(() => {
+    vi.clearAllMocks(); 
+  });
+
+  it("returns the entry point when the file exists", () => {
+    mockedAccessSync.mockImplementationOnce(() => {});
+    const entry = "kfc.ts";
+    const result = fileExists(entry);
+    expect(mockedAccessSync).toHaveBeenCalledWith(resolve(entry), constants.F_OK);
+    expect(result).toBe(entry);
+  });
+
+  it("logs and exits when the file is missing", () => {
+    mockedAccessSync.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    expect(() => fileExists("missing.ts")).toThrow("exit");
+    exitSpy.mockRestore();
+  });
+
+  it("uses default arg when no entry is provided", () => {
+    mockedAccessSync.mockImplementationOnce(() => {});
+    expect(fileExists()).toBe("pepr.ts");
+    expect(mockedAccessSync).toHaveBeenCalledWith(resolve("pepr.ts"), constants.F_OK);
+  });
+});
 describe("assignImage", () => {
   const mockPeprVersion = "1.0.0";
 

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -12,7 +12,7 @@ import {
   handleCustomImageBuild,
 } from "./build.helpers";
 import Log from "../../lib/telemetry/logger";
-import { accessSync, constants } from "fs";
+import { accessSync } from "fs";
 
 vi.mock("fs", async () => {
   const actual = await vi.importActual<typeof import("fs")>("fs");
@@ -347,7 +347,7 @@ describe("build CLI command", () => {
     entryPointFlag => {
       const mockedAccessSync = vi.mocked(accessSync);
       it("should attempt to build the module", async () => {
-         mockedAccessSync.mockImplementationOnce(() => {});
+        mockedAccessSync.mockImplementationOnce(() => {});
         await runProgramWithArgs([entryPointFlag, "pepr.ts"]);
         expect(buildModule).toBeCalled();
       });

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -20,6 +20,9 @@ vi.mock("fs", async () => {
     ...actual,
     accessSync: vi.fn(),
     constants: { F_OK: 0 },
+    statSync: vi.fn(() => ({
+      isFile: () => true,
+    })),
   };
 });
 
@@ -79,6 +82,7 @@ vi.mock("../../lib/telemetry/logger", () => ({
   __esModule: true,
   default: {
     info: vi.fn(),
+    error: vi.fn(),
   },
 }));
 

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -12,6 +12,16 @@ import {
   handleCustomImageBuild,
 } from "./build.helpers";
 import Log from "../../lib/telemetry/logger";
+import { accessSync, constants } from "fs";
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+    constants: { F_OK: 0 },
+  };
+});
 
 vi.mock("../../lib/tls.ts", async () => {
   return {
@@ -335,7 +345,9 @@ describe("build CLI command", () => {
   describe.each([["-e"], ["--entry-point"]])(
     "when the entry point flag is set (%s)",
     entryPointFlag => {
+      const mockedAccessSync = vi.mocked(accessSync);
       it("should attempt to build the module", async () => {
+         mockedAccessSync.mockImplementationOnce(() => {});
         await runProgramWithArgs([entryPointFlag, "pepr.ts"]);
         expect(buildModule).toBeCalled();
       });

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -13,6 +13,7 @@ import {
   handleCustomImageBuild,
   validImagePullSecret,
   generateYamlAndWriteToDisk,
+  fileExists
 } from "./build.helpers";
 import { buildModule } from "./buildModule";
 import Log from "../../lib/telemetry/logger";
@@ -40,7 +41,7 @@ export default function (program: Command): void {
         "Set name for zarf component and service monitors in helm charts.",
       ),
     )
-    .option("-e, --entry-point <file>", "Specify the entry point file to build with.", "pepr.ts")
+    .option("-e, --entry-point <file>", "Specify the entry point file to build with. Default: pepr.ts", fileExists)
     .addOption(
       new Option(
         "-i, --custom-image <image>",

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -13,7 +13,7 @@ import {
   handleCustomImageBuild,
   validImagePullSecret,
   generateYamlAndWriteToDisk,
-  fileExists
+  fileExists,
 } from "./build.helpers";
 import { buildModule } from "./buildModule";
 import Log from "../../lib/telemetry/logger";
@@ -41,7 +41,11 @@ export default function (program: Command): void {
         "Set name for zarf component and service monitors in helm charts.",
       ),
     )
-    .option("-e, --entry-point <file>", "Specify the entry point file to build with. Default: pepr.ts", fileExists)
+    .option(
+      "-e, --entry-point <file>",
+      "Specify the entry point file to build with. (default: pepr.ts)",
+      fileExists,
+    )
     .addOption(
       new Option(
         "-i, --custom-image <image>",


### PR DESCRIPTION
## Description

The mocks fs mocks were necessary bc this build made `index.test.ts` fail.

There are 3 scenarios here we need to account for:

**No entry point**
```bash
> npx --yes pepr-0.0.0-development.tgz build

  dist/pepr-two-webhooks.js      1.2kb  100.0%
   ├ package.json                802b    67.6%
   ├ capabilities/hello-pepr.ts  291b    24.5%
   └ pepr.ts                      46b     3.9%

K8s resource for the module saved to /Users/cmwylie19/pepr-2546/dist/pepr-module-two-webhooks.yaml
[13:57:25.753] INFO (53217): Module two-webhooks has capability: two-webhooks
[13:57:25.753] INFO (53217): Registered Pepr Capability "two-webhooks"
```

**Entry point does not exist**
```bash
> npx --yes pepr-0.0.0-development.tgz build --entry-point nothing.ts
The entry-point option requires a file (e.g., pepr.ts), nothing.ts is not a file
```

**Custom Entry Point** 
```bash
> cp pepr.ts kfc.ts
> npx --yes pepr-0.0.0-development.tgz build --entry-point kfc.ts    

  dist/pepr-two-webhooks.js      1.2kb  100.0%
   ├ package.json                802b    67.6%
   ├ capabilities/hello-pepr.ts  291b    24.5%
   └ kfc.ts                       46b     3.9%

K8s resource for the module saved to /Users/cmwylie19/pepr-2546/dist/pepr-module-two-webhooks.yaml
[13:59:35.290] INFO (53698): Module two-webhooks has capability: two-webhooks
[13:59:35.291] INFO (53698): Registered Pepr Capability "two-webhooks
```

## Related Issue

Fixes #2512 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
