### PR TITLE
chore: updated to kindNsName and fixed spelling typo

### DIFF
--- a/docs/010_user-guide/060_customization.md
+++ b/docs/010_user-guide/060_customization.md
@@ -54,7 +54,7 @@ Default (without):
 
 ## Customizing Watch Configuration
 
-The Watch configuration is a part of the Pepr module that allows you to watch for specific resources in the Kubernetes cluster. The Watch configuration can be customized by specific enviroment variables of the Watcher Deployment and can be set in the field in the `package.json` or in the helm `values.yaml` file.
+The Watch configuration is a part of the Pepr module that allows you to watch for specific resources in the Kubernetes cluster. The Watch configuration can be customized by specific environment variables of the Watcher Deployment and can be set in the field in the `package.json` or in the helm `values.yaml` file.
 
 | Field                        | Description                                                                                                      | Example Values                  |
 |------------------------------|------------------------------------------------------------------------------------------------------------------|---------------------------------|
@@ -69,7 +69,7 @@ The [Reconcile Action](/actions/reconcile) allows you to maintain ordering of re
 
 | Field | Description | Example Values |
 |-|-|-|
-| `PEPR_RECONCILE_STRATEGY` | How Pepr should order resource updates being Reconcile()'d. | default: `"kind"` |
+| `PEPR_RECONCILE_STRATEGY` | How Pepr should order resource updates being Reconcile()'d. | default: `"kindNsName"` |
 
 | Available Options ||
 |-|-|


### PR DESCRIPTION
## Description

Updated the default in the docs to `kindNsName` for `PEPR_RECONCILE_STRATEGY`.  Fixed spelling typo for environment on same page https://docs.pepr.dev/user-guide/customization/

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
