### PR TITLE
chore: codecov fix

### DIFF
--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -66,8 +66,8 @@ jobs:
       - run: npm run test:unit
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          token: ${{ secrets.CODECOV_ORG_TOKEN }}
 
   test-docs:
     if: inputs.run-units == true

--- a/config/vitest.root.config.ts
+++ b/config/vitest.root.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: "v8",
-      reporter: ["text", "html"],
+      reporter: ["text", "html", "lcov"],
       reportsDirectory: "./coverage",
       include: ["src/**/*.ts"],
       exclude: [


### PR DESCRIPTION
## Description

Codecov has not run in Pepr in [3 months](https://app.codecov.io/gh/defenseunicorns/pepr). Now we have to pass in a `with.token` syntax and make vitest create an lcov.info file.

[here](https://github.com/defenseunicorns/lula/actions/runs/17649109525/job/50155037507) is a working example in lula


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
