### PR TITLE
feat: change default reconcile strategy

### DIFF
--- a/src/lib/processors/watch-processor.ts
+++ b/src/lib/processors/watch-processor.ts
@@ -30,7 +30,7 @@ const queues: Record<string, Queue<KubernetesObject>> = {};
  */
 export function queueKey(obj: KubernetesObject): string {
   const options = ["kind", "kindNs", "kindNsName", "global"];
-  const d3fault = "kind";
+  const d3fault = "kindNsName";
 
   let strat = process.env.PEPR_RECONCILE_STRATEGY || d3fault;
   strat = options.includes(strat) ? strat : d3fault;


### PR DESCRIPTION
## Description

Change the default reconcile strategy to `kindNsName` because it is the only one that really makes sense when you are building an operator based on parallelism and processes _given workloads_ in the order they were received. 

**I don't know if I consider this a breaking change bc they can set the `PEPR_RECONCILE_STRATEGY`**

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
