### PR TITLE
chore: semantic release adr update

### DIFF
--- a/adr/0011-semantic-release.md
+++ b/adr/0011-semantic-release.md
@@ -4,7 +4,7 @@ Date: 2024-07-17
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -27,7 +27,7 @@ Pros:
 - is widely used & well-supported -- with over 1500 commits / 200 contributors / 400 releases on GitHub and a million weekly downloads from NPM (at time of writing) there is very little worry about longevity.
 
 Cons:
-- It takes a [firm](https://github.com/semantic-release/semantic-release/issues/1507) [stance](https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0.0.1) on _not supporting_ "version zero" (v0.0.1) -style workflows and suggests that projects start at v1.0.0 instead.
+- It takes a [firm](https://github.com/semantic-release/semantic-release/issues/1507) [stance](https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0.0.1) on _not supporting_ "version zero" (v0.0.1) -style workflows and suggests that projects start at v1.0.0 instead. We get around this by delegating the actual release to SLSA 3 workflow.
 
 The balance of Pros, the Con-that-isn't-much-of-a-con, and fact that Pepr's sister project, the [Kubernetes Fluent Client (a.k.a. "the KFC")](https://github.com/defenseunicorns/kubernetes-fluent-client), is already using the semantic-release tool makes pulling it into Pepr an easy choice.
 
@@ -39,8 +39,4 @@ We will pull the semantic-release library into the Pepr project and use it as a 
 
 ## Consequences
 
-We will have to transition Pepr away from its "v0"-style (i.e. v0.33.0) versioning  -- a legacy scheme inherited by the current team -- and move into the future using a fully automation-friendly scheme (i.e. v1.0.0) instead.
-
-Due to the way that semantic-release works -- tracking version numbers & release history within the git tags / distrution channels (i.e. NPM) by way of git branches -- the structure of the [Pepr repository](https://github.com/defenseunicorns/pepr/tree/main) must change. Going forward, active development will occur on the `next` branch where validation processes (i.e. CI) will be watching for changes, will test them, and will then merge those changes into to the `main` branch for version tracking & publishing purposes, etc.
-
-Finally, we expect this library to be a core player in the upcoming work for [13. Soak Testing](./0013-soak-testing.md) as well. Specifically, to be used as part of the testing pipeline in order to recommend appropriate release candidate versions (e.g. v1.0.0-rc.1) and facilitate publishing for test.
+Due to the desire to maintain SLSA 3 compliance within Pepr, the actual publishing of releases (i.e. pushing to NPM) will still occur within the SLSA 3 workflow defined in [10. Automated Releases](./0010-automated-releases.md). However, semantic-release will be used to determine the next version number, generate release notes, and create git tags for each release.

--- a/adr/0011-semantic-release.md
+++ b/adr/0011-semantic-release.md
@@ -27,7 +27,7 @@ Pros:
 - is widely used & well-supported -- with over 1500 commits / 200 contributors / 400 releases on GitHub and a million weekly downloads from NPM (at time of writing) there is very little worry about longevity.
 
 Cons:
-- It takes a [firm](https://github.com/semantic-release/semantic-release/issues/1507) [stance](https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0.0.1) on _not supporting_ "version zero" (v0.0.1) -style workflows and suggests that projects start at v1.0.0 instead. We get around this by delegating the actual release to SLSA 3 workflow.
+- It takes a [firm](https://github.com/semantic-release/semantic-release/issues/1507) [stance](https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0.0.1) on _not supporting_ "version zero" (v0.0.1) -style workflows and suggests that projects start at v1.0.0 instead. We get around this by delegating the actual release to a SLSA 3 workflow.
 
 The balance of Pros, the Con-that-isn't-much-of-a-con, and fact that Pepr's sister project, the [Kubernetes Fluent Client (a.k.a. "the KFC")](https://github.com/defenseunicorns/kubernetes-fluent-client), is already using the semantic-release tool makes pulling it into Pepr an easy choice.
 


### PR DESCRIPTION
## Description

When writing a Pepr tip in Kubernetes slack and referencing this ADR I realized it was still proposed, then I also realized it was not technically accureate anymore. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
