### PR TITLE
fix: run semantic release action from merge queue

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,6 @@ name: "CodeQL"
 
 on:
   push:
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
-    - "**.md"
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ name: "CodeQL"
 
 on:
   push:
+    paths-ignore:
+    - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
 permissions:
   contents: read
 

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -5,12 +5,15 @@ permissions:
 
 on:
   push:
-    branches:
-      - main
+    paths-ignore:
+    - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"   
   pull_request:
-    branches:
-      - main
-    
+    paths-ignore:
+    - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"   
 jobs:
   container-scans:
     runs-on: ubuntu-latest

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -10,10 +10,6 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
     
 jobs:
   container-scans:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,11 +9,6 @@
 name: 'Dependency Review'
 on: 
   pull_request:
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
-    - "**.md"
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,10 @@
 name: 'Dependency Review'
 on: 
   pull_request:
-
+    paths-ignore:
+    - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS" 
 permissions:
   contents: read
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,15 +1,16 @@
 name: Node.js CI
 
 on:
-  workflow_call:
   push:
-    branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
   pull_request:
-    branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
     
 permissions:
   id-token: write # This is needed for OIDC federation.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,7 @@
 name: Node.js CI
 
 on:
+  workflow_call:
   push:
     branches: ["main"]
     paths-ignore:
@@ -9,12 +10,7 @@ on:
     branches: ["main"]
     paths-ignore:
     - "**.md"
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
-    - "**.md"
-
+    
 permissions:
   id-token: write # This is needed for OIDC federation.
   contents: read

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -5,12 +5,8 @@ permissions:
   contents: read
 
 on:
+  workflow_call:
   workflow_dispatch:
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
-    - "**.md"
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -5,7 +5,6 @@ permissions:
   contents: read
 
 on:
-  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
@@ -13,10 +12,14 @@ on:
     branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
   pull_request:
     branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
 
 # refs
 # https://frontside.com/blog/2022-12-12-dynamic-github-action-jobs/

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -2,12 +2,8 @@ name: E2E - Pepr Excellent Examples
 
 permissions: read-all
 on:
+  workflow_call:
   workflow_dispatch:
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
-    - "**.md"
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:

--- a/.github/workflows/pepr-excellent-examples.yml
+++ b/.github/workflows/pepr-excellent-examples.yml
@@ -2,18 +2,20 @@ name: E2E - Pepr Excellent Examples
 
 permissions: read-all
 on:
-  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST
   push:
-    branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
   pull_request:
-    branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
+
 
 # refs
 # https://frontside.com/blog/2022-12-12-dynamic-github-action-jobs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Version Release
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -27,10 +26,10 @@ jobs:
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Use Node.js 24
+      - name: Use Node.js 20
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 24
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
@@ -74,10 +73,6 @@ jobs:
   publish:
     needs: [slsa]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -86,18 +81,8 @@ jobs:
       - name: Set up Node registry authentication
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 24
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
-
-      - name: Create release notes and tag release
-        run: |
-          npx semantic-release \
-          --publish @semantic-release/github
-
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish package
         id: publish
         uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@9103ac683d00ceecdb1c21507a9c7a9983ef46f4 # v2.0.0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
     - "LICENSE"
     - "CODEOWNERS"
+    - "**.md"
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,43 @@
+name: Semantic Release
+
+on:
+  merge_group:
+
+jobs:
+  on-demand-workflows:
+    uses: ./.github/workflows/on-demand-workflows.yaml
+    secrets:
+      CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+    with:
+      run-format: false # no need to check the format again
+      run-units: true
+      run-integration: true
+  unicorn-pexex:
+    uses: ./.github/workflows/pepr-excellent-examples-unicorn.yml
+    needs: [on-demand-workflows]
+  publish:
+    needs: [unicorn-pexex]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up Node registry authentication
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release \
+          --prepare @semantic-release/npm \
+          --publish @semantic-release/github

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -12,11 +12,8 @@ jobs:
       run-format: false # no need to check the format again
       run-units: true
       run-integration: true
-  unicorn-pexex:
-    uses: ./.github/workflows/pepr-excellent-examples-unicorn.yml
-    needs: [on-demand-workflows]
   publish:
-    needs: [unicorn-pexex]
+    needs: [on-demand-workflows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -2,6 +2,7 @@ name: UDS - Smoke Test
 
 permissions: read-all
 on:
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -2,7 +2,6 @@ name: UDS - Smoke Test
 
 permissions: read-all
 on:
-  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *' # 12AM EST/9PM PST

--- a/.github/workflows/upgrade-unicorn.yml
+++ b/.github/workflows/upgrade-unicorn.yml
@@ -1,6 +1,7 @@
 name: Upgrade Test - Unicorn
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: ["main"]
@@ -9,11 +10,6 @@ on:
   pull_request:
     branches: ["main"]
     paths-ignore:
-    - "**.md"
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
     - "**.md"
 
 permissions:

--- a/.github/workflows/upgrade-unicorn.yml
+++ b/.github/workflows/upgrade-unicorn.yml
@@ -7,10 +7,14 @@ on:
     branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
   pull_request:
     branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
 
 permissions:
   contents: read

--- a/.github/workflows/upgrade-upstream.yml
+++ b/.github/workflows/upgrade-upstream.yml
@@ -1,6 +1,7 @@
 name: Upgrade Test - Upstream
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: ["main"]
@@ -9,11 +10,6 @@ on:
   pull_request:
     branches: ["main"]
     paths-ignore:
-    - "**.md"
-  merge_group:
-    paths-ignore:
-    - "LICENSE"
-    - "CODEOWNERS"
     - "**.md"
 
 permissions:

--- a/.github/workflows/upgrade-upstream.yml
+++ b/.github/workflows/upgrade-upstream.yml
@@ -1,16 +1,20 @@
 name: Upgrade Test - Upstream
 
 on:
-  workflow_call:
   workflow_dispatch:
   push:
     branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
+
   pull_request:
     branches: ["main"]
     paths-ignore:
     - "**.md"
+    - "LICENSE"
+    - "CODEOWNERS"
 
 permissions:
   contents: read

--- a/config/vitest.tutorials.config.ts
+++ b/config/vitest.tutorials.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     pool: "forks",
     maxWorkers: 1,
     minWorkers: 1,
-    testTimeout: 30000,
-    teardownTimeout: 10000,
+    testTimeout: 60000,
+    teardownTimeout: 60000,
     isolate: true,
     include: ["docs/**/*.test.ts"],
     exclude: [

--- a/config/vitest.tutorials.config.ts
+++ b/config/vitest.tutorials.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     pool: "forks",
     maxWorkers: 1,
     minWorkers: 1,
-    testTimeout: 60000,
+    testTimeout: 120000,
     teardownTimeout: 60000,
     isolate: true,
     include: ["docs/**/*.test.ts"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@commitlint/config-conventional": "20.0.0",
         "@fast-check/vitest": "^0.2.1",
         "@semantic-release/git": "^10.0.1",
+        "@semantic-release/npm": "^13.0.0",
         "@types/command-line-args": "^5.2.3",
         "@types/eslint": "9.6.1",
         "@types/express": "5.0.3",
@@ -1519,7 +1520,6 @@
       "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.22.0"
       }
@@ -1530,7 +1530,6 @@
       "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "4.2.10"
       },
@@ -1543,8 +1542,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@pnpm/npm-conf": {
       "version": "2.3.1",
@@ -1552,7 +1550,6 @@
       "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pnpm/config.env-replace": "^1.1.0",
         "@pnpm/network.ca-file": "^1.0.1",
@@ -1847,8 +1844,7 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "13.0.1",
@@ -1925,7 +1921,6 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2135,7 +2130,6 @@
       "integrity": "sha512-7RIx9nUdUekYbIZ0dG7k7G/iSvUCZb03LmmBPFqAQEhPVC+BnHfhFxj5ewSNP6zMUsYaEQSckcOhKD8AuS/EzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
@@ -2263,7 +2257,6 @@
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2487,8 +2480,7 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prompts": {
       "version": "2.4.9",
@@ -3164,7 +3156,6 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -3727,7 +3718,6 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -3744,7 +3734,6 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3990,7 +3979,6 @@
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -4001,8 +3989,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -4228,7 +4215,6 @@
       "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^1.0.1"
       },
@@ -4245,7 +4231,6 @@
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4478,7 +4463,6 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5338,7 +5322,6 @@
       "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -5366,7 +5349,6 @@
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -5384,7 +5366,6 @@
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5609,7 +5590,6 @@
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -5882,7 +5862,6 @@
       "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -6341,7 +6320,6 @@
       "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
@@ -6432,7 +6410,6 @@
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -6562,7 +6539,6 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6576,7 +6552,6 @@
       "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6708,7 +6683,6 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6754,7 +6728,6 @@
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6978,7 +6951,6 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -7272,8 +7244,7 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -7719,8 +7690,7 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",
@@ -7775,7 +7745,6 @@
       "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "hosted-git-info": "^7.0.0",
         "semver": "^7.3.5",
@@ -7791,7 +7760,6 @@
       "integrity": "sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -7872,7 +7840,6 @@
       ],
       "dev": true,
       "license": "Artistic-2.0",
-      "peer": true,
       "workspaces": [
         "docs",
         "smoke-tests",
@@ -7961,7 +7928,6 @@
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0",
         "unicorn-magic": "^0.3.0"
@@ -7979,7 +7945,6 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7993,7 +7958,6 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10883,7 +10847,6 @@
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10959,7 +10922,6 @@
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11376,7 +11338,6 @@
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -11451,8 +11412,7 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -11608,7 +11568,6 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11624,8 +11583,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
@@ -11633,7 +11591,6 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11677,7 +11634,6 @@
       "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.3",
         "normalize-package-data": "^6.0.0",
@@ -11698,7 +11654,6 @@
       "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "index-to-position": "^1.1.0",
@@ -11717,7 +11672,6 @@
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -11756,7 +11710,6 @@
       "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pnpm/npm-conf": "^2.1.0"
       },
@@ -12440,7 +12393,6 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -12672,7 +12624,6 @@
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -12683,8 +12634,7 @@
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
-      "license": "CC-BY-3.0",
-      "peer": true
+      "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
@@ -12692,7 +12642,6 @@
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -12703,8 +12652,7 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
-      "license": "CC0-1.0",
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -12879,7 +12827,6 @@
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -13082,7 +13029,6 @@
       "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -13093,7 +13039,6 @@
       "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-stream": "^3.0.0",
         "temp-dir": "^3.0.0",
@@ -13113,7 +13058,6 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -13127,7 +13071,6 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -13690,7 +13633,6 @@
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crypto-random-string": "^4.0.0"
       },
@@ -13715,7 +13657,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -13783,7 +13724,6 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -14245,7 +14185,6 @@
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@commitlint/config-conventional": "20.0.0",
     "@fast-check/vitest": "^0.2.1",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/npm": "^13.0.0",
     "@types/command-line-args": "^5.2.3",
     "@types/eslint": "9.6.1",
     "@types/express": "5.0.3",


### PR DESCRIPTION
## Description

We need to run the semantic release from a merge queue so that it can create the GitHub release, trigger the current release workflow. WIP 

[Original PR](https://github.com/defenseunicorns/pepr/actions/runs/18572172001/job/52948539310) - Our release scripts and actions are expecting release events, and on push to main the refs are different and causes problems.

Proposed solution - Keep the release action the exact same as it was, and have semantic release occur in the merge queue, kicking off a GitHub release, and the original release action works like normal

**Background**
When a PR goes into the merge queue, the code is updated and CI runs on the updated code on the branch. We are running unit tests, integration tests, several flavors of PEXEX tests ( unicorn, iron bank, upstream ). This is overkill as all of these tests would have _just passed_ before entering into the merge queue. The _risk_ we have to account for is really in the _build_. If the PR that goes into a queue is a TypeScript update and the next PR in the queue is a unit test, then once the unit test PR is updated with the TypeScript update there could be _version conflicts_. So what we really need to do is test that the code can build and all of the unit and integration tests pass. Not retest the controller. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
