### PR TITLE
fix: ghcr push perms and job outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write 
+      packages: write
+
+    outputs:
+      pepr_version: ${{ steps.capture.outputs.pepr_version }}
 
     steps:
       - name: Harden Runner
@@ -80,6 +84,7 @@ jobs:
           --publish @semantic-release/github
 
       - name: Capture Pepr version
+        id: capture
         run: |
           echo "PEPR_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
           echo "Detected version: $(jq -r .version package.json)"
@@ -88,6 +93,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./.github/workflows/scripts/release.sh "${PEPR_VERSION}" 
+
+
+
 
   slsa:
     permissions:
@@ -103,6 +111,8 @@ jobs:
   publish:
     needs: [slsa]
     runs-on: ubuntu-latest
+    env:
+      PEPR_VERSION: ${{ needs.build-and-release.outputs.pepr_version }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -141,7 +151,8 @@ jobs:
   pack-and-push:
     needs: [publish]
     runs-on: ubuntu-latest
-
+    env:
+      PEPR_VERSION: ${{ needs.build-and-release.outputs.pepr_version }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1


### PR DESCRIPTION
## Description

Currently we are seeing two problems in the publish pipeline:
1. [Permissions to push to GHCR](https://github.com/defenseunicorns/pepr/actions/runs/18700876621/job/53329145653#step:13:1477)
2. [Env Var is not populated for version](https://github.com/defenseunicorns/pepr/actions/runs/18700876621/job/53329826955#step:6:1)

This uses the outputs from other jobs to populate the `PEPR_VERSION` env var and gives write packages permissions to `build-and-release`

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
