### PR TITLE
chore: teardowntimeout and workers for tutorials test

### DIFF
--- a/.github/workflows/tutorials-test.yml
+++ b/.github/workflows/tutorials-test.yml
@@ -47,5 +47,5 @@ jobs:
         run: |
           cd "$PEPR"
           npm ci
-          npx vitest run docs/030_tutorials/tests/*.test.ts   
+          npx vitest --config config/vitest.tutorials.config.ts run docs/030_tutorials/tests/*.test.ts
 

--- a/config/vitest.tutorials.config.ts
+++ b/config/vitest.tutorials.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    maxWorkers: 1,
+    minWorkers: 1,
+    testTimeout: 30000,
+    teardownTimeout: 10000,
+    isolate: true,
+    include: ["docs/**/*.test.ts"],
+    exclude: [
+      "node_modules",
+      "dist",
+      "pepr/**",
+      "src/templates/**",
+      "coverage",
+      "src/build-artifact.test.ts",
+    ],
+    hookTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Description

The tutorials test has been failing in CI and then I noticed it also failed locally. After adding this change it has passed 3 times. 

This seems to make it more stable. 

Once this PR proves to make the test more stable then we should ensure the release is blocked if this test fails. The funny thing is now 24/24 tests are passing but the error comes from an `onTaskUpdate` timeout. 


## Related Issue

Fixes #2685 
<!-- or -->
Relates to #2686 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
