### PR TITLE
chore: grype ignore

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -33,17 +33,13 @@ jobs:
         run: npm ci
       - name: Build Pepr Controller Image
         run: npm run build:image
-      - name: Configure Grype Ignore File
-        run: |
-          mkdir -p ~/.grype
-          echo "ignore:" > ~/.grype.yaml
-          echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         with:
           image: "pepr:dev"
           fail-build: true
           severity-cutoff: high
+          grype-config: ./config/.grype.yaml
       - name: Generate SBOM
         uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -33,6 +33,11 @@ jobs:
         run: npm ci
       - name: Build Pepr Controller Image
         run: npm run build:image
+      - name: Configure Grype Ignore File
+        run: |
+          mkdir -p ~/.grype
+          echo "ignore:" > ~/.grype.yaml
+          echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         with:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -33,13 +33,17 @@ jobs:
         run: npm ci
       - name: Build Pepr Controller Image
         run: npm run build:image
+      - name: Configure Grype Ignore File
+        run: |
+          mkdir -p ~/.grype
+          echo "ignore:" > ~/.grype.yaml
+          echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         with:
           image: "pepr:dev"
           fail-build: true
           severity-cutoff: high
-          grype-config: ./config/.grype.yaml
       - name: Generate SBOM
         uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:

--- a/config/.grype.yaml
+++ b/config/.grype.yaml
@@ -1,3 +1,0 @@
-ignore:
-# this is affecting all node alpine upstream images
-- vulnerability: CVE-2025-9230

--- a/config/.grype.yaml
+++ b/config/.grype.yaml
@@ -1,0 +1,3 @@
+ignore:
+# this is affecting all node alpine upstream images
+- vulnerability: CVE-2025-9230


### PR DESCRIPTION
## Description

There is a CVE in the upstream grype image, we cannot upgrade out of it because the other patch versions are affected too. This technically [forces us to force merge over CI ](https://github.com/defenseunicorns/pepr/pull/2664)and we cannot use the merge queue. This is to ignore this known CVE during CI


```bash
> grype docker.io/library/node@sha256:e8e882c692a08878d55ec8ff6c5a4a71b3edca25eda0af4406e2a160d8a93cf2
 ✔ Pulled image                    
 ✔ Loaded image                                                                                                                                                                                       docker.io/library/node@sha256:e8e882c692a08878d55ec8ff6c5a4a71b3edca25eda0af4406e2a160d8a93cf2 
 ✔ Parsed image                                                                                                                                                                                                              sha256:4c78c378ba471e0fc6e1b02453cfb59c3dcfe7b36c8193d70bf4eb42dc7b09b8 
 ✔ Cataloged contents                                                                                                                                                                                                               adad835cd11424956529650cda98e46ba720c200d273547ce60d45df28bbfbba 
   ├── ✔ Packages                        [233 packages]  
   ├── ✔ Executables                     [20 executables]  
   ├── ✔ File metadata                   [298 locations]  
   └── ✔ File digests                    [298 files]  
 ✔ Scanned for vulnerabilities     [12 vulnerability matches]  
   ├── by severity: 0 critical, 2 high, 4 medium, 6 low, 0 negligible
   └── by status:   6 fixed, 6 not-fixed, 0 ignored 
NAME           INSTALLED   FIXED-IN  TYPE  VULNERABILITY   SEVERITY  EPSS%  RISK  
busybox        1.37.0-r18            apk   CVE-2024-58251  Low        2.00  < 0.1  
busybox-binsh  1.37.0-r18            apk   CVE-2024-58251  Low        2.00  < 0.1  
ssl_client     1.37.0-r18            apk   CVE-2024-58251  Low        2.00  < 0.1  
busybox        1.37.0-r18            apk   CVE-2025-46394  Low        0.96  < 0.1  
busybox-binsh  1.37.0-r18            apk   CVE-2025-46394  Low        0.96  < 0.1  
ssl_client     1.37.0-r18            apk   CVE-2025-46394  Low        0.96  < 0.1  
libcrypto3     3.5.1-r0    3.5.4-r0  apk   CVE-2025-9230   High        N/A    N/A  
libssl3        3.5.1-r0    3.5.4-r0  apk   CVE-2025-9230   High        N/A    N/A  
libcrypto3     3.5.1-r0    3.5.4-r0  apk   CVE-2025-9231   Medium      N/A    N/A  
libcrypto3     3.5.1-r0    3.5.4-r0  apk   CVE-2025-9232   Medium      N/A    N/A  
libssl3        3.5.1-r0    3.5.4-r0  apk   CVE-2025-9231   Medium      N/A    N/A  
libssl3        3.5.1-r0    3.5.4-r0  apk   CVE-2025-9232   Medium      N/A    N/A
A newer version of grype is available for download: 0.96.1 (installed version is 0.94.0)
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
