### PR TITLE
chore: account for early exit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,11 @@ jobs:
           echo "PEPR_VERSION=$V" >> "$GITHUB_ENV"
           echo "Detected version: $V"
 
+      - name: Early Exit step
+        if: ${{ env.PEPR_VERSION == '0.0.0-development' }}
+        run: |
+          echo "No release required, skipping remaining steps."
+
       - name: Publish to GHCR 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

https://github.com/defenseunicorns/pepr/actions/runs/18723924425/job/53403492626

Noticed we failed during merge to main which made an exit 1. This should fix it organically by checking if it is the default 0.0.0-development.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
