### PR TITLE
fix: set version script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./.github/workflows/scripts/release.sh "${PEPR_VERSION}" 
 
-  slsa:
+  slsa: # This is where the slsa tarball is built for publish-package step
     permissions:
       id-token: write
       actions: read
@@ -104,7 +104,7 @@ jobs:
     needs: [build-and-release]
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.1.0
     with:
-      run-scripts: "ci, build"
+      run-scripts: "set-version, ci, build"
     secrets: inherit
 
   publish:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gen-data-json": "node hack/build-template-data.js",
     "prebuild": "rm -fr dist/* && npm run gen-data-json",
     "prepare": "if [ \"$NODE_ENV\" != 'production' ]; then husky; fi",
+    "set-version": "bash -lc 'ver=${PEPR_VERSION:-}; if [ -z \"$ver\" ]; then git fetch --tags --force; ver=$(git describe --tags --abbrev=0); fi; ver=${ver#v}; echo Using version $ver; node ./scripts/set-version.js \"$ver\"'",
     "test": "npm run test:unit && npm run test:integration",
     "test:artifacts": "npm run build && vitest run src/build-artifact.test.ts",
     "test:docs": "vitest run --config=config/vitest.integration.config.ts integration/cli/docs/*.test.ts",


### PR DESCRIPTION
## Description

https://github.com/defenseunicorns/pepr/actions/runs/18715887653/job/53376421615#step:7:697

It is trying to do a slsa publish with the 0.0.0-development version, the problem is the job below needs to tag. Hopefully this will create the correct rtag

```yaml
  slsa: # This is where the slsa tarball is built for publish-package step
    permissions:
      id-token: write
      actions: read
      contents: read
    needs: [build-and-release]
    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v2.1.0
    with:
      run-scripts: "set-version, ci, build"
    secrets: inherit
 ```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
