### PR TITLE
chore: override vulnerable npm libs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,50 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: daily
-    ignore:
-      - dependency-name: "pino"
-        versions: ["9.8.0"]
     groups:
       production-dependencies:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
- 
+    ignore:
+      - dependency-name: "pino"
+        versions: ["9.8.0"]
+      - dependency-name: "backslash"
+        versions: ["0.2.1"]
+      - dependency-name: "chalk"
+        versions: ["5.6.1"]
+      - dependency-name: "chalk-template"
+        versions: ["1.1.1"]
+      - dependency-name: "color-convert"
+        versions: ["3.1.1"]
+      - dependency-name: "color-name"
+        versions: ["2.0.1"]
+      - dependency-name: "color-string"
+        versions: ["2.1.1"]
+      - dependency-name: "wrap-ansi"
+        versions: ["9.0.1"]
+      - dependency-name: "supports-hyperlinks"
+        versions: ["4.1.1"]
+      - dependency-name: "strip-ansi"
+        versions: ["7.1.1"]
+      - dependency-name: "slice-ansi"
+        versions: ["7.1.1"]
+      - dependency-name: "simple-swizzle"
+        versions: ["0.2.3"]
+      - dependency-name: "is-arrayish"
+        versions: ["0.3.3"]
+      - dependency-name: "error-ex"
+        versions: ["1.3.3"]
+      - dependency-name: "has-ansi"
+        versions: ["6.0.1"]
+      - dependency-name: "ansi-regex"
+        versions: ["6.2.1"]
+      - dependency-name: "ansi-styles"
+        versions: ["6.2.2"]
+      - dependency-name: "supports-color"
+        versions: ["10.2.1"]
+      - dependency-name: "debug"
+        versions: ["4.4.2"] 
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "backslash": "0.2.1",
     "chalk-template": "1.1.1",
     "color-string": "2.1.1",
-    "slice-ansi": "7.1.1",
     "simple-swizzle": "0.2.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,11 +91,7 @@
     "vitest": "^3.2.3"
   },
   "overrides": {
-    "glob": "^9.0.0",
-    "backslash": "0.2.1",
-    "chalk-template": "1.1.1",
-    "color-string": "2.1.1",
-    "simple-swizzle": "0.2.3"
+    "glob": "^9.0.0"
   },
   "peerDependencies": {
     "@types/prompts": "2.4.9",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,12 @@
     "vitest": "^3.2.3"
   },
   "overrides": {
-    "glob": "^9.0.0"
+    "glob": "^9.0.0",
+    "backslash": "0.2.1",
+    "chalk-template": "1.1.1",
+    "color-string": "2.1.1",
+    "slice-ansi": "7.1.1",
+    "simple-swizzle": "0.2.3"
   },
   "peerDependencies": {
     "@types/prompts": "2.4.9",


### PR DESCRIPTION
## Description

Overrides vulnerable npm libraries so we do not get them through dependabot

https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack

_Many_ of these packages have already removed the vulnerable versions.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
