### PR TITLE
chore: force user to use an integer for webhook's timeoutSeconds

### DIFF
--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -336,7 +336,11 @@ describe("build CLI command", () => {
         error: "Number must be between 1 and 30.",
         description: "reject values above maximum",
       },
-      { value: "not-a-number", error: "Not a number.", description: "reject non-numeric values" },
+      {
+        value: "not-a-number",
+        error: "Value must be an integer.",
+        description: "reject non-numeric values",
+      },
       { value: "5.2", error: "Value must be an integer.", description: "reject float values" },
     ])("should $description: $value", async ({ value, error }) => {
       await runProgramWithError([timeoutFlag, value], error);

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -341,6 +341,7 @@ describe("build CLI command", () => {
         error: "Value must be an integer.",
         description: "reject non-numeric values",
       },
+      { value: "5.0", error: "Value must be an integer.", description: "reject float values" },
       { value: "5.2", error: "Value must be an integer.", description: "reject float values" },
     ])("should $description: $value", async ({ value, error }) => {
       await runProgramWithError([timeoutFlag, value], error);

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -710,6 +710,7 @@ describe("parseTimeout", () => {
   it("should throw an InvalidArgumentError for numeric strings that represent floating point numbers", () => {
     expect(() => parseTimeout("5.5")).toThrow(Error);
     expect(() => parseTimeout("20.1")).toThrow(Error);
+    expect(() => parseTimeout("5.0")).toThrow(Error);
   });
 });
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -229,7 +229,7 @@ export function secretOverLimit(str: string): boolean {
 export const parseTimeout = (value: string): number => {
   const num = Number(value);
 
-  if (!Number.isInteger(num)) {
+  if (!Number.isInteger(num) || value.includes(".")) {
     throw new Error("Value must be an integer.");
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -227,16 +227,17 @@ export function secretOverLimit(str: string): boolean {
 }
 
 export const parseTimeout = (value: string): number => {
-  const parsedValue = parseInt(value, 10);
-  const floatValue = parseFloat(value);
-  if (isNaN(parsedValue)) {
-    throw new Error("Not a number.");
-  } else if (parsedValue !== floatValue) {
+  const num = Number(value);
+
+  if (!Number.isInteger(num)) {
     throw new Error("Value must be an integer.");
-  } else if (parsedValue < 1 || parsedValue > 30) {
+  }
+
+  if (num < 1 || num > 30) {
     throw new Error("Number must be between 1 and 30.");
   }
-  return parsedValue;
+
+  return num;
 };
 
 // Remove leading whitespace while keeping format of file


### PR DESCRIPTION
## Description

Currently the user can use a float for the webhook timeout, in Kubernetes it must be an integer so we are going to force the user to use an integer.

```bash
> k explain MutatingWebhookConfiguration.webhooks.timeoutSeconds
GROUP:      admissionregistration.k8s.io
KIND:       MutatingWebhookConfiguration
VERSION:    v1

FIELD: timeoutSeconds <integer>


DESCRIPTION:
    TimeoutSeconds specifies the timeout for this webhook. After the timeout
    passes, the webhook call will be ignored or the API call will fail based on
    the failure policy. The timeout value must be between 1 and 30 seconds.
    Default to 10 seconds.
```

## Related Issue

Fixes #2514 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
