### PR TITLE
chore: added tutorials testing back to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,9 @@ jobs:
     with:
       run-scripts: "set:version, ci, build"
 
-  # tutorials-test:
-  #   permissions: read-all 
-  #   uses: ./.github/workflows/tutorials-test.yml
+  tutorials-test:
+    permissions: read-all 
+    uses: ./.github/workflows/tutorials-test.yml
 
   publish:
     needs: [slsa]


### PR DESCRIPTION
## Description
Reverted changes made in previous [PR]( https://github.com/defenseunicorns/pepr/pull/2630) that were needed to remove the tutorials test before a release due to us overhauling the docs flow.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
