### PR TITLE
fix: create env var for node auth token

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx semantic-release \
           --analyze-commits @semantic-release/commit-analyzer \


### PR DESCRIPTION
## Description

We are still getting authentication [errors](https://github.com/defenseunicorns/pepr/actions/runs/18657821991/job/53191628702) in the semantic release action despite verifying that the token is good. 

It seems like _part_ of the flow needs the `NPM_TOKEN` secret to be an env var `NODE_AUTH_TOKEN` like in the SLSA flow. 


https://github.com/defenseunicorns/pepr/blob/7dc25494630b7888de8c94b0e3651fd24dcdf63d/.github/workflows/release.yml#L58
## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
