### PR TITLE
chore: update link for contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Welcome to Pepr! To learn more about contributing to the [project](README.md), check out the [Contributor's Guide](docs/120_contribute/README.md).
+Welcome to Pepr! To learn more about contributing to the [project](README.md), check out the [Contributor's Guide](docs/060_contribute/010_contributor-guide.md).


### PR DESCRIPTION
## Description

When working on adding a [contributing guide](https://github.com/defenseunicorns/lula/issues/53) to Lula I wanted to use Pepr's as a reference. Clicking the link in `CONTRIBUTING.md` I realized that we needed to change the markdown link

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
