### PR TITLE
chore: remove tutorials test for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,9 @@ jobs:
     with:
       run-scripts: "set:version, ci, build"
 
-  tutorials-test:
-    permissions: read-all 
-    uses: ./.github/workflows/tutorials-test.yml
+  # tutorials-test:
+  #   permissions: read-all 
+  #   uses: ./.github/workflows/tutorials-test.yml
 
   publish:
     needs: [slsa, tutorials-test]


### PR DESCRIPTION
## Description

The release is failing bc we are overhauling our docs. We need to not do the tutorials doc test for the moment while we are still working to improve our doc experience.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
