### PR TITLE
chore: fix permissions on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
       run-scripts: "set:version, ci, build"
 
   tutorials-test:
+    permissions: read-all 
     uses: ./.github/workflows/tutorials-test.yml
 
   publish:


### PR DESCRIPTION
## Description

Seems to be a permission mismatch between release and the tutorials test

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
