### PR TITLE
chore: corrected broken links

### DIFF
--- a/docs/010_user-guide/040_capabilities.md
+++ b/docs/010_user-guide/040_capabilities.md
@@ -6,7 +6,7 @@ When you [`npx pepr init`](/user-guide/pepr-cli#pepr-init), a `capabilities` dir
 
 ## Creating a Capability
 
-Defining a new capability can be done via a [VSCode Snippet](https://code.visualstudio.com/docs/editor/userdefinedsnippets) generated during [`npx pepr init`](/pepr-cli#pepr-init).
+Defining a new capability can be done via a [VSCode Snippet](https://code.visualstudio.com/docs/editor/userdefinedsnippets) generated during [`npx pepr init`](/user-guide/pepr-cli#pepr-init).
 
 1. Create a new file in the `capabilities` directory with the name of your capability. For example, `capabilities/my-capability.ts`.
 

--- a/docs/030_tutorials/030_create-pepr-operator.md
+++ b/docs/030_tutorials/030_create-pepr-operator.md
@@ -19,7 +19,7 @@ The WebApp Operator will:
 
 All resources will include `ownerReferences`, triggering cascading deletion when a WebApp is removed. The operator will also automatically restore any managed resources that are deleted externally.
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ All resources will include `ownerReferences`, triggering cascading deletion when
 - Familiarity with TypeScript
 - Node.js ≥ 20.0
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Tutorial Steps
 
@@ -40,7 +40,7 @@ All resources will include `ownerReferences`, triggering cascading deletion when
 5. [Build and Deploy Your Operator](#build-and-deploy-your-operator)
 6. [Test Your Operator](#test-your-operator)
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Create a new Pepr Module
 
@@ -66,7 +66,7 @@ To track your progress in this tutorial, let's treat it as a `git` repository:
 git init && git add --all && git commit -m "npx pepr init"
 ```
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Create CRD
 
@@ -163,7 +163,7 @@ Commit your changes for CRD registration & validation:
 git add capabilities/crd/ && git commit -m "Create CRD handling logic"
 ```
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Create Helpers
 
@@ -200,7 +200,7 @@ Commit your changes for deployment, service, and configmap generation:
 git add capabilities/controller/ && git commit -m "Add generators for WebApp deployments, services, and configmaps"
 ```
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Create Reconciler
 
@@ -244,7 +244,7 @@ Commit your changes with:
 git add capabilities/ && git commit -m "Create reconciler for webapps"
 ```
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Add capability to Pepr Module
 
@@ -452,7 +452,7 @@ FIELDS:
 `wa` is the short form of `webapp` that kubectl recognizes. This resource structure directly matches the TypeScript interface we defined earlier in our code.
 :::
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)
 
 ## Test Your Operator
 
@@ -788,4 +788,4 @@ For more information, check out:
 - [Kubernetes Operator Best Practices](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
 - [Custom Resource Definition Documentation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)
 
-[Back to top](#building-a-kubernetes-operator-with-pepr)
+[Back to top](#introduction)

--- a/docs/040_reference/010_best-practices.md
+++ b/docs/040_reference/010_best-practices.md
@@ -44,7 +44,7 @@ By validating the mutated resource, you ensure it adheres to expected formats, s
 1. Catch Logic Errors in Mutations:
 A mutation may not always produce the intended output due to edge cases, unexpected inputs, or incorrect assumptions in the mutation logic.
 
-Validation helps catch such issues early and becomes _particularly_ important if your Module is [configured](user-guide/customization/#admission-and-watcher-subparameters) to use a Webhook [failurePolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) of `ignore`. In that case, admission requests failures _won't prevent further processing and/or acceptance_ of mutate-failed requests and could result in undesirable resources getting into your cluster!
+Validation helps catch such issues early and becomes _particularly_ important if your Module is [configured](/user-guide/customization/#admission-and-watcher-subparameters) to use a Webhook [failurePolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) of `ignore`. In that case, admission requests failures _won't prevent further processing and/or acceptance_ of mutate-failed requests and could result in undesirable resources getting into your cluster!
 
 1. Comply with Kubernetes Best Practices:
 Kubernetes resources must meet specific structural and functional requirements. Validating ensures compliance, preventing the risk of deployment failures or runtime errors.


### PR DESCRIPTION
## Description
Multiple links in the docs were causing 404 errors. This was due to format errors or incorrect hash links.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
