### PR TITLE
Determine webhook type inside rule generation function

### DIFF
--- a/src/lib/assets/ignoredNamespaces.ts
+++ b/src/lib/assets/ignoredNamespaces.ts
@@ -1,5 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+import { ModuleConfig } from "../types";
+
+export function getIgnoreNamespaces(config?: ModuleConfig): string[] {
+  const fromConfig = config?.alwaysIgnore?.namespaces?.length
+    ? config.alwaysIgnore.namespaces
+    : config?.admission?.alwaysIgnore?.namespaces;
+
+  return resolveIgnoreNamespaces(fromConfig);
+}
 
 export function resolveIgnoreNamespaces(ignoredNSConfig: string[] = []): string[] {
   const ignoredNSEnv = process.env.PEPR_ADDITIONAL_IGNORED_NAMESPACES;

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -402,7 +402,21 @@ describe("configureAdditionalWebhooks", () => {
     expect(result).toEqual(webhookConfig);
   });
 
-  it("should ignore additionalWebHooks if the original webhookConfig does not contain any webhooks", () => {
+  it("should return the original webhookConfig if no webhooks are present in webhookConfig", () => {
+    const webhookConfig: kind.MutatingWebhookConfiguration = {
+      apiVersion: "admissionregistration.k8s.io/v1",
+      kind: "MutatingWebhookConfiguration",
+      metadata: { name: "test-webhook" },
+    };
+    const additionalWebhooks = [
+      { failurePolicy: "Fail", namespace: "additional-namespace-1" },
+      { failurePolicy: "Ignore", namespace: "additional-namespace-2" },
+    ];
+    const result = configureAdditionalWebhooks(webhookConfig, additionalWebhooks);
+    expect(result).toEqual(webhookConfig);
+  });
+
+  it("should ignore additionalWebHooks if the original webhookConfig contains an empty array of webhooks", () => {
     const webhookConfig: kind.MutatingWebhookConfiguration = {
       apiVersion: "admissionregistration.k8s.io/v1",
       kind: "MutatingWebhookConfiguration",
@@ -571,7 +585,7 @@ describe("buildNamespaceIgnoreExpressions", () => {
     ]);
   });
 
-  it("combines default peprIgnoreNamespaces with onfig.admission.alwaysIgnore.namespaces", () => {
+  it("combines default peprIgnoreNamespaces with config.admission.alwaysIgnore.namespaces", () => {
     const localAssets = createTestAssets({
       config: {
         ...(createTestAssets().config as ModuleConfig),

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -246,6 +246,18 @@ describe("Webhook Management", () => {
       ]);
     });
 
+    it("should include additionawebhooks info in namespace selector", async () => {
+      const additionalWebhooks = [{ failurePolicy: "Ignore", namespace: "additional-namespace-2" }];
+      assets.config.additionalWebhooks = additionalWebhooks;
+      const result = await webhookConfigGenerator(assets, WebhookType.VALIDATE);
+      expect(result!.webhooks![0].namespaceSelector!.matchExpressions![0].values).toEqual([
+        "kube-system",
+        "pepr-system",
+        "cicd",
+        "additional-namespace-2",
+      ]);
+    });
+
     describe("when a host is specified", () => {
       it("should use that host in webhook URL", async () => {
         const assetsWithHost = new Assets(
@@ -376,6 +388,21 @@ describe("configureAdditionalWebhooks", () => {
       webhooks: [],
     };
     const result = configureAdditionalWebhooks(webhookConfig, []);
+    expect(result).toEqual(webhookConfig);
+  });
+
+  it("should ignore additionalWebHooks if the original webhookConfig does not contain any webhooks", () => {
+    const webhookConfig: kind.MutatingWebhookConfiguration = {
+      apiVersion: "admissionregistration.k8s.io/v1",
+      kind: "MutatingWebhookConfiguration",
+      metadata: { name: "test-webhook" },
+      webhooks: [],
+    };
+    const additionalWebhooks = [
+      { failurePolicy: "Fail", namespace: "additional-namespace-1" },
+      { failurePolicy: "Ignore", namespace: "additional-namespace-2" },
+    ];
+    const result = configureAdditionalWebhooks(webhookConfig, additionalWebhooks);
     expect(result).toEqual(webhookConfig);
   });
 

--- a/src/lib/assets/webhooks.test.ts
+++ b/src/lib/assets/webhooks.test.ts
@@ -246,7 +246,7 @@ describe("Webhook Management", () => {
       ]);
     });
 
-    it("should include additionawebhooks info in namespace selector", async () => {
+    it("should include additionalWebhooks info in namespace selector", async () => {
       const additionalWebhooks = [{ failurePolicy: "Ignore", namespace: "additional-namespace-2" }];
       assets.config.additionalWebhooks = additionalWebhooks;
       const result = await webhookConfigGenerator(assets, WebhookType.VALIDATE);
@@ -256,6 +256,17 @@ describe("Webhook Management", () => {
         "cicd",
         "additional-namespace-2",
       ]);
+    });
+
+    it("should return null when no capabilities are included", async () => {
+      const testAssets: Assets = new Assets(
+        loseAssets.config as ModuleConfig,
+        loseAssets.path,
+        loseAssets.imagePullSecrets,
+      );
+      testAssets.capabilities = [];
+      const result = await webhookConfigGenerator(testAssets, WebhookType.VALIDATE);
+      expect(result).toBeNull();
     });
 
     describe("when a host is specified", () => {

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -46,9 +46,10 @@ export const validateRule = (
 
 export async function generateWebhookRules(
   assets: Assets,
-  isMutateWebhook: boolean,
+  webhookType: WebhookType,
 ): Promise<V1RuleWithOperations[]> {
   const { capabilities } = assets;
+  const isMutateWebhook = webhookType === WebhookType.MUTATE;
 
   const rules = capabilities.flatMap(capability =>
     capability.bindings
@@ -61,15 +62,15 @@ export async function generateWebhookRules(
 
 export async function webhookConfigGenerator(
   assets: Assets,
-  mutateOrValidate: WebhookType,
+  webhookType: WebhookType,
   timeoutSeconds = 10,
 ): Promise<kind.MutatingWebhookConfiguration | kind.ValidatingWebhookConfiguration | null> {
-  const rules = await generateWebhookRules(assets, mutateOrValidate === WebhookType.MUTATE);
+  const rules = await generateWebhookRules(assets, webhookType);
   if (rules.length < 1) {
     return null;
   }
 
-  const baseConfig = makeBaseWebhookConfig(assets, mutateOrValidate, timeoutSeconds, rules);
+  const baseConfig = makeBaseWebhookConfig(assets, webhookType, timeoutSeconds, rules);
 
   // If additional webhooks are specified, add them to the config
   if (assets.config.additionalWebhooks) {

--- a/src/lib/assets/webhooks.ts
+++ b/src/lib/assets/webhooks.ts
@@ -149,16 +149,13 @@ export function buildClientConfig(
 export function buildNamespaceIgnoreExpressions(assets: Assets): V1LabelSelectorRequirement[] {
   const { config } = assets;
 
-  const resolved =
-    resolveIgnoreNamespaces(
-      config?.alwaysIgnore?.namespaces?.length
-        ? config.alwaysIgnore.namespaces
-        : config?.admission?.alwaysIgnore?.namespaces,
-    ) ?? [];
+  const resolved = resolveIgnoreNamespaces(
+    config?.alwaysIgnore?.namespaces?.length
+      ? config.alwaysIgnore.namespaces
+      : config?.admission?.alwaysIgnore?.namespaces,
+  );
 
   const ignoreValues = concat(peprIgnoreNamespaces, resolved);
-
-  if (ignoreValues.length === 0) return [];
 
   return [
     {

--- a/src/lib/assets/yaml/overridesFile.test.ts
+++ b/src/lib/assets/yaml/overridesFile.test.ts
@@ -3,7 +3,18 @@
 
 import { expect, describe, it, vi, type Mock, beforeEach } from "vitest";
 import { promises as fs } from "fs";
-import { overridesFile, writeSchemaYamlFromObject } from "./overridesFile";
+import {
+  overridesFile,
+  writeSchemaYamlFromObject,
+  runIdsForImage,
+  commonProbes,
+  podSecurityContext,
+  controllerAnnotations,
+  namespaceBlock,
+  commonResources,
+  controllerLabels,
+  containerSecurityContext,
+} from "./overridesFile";
 import type { ChartOverrides } from "./overridesFile";
 import { load as loadYaml } from "js-yaml";
 import { ModuleConfig } from "../../types";
@@ -268,5 +279,140 @@ describe("overridesFile", () => {
 
     expect(featuresDef.required).toEqual(expect.arrayContaining(["enabled"]));
     expect(featuresDef.required).toHaveLength(1);
+  });
+});
+
+describe("overrides helpers", () => {
+  describe("runIdsForImage", () => {
+    it("returns 1000 uid/gid/fsGroup for images containing 'private'", () => {
+      const ids = runIdsForImage("ghcr.io/org/private-controller:1.2.3");
+      expect(ids).toEqual({ uid: 1000, gid: 1000, fsGroup: 1000 });
+    });
+
+    it("returns 65532 uid/gid/fsGroup for non-private images", () => {
+      const ids = runIdsForImage("ghcr.io/org/controller:1.2.3");
+      expect(ids).toEqual({ uid: 65532, gid: 65532, fsGroup: 65532 });
+    });
+  });
+
+  describe("commonProbes", () => {
+    it("returns HTTPS /healthz probes on port 3000 with 10s initial delay", () => {
+      const probes = commonProbes();
+      expect(probes).toEqual({
+        readinessProbe: {
+          httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
+          initialDelaySeconds: 10,
+        },
+        livenessProbe: {
+          httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
+          initialDelaySeconds: 10,
+        },
+      });
+    });
+  });
+
+  describe("commonResources", () => {
+    it("returns expected CPU/memory requests and limits", () => {
+      const res = commonResources();
+      expect(res).toEqual({
+        requests: { memory: "256Mi", cpu: "200m" },
+        limits: { memory: "512Mi", cpu: "500m" },
+      });
+    });
+  });
+
+  describe("podSecurityContext", () => {
+    it("maps ids from runIdsForImage for non-private images", () => {
+      const ctx = podSecurityContext("repo/controller:latest");
+      expect(ctx).toEqual({
+        runAsUser: 65532,
+        runAsGroup: 65532,
+        runAsNonRoot: true,
+        fsGroup: 65532,
+      });
+    });
+
+    it("maps ids from runIdsForImage for private images", () => {
+      const ctx = podSecurityContext("repo/private-controller:latest");
+      expect(ctx).toEqual({
+        runAsUser: 1000,
+        runAsGroup: 1000,
+        runAsNonRoot: true,
+        fsGroup: 1000,
+      });
+    });
+  });
+
+  describe("containerSecurityContext", () => {
+    it("returns non-root, no-priv-esc, drop ALL caps for non-private images", () => {
+      const ctx = containerSecurityContext("repo/controller:latest");
+      expect(ctx).toEqual({
+        runAsUser: 65532,
+        runAsGroup: 65532,
+        runAsNonRoot: true,
+        allowPrivilegeEscalation: false,
+        capabilities: { drop: ["ALL"] },
+      });
+    });
+
+    it("returns non-root, no-priv-esc, drop ALL caps for private images with user 1000", () => {
+      const ctx = containerSecurityContext("repo/private-controller:latest");
+      expect(ctx).toEqual({
+        runAsUser: 1000,
+        runAsGroup: 1000,
+        runAsNonRoot: true,
+        allowPrivilegeEscalation: false,
+        capabilities: { drop: ["ALL"] },
+      });
+    });
+  });
+
+  describe("controllerLabels", () => {
+    it("sets app to name for admission", () => {
+      const labels = controllerLabels("pepr", "uuid-123", "admission");
+      expect(labels).toEqual({
+        app: "pepr",
+        "pepr.dev/controller": "admission",
+        "pepr.dev/uuid": "uuid-123",
+      });
+    });
+
+    it("sets app to name-watcher for watcher", () => {
+      const labels = controllerLabels("pepr", "uuid-123", "watcher");
+      expect(labels).toEqual({
+        app: "pepr-watcher",
+        "pepr.dev/controller": "watcher",
+        "pepr.dev/uuid": "uuid-123",
+      });
+    });
+  });
+
+  describe("controllerAnnotations", () => {
+    it("includes description when provided", () => {
+      expect(controllerAnnotations("hello")).toEqual({ "pepr.dev/description": "hello" });
+    });
+
+    it("falls back to empty string when description is undefined", () => {
+      expect(controllerAnnotations()).toEqual({ "pepr.dev/description": "" });
+    });
+  });
+
+  describe("namespaceBlock", () => {
+    it("returns default label when no custom namespace labels are provided", () => {
+      const cfg = { customLabels: undefined } as unknown as ModuleConfig;
+      const ns = namespaceBlock(cfg);
+      expect(ns).toEqual({ annotations: {}, labels: { "pepr.dev": "" } });
+    });
+
+    it("returns provided custom namespace labels when present", () => {
+      const cfg = {
+        customLabels: { namespace: { "pepr.dev/custom": "x", team: "unicorns" } },
+      } as unknown as ModuleConfig;
+      const ns = namespaceBlock(cfg);
+      expect(ns).toEqual({
+        annotations: {},
+        labels: { "pepr.dev/custom": "x", team: "unicorns" },
+      });
+    });
   });
 });

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -14,7 +14,7 @@ export type ChartOverrides = {
   name: string;
   image: string;
 };
-export type Probes = {
+type Probes = {
   readinessProbe: {
     httpGet: { path: string; port: number; scheme: "HTTPS" };
     initialDelaySeconds: number;
@@ -24,17 +24,17 @@ export type Probes = {
     initialDelaySeconds: number;
   };
 };
-export type Resources = {
+type Resources = {
   requests: { memory: string; cpu: string };
   limits: { memory: string; cpu: string };
 };
-export type PodSecurityContext = {
+type PodSecurityContext = {
   runAsUser: number;
   runAsGroup: number;
   runAsNonRoot: true;
   fsGroup: number;
 };
-export type ContainerSecurityContext = {
+type ContainerSecurityContext = {
   runAsUser: number;
   runAsGroup: number;
   runAsNonRoot: true;
@@ -114,7 +114,6 @@ export async function overridesFile(
     },
   };
 
-  // write values.schema.yaml
   await writeSchemaYamlFromObject(JSON.stringify(overrides, null, 2), path);
   // write values.yaml
   await fs.writeFile(path, dumpYaml(overrides, { noRefs: true, forceQuotes: true }));
@@ -139,12 +138,12 @@ export async function writeSchemaYamlFromObject(
   await fs.writeFile(schemaPath, JSON.stringify(schemaObj, null, 2), "utf8");
 }
 
-export function runIdsForImage(image: string): { uid: number; gid: number; fsGroup: number } {
+function runIdsForImage(image: string): { uid: number; gid: number; fsGroup: number } {
   const id = image.includes("private") ? 1000 : 65532;
   return { uid: id, gid: id, fsGroup: id };
 }
 
-export function commonProbes(): Probes {
+function commonProbes(): Probes {
   return {
     readinessProbe: {
       httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
@@ -157,14 +156,14 @@ export function commonProbes(): Probes {
   };
 }
 
-export function commonResources(): Resources {
+function commonResources(): Resources {
   return {
     requests: { memory: "256Mi", cpu: "200m" },
     limits: { memory: "512Mi", cpu: "500m" },
   };
 }
 
-export function podSecurityContext(image: string): PodSecurityContext {
+function podSecurityContext(image: string): PodSecurityContext {
   const ids = runIdsForImage(image);
   return {
     runAsUser: ids.uid,
@@ -174,7 +173,7 @@ export function podSecurityContext(image: string): PodSecurityContext {
   };
 }
 
-export function containerSecurityContext(image: string): ContainerSecurityContext {
+function containerSecurityContext(image: string): ContainerSecurityContext {
   const ids = runIdsForImage(image);
   return {
     runAsUser: ids.uid,
@@ -185,7 +184,7 @@ export function containerSecurityContext(image: string): ContainerSecurityContex
   };
 }
 
-export function controllerLabels(
+function controllerLabels(
   name: string,
   uuid: string,
   kind: "admission" | "watcher",
@@ -197,11 +196,11 @@ export function controllerLabels(
   };
 }
 
-export function controllerAnnotations(description?: string): Record<string, string> {
+function controllerAnnotations(description?: string): Record<string, string> {
   return { "pepr.dev/description": `${description ?? ""}` };
 }
 
-export function namespaceBlock(config: ModuleConfig): {
+function namespaceBlock(config: ModuleConfig): {
   annotations: Record<string, string>;
   labels: Record<string, string>;
 } {

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -42,6 +42,7 @@ export type ContainerSecurityContext = {
   capabilities: { drop: ["ALL"] };
 };
 
+// Helm Chart overrides file (values.yaml) generated from assets
 export async function overridesFile(
   { hash, name, image, config, apiPath, capabilities }: ChartOverrides,
   path: string,
@@ -54,7 +55,7 @@ export async function overridesFile(
     imagePullSecrets,
     additionalIgnoredNamespaces: resolveIgnoreNamespaces(
       config?.alwaysIgnore?.namespaces?.length
-        ? config.alwaysIgnore.namespaces
+        ? config?.alwaysIgnore?.namespaces
         : config?.admission?.alwaysIgnore?.namespaces,
     ),
     rbac: rbacOverrides,

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -3,7 +3,7 @@ import { CapabilityExport, ModuleConfig } from "../../types";
 import { dumpYaml } from "@kubernetes/client-node";
 import { clusterRole } from "../rbac";
 import { promises as fs } from "fs";
-import { resolveIgnoreNamespaces } from "../ignoredNamespaces";
+import { getIgnoreNamespaces } from "../ignoredNamespaces";
 import { quicktype, InputData, jsonInputForTargetLanguage } from "quicktype-core";
 
 export type ChartOverrides = {
@@ -53,11 +53,7 @@ export async function overridesFile(
 
   const overrides = {
     imagePullSecrets,
-    additionalIgnoredNamespaces: resolveIgnoreNamespaces(
-      config?.alwaysIgnore?.namespaces?.length
-        ? config?.alwaysIgnore?.namespaces
-        : config?.admission?.alwaysIgnore?.namespaces,
-    ),
+    additionalIgnoredNamespaces: getIgnoreNamespaces(config),
     rbac: rbacOverrides,
     secrets: { apiPath: Buffer.from(apiPath).toString("base64") },
     hash,

--- a/src/lib/controller/index.test.ts
+++ b/src/lib/controller/index.test.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 import { afterEach, describe, it, vi, beforeEach, expect } from "vitest";
-import { Controller, ControllerHooks } from "./index";
+import { Controller, ControllerHooks, getContextAndLog } from "./index";
 import { Capability } from "../core/capability";
 import { ModuleConfig, CapabilityCfg } from "../types";
+import { AdmissionRequest } from "../common-types";
+import { Operation } from "../enums";
+import express from "express";
 
 vi.mock("./store", () => {
   return {
@@ -56,5 +59,66 @@ describe("Controller", () => {
   it("should initialize with provided config, capabilities, and hooks", () => {
     expect(controller).toBeDefined();
     expect(mockHooks.onReady).toHaveBeenCalled();
+  });
+});
+
+describe("getContextAndLog", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("builds reqMetadata with name prefixed by '/', preserves namespace & kind, logs info/debug, and returns context", () => {
+    const request: AdmissionRequest = {
+      uid: "abc-123",
+      name: "my-cm",
+      namespace: "demo",
+      kind: { group: "", version: "v1", kind: "ConfigMap" },
+      resource: { group: "", version: "v1", resource: "configmaps" },
+      operation: Operation.CREATE,
+      object: {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: { name: "my-cm", namespace: "demo" },
+      },
+      userInfo: {},
+    };
+
+    const req = { body: { request } } as unknown as express.Request;
+
+    const result = getContextAndLog(req, "Mutate");
+
+    expect(result.request).toBe(request);
+    expect(result.reqMetadata).toEqual({ uid: "abc-123", namespace: "demo", name: "/my-cm" });
+  });
+
+  it("handles missing fields: empty name/namespace, default gvk, undefined uid/operation", () => {
+    const req = { body: {} } as unknown as express.Request;
+
+    const result = getContextAndLog(req, "Validate");
+
+    expect(result.reqMetadata).toEqual({
+      uid: undefined as unknown as string,
+      namespace: "",
+      name: "",
+    });
+  });
+
+  it("does not prefix name when request.name is falsy", () => {
+    const request = {
+      uid: "z-1",
+      name: "", // falsy
+      namespace: "",
+      kind: undefined,
+      operation: undefined,
+      // minimal object to satisfy type at runtime; not strictly required for the function
+      object: { apiVersion: "v1", kind: "ConfigMap", metadata: { name: "" } },
+      resource: { group: "", version: "v1", resource: "configmaps" },
+      userInfo: {},
+    } as unknown as AdmissionRequest;
+
+    const req = { body: { request } } as unknown as express.Request;
+
+    const { reqMetadata } = getContextAndLog(req, "Mutate");
+    expect(reqMetadata.name).toBe(""); // no leading slash when name is falsy
   });
 });

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -307,7 +307,7 @@ export class Controller {
   }
 }
 
-function getContextAndLog(
+export function getContextAndLog(
   req: express.Request,
   admissionKind: "Mutate" | "Validate",
 ): {

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -221,6 +221,7 @@ export class Controller {
   ): ((req: express.Request, res: express.Response) => Promise<void>) => {
     // Create the admission request handler
     return async (req: express.Request, res: express.Response) => {
+      // Start the metrics timer
       const startTime = MetricsCollector.observeStart();
 
       try {
@@ -231,6 +232,7 @@ export class Controller {
           this.#beforeHook(request || {});
         }
 
+        // Process the request
         const response: MutateResponse | ValidateResponse[] =
           admissionKind === "Mutate"
             ? await mutateProcessor(this.#config, this.#capabilities, request, reqMetadata)

--- a/src/lib/core/capability.test.ts
+++ b/src/lib/core/capability.test.ts
@@ -20,12 +20,6 @@ import { OnSchedule } from "./schedule";
 import { AdmissionRequest } from "../common-types";
 import type { Logger } from "pino";
 
-interface PartialLogger {
-  info: (...args: unknown[]) => void;
-  debug?: (...args: unknown[]) => void;
-  child?: (...args: unknown[]) => PartialLogger;
-}
-
 // Mocking isBuildMode, isWatchMode, and isDevMode globally
 vi.mock("./envChecks", () => ({
   isBuildMode: vi.fn(() => true),
@@ -151,7 +145,7 @@ describe("Capability", () => {
     const capability = new Capability(capabilityConfig);
 
     const mockMutateCallback: MutateAction<typeof V1Pod, V1Pod> = vi.fn(
-      async (req: PeprMutateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+      async (req: PeprMutateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("Executing mutation action");
       },
     );
@@ -187,8 +181,8 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockMutateCallback: MutateAction<typeof V1Pod, V1Pod> = vi.fn(
-        (req: PeprMutateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
-          logger.info("Mutate action log");
+        async (req: PeprMutateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
+          logger.info("Executing mutation action");
         },
       );
 
@@ -213,7 +207,7 @@ describe("Capability", () => {
       expect(mockMutateCallback).toHaveBeenCalledWith(peprRequest, expect.anything());
       expect(mockLog.child).toHaveBeenCalledWith({ alias: "test-alias" });
       expect(mockLog.info).toHaveBeenCalledWith("Executing mutation action with alias: test-alias");
-      expect(mockLog.info).toHaveBeenCalledWith("Mutate action log");
+      expect(mockLog.info.mock.calls.flat()).toContain("Executing mutation action");
     });
 
     it("should handle complex alias and logging correctly", async () => {
@@ -226,8 +220,8 @@ describe("Capability", () => {
       const capability = new Capability(complexCapabilityConfig);
 
       const mockMutateCallback: MutateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (po: PeprMutateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
-          logger.info(`SNAKES ON A PLANE! ${po.Raw.metadata?.name}`);
+        async (req: PeprMutateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
+          logger.info(`SNAKES ON A PLANE! ${req.Raw.metadata?.name}`);
         },
       );
 
@@ -270,7 +264,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (req: PeprValidateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+        async (req: PeprValidateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Validate action log");
           return { allowed: true };
         },
@@ -303,7 +297,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockReconcileCallback: WatchLogAction<typeof V1Pod> = vi.fn(
-        async (update, phase, logger: PartialLogger = mockLog) => {
+        async (update, phase, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Reconcile action log");
         },
       );
@@ -329,7 +323,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockFinalizeCallback: FinalizeAction<typeof V1Pod> = vi.fn(
-        async (update, logger: PartialLogger = mockLog) => {
+        async (update, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Finalize action log");
         },
       );
@@ -368,8 +362,8 @@ describe("Capability", () => {
 
       // Mock the watch callback
       const mockWatchCallback: WatchLogAction<typeof V1Pod> = vi.fn(
-        async (update: V1Pod, phase: WatchPhase, logger?: typeof Log) => {
-          logger?.info("Watch action log");
+        async (update, phase, logger: Logger = mockLog as unknown as Logger) => {
+          logger.info("Watch action executed");
         },
       );
 
@@ -383,7 +377,33 @@ describe("Capability", () => {
       const testPod = new V1Pod();
       await binding.watchCallback?.(testPod, WatchPhase.Added); // No logger passed
 
-      expect(mockLog.info).toHaveBeenCalledWith("Watch action log");
+      expect(mockLog.info.mock.calls.flat()).toContain("Watch action executed");
+    });
+
+    it("should log alias during Watch and Reconcile actions", async () => {
+      const capability = new Capability({
+        name: "alias-cap",
+        description: "alias test",
+        namespaces: [],
+      });
+
+      const mockWatchCallback = vi.fn(async () => {});
+      const mockReconcileCallback = vi.fn(async () => {});
+      const testPod = new V1Pod();
+
+      // Watch with alias
+      capability.When(a.Pod).IsCreated().Alias("watch-alias").Watch(mockWatchCallback);
+
+      await capability.bindings[0].watchCallback?.(testPod, WatchPhase.Added);
+      expect(Log.info).toHaveBeenCalledWith("Executing watch action with alias: watch-alias");
+
+      // Reconcile with alias
+      capability.When(a.Pod).IsCreated().Alias("reconcile-alias").Reconcile(mockReconcileCallback);
+
+      await capability.bindings[1].watchCallback?.(testPod, WatchPhase.Modified);
+      expect(Log.info).toHaveBeenCalledWith(
+        "Executing reconcile action with alias: reconcile-alias",
+      );
     });
   });
 
@@ -391,13 +411,13 @@ describe("Capability", () => {
     const capability = new Capability(capabilityConfig);
 
     const firstMutateCallback: MutateAction<typeof V1Pod, V1Pod> = vi.fn(
-      async (req: PeprMutateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+      async (req: PeprMutateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("First mutation action");
       },
     );
 
     const secondMutateCallback: MutateAction<typeof V1Pod, V1Pod> = vi.fn(
-      async (req: PeprMutateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+      async (req: PeprMutateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("Second mutation action");
       },
     );
@@ -438,7 +458,7 @@ describe("Capability", () => {
 
     // Mock Watch callback function
     const mockWatchCallback: WatchLogAction<typeof V1Pod> = vi.fn(
-      async (update, phase, logger: PartialLogger = mockLog) => {
+      async (update, phase, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("Watch action executed");
       },
     );
@@ -466,7 +486,7 @@ describe("Capability", () => {
     const capability = new Capability(capabilityConfig);
 
     const mockWatchCallback: WatchLogAction<typeof V1Pod> = vi.fn(
-      async (update, phase, logger: PartialLogger = mockLog) => {
+      async (update, phase, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("Watch action executed");
       },
     );
@@ -490,13 +510,13 @@ describe("Capability", () => {
     const capability = new Capability(capabilityConfig);
 
     const mockReconcileCallback: WatchLogAction<typeof V1Pod> = vi.fn(
-      async (update, phase, logger: PartialLogger = mockLog) => {
-        logger.info("external api call (reconcile-create-alias): reconcile/callback");
+      async (update, phase, logger: Logger = mockLog as unknown as Logger) => {
+        logger.info("Reconcile action log");
       },
     );
 
     const mockFinalizeCallback: FinalizeAction<typeof V1Pod> = vi.fn(
-      async (update: V1Pod, logger: PartialLogger = mockLog) => {
+      async (update, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("Finalize action log");
       },
     );
@@ -535,13 +555,13 @@ describe("Capability", () => {
     const capability = new Capability(capabilityConfig);
 
     const mockWatchCallback: WatchLogAction<typeof V1Pod> = vi.fn(
-      async (update, phase, logger: PartialLogger = mockLog) => {
-        logger.info("external api call (watch-create-alias): watch/callback");
+      async (update, phase, logger: Logger = mockLog as unknown as Logger) => {
+        logger.info("Watch action executed");
       },
     );
 
     const mockFinalizeCallback: FinalizeAction<typeof V1Pod> = vi.fn(
-      async (update: V1Pod, logger: PartialLogger = mockLog) => {
+      async (update, logger: Logger = mockLog as unknown as Logger) => {
         logger.info("Finalize action log");
       },
     );
@@ -581,7 +601,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (req: PeprValidateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+        async (req: PeprValidateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Validate action log");
           return { allowed: true };
         },
@@ -601,7 +621,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (req: PeprValidateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+        async (req: PeprValidateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Validate action log");
           return { allowed: true };
         },
@@ -621,7 +641,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (req: PeprValidateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+        async (req: PeprValidateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Validate action log");
           return { allowed: true };
         },
@@ -643,7 +663,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (req: PeprValidateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+        async (req: PeprValidateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Validate action log");
           return { allowed: true };
         },
@@ -659,7 +679,7 @@ describe("Capability", () => {
       const capability = new Capability(capabilityConfig);
 
       const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(
-        async (req: PeprValidateRequest<V1Pod>, logger: PartialLogger = mockLog) => {
+        async (req: PeprValidateRequest<V1Pod>, logger: Logger = mockLog as unknown as Logger) => {
           logger.info("Validate action log");
           return { allowed: true };
         },
@@ -754,5 +774,200 @@ describe("Capability", () => {
     capability.When(a.Pod).IsCreatedOrUpdated().WithAnnotation("test-annotation");
 
     expect(capability.bindings).toHaveLength(0);
+  });
+
+  it("should return no-op chains when admission is disabled", async () => {
+    // Reset modules so registerAdmission is recomputed on import
+    vi.resetModules();
+
+    // Update envChecks mocks to simulate admission disabled (isBuildMode=false, isWatchMode=true)
+    const env = await import("./envChecks");
+    (env.isBuildMode as unknown as Mock).mockReturnValue(false);
+    (env.isWatchMode as unknown as Mock).mockReturnValue(true);
+
+    // Re-import Capability so it picks up the changed envChecks behaviour
+    const { Capability: CapabilityLocal } = await import("./capability");
+
+    const capability = new CapabilityLocal(capabilityConfig);
+
+    const mockValidate: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(async () => ({
+      allowed: true,
+    }));
+    const validateChain = capability.When(a.Pod).IsCreatedOrUpdated().Validate(mockValidate);
+
+    // The returned chain functions are no-ops when admission is disabled; use any-casts to call them
+    const finalizeChain = (
+      validateChain as unknown as { Watch: () => { Finalize: () => void } }
+    ).Watch();
+    expect(finalizeChain.Finalize()).toBeUndefined();
+
+    const reconcileChain = (
+      validateChain as unknown as { Reconcile: () => { Finalize: () => void } }
+    ).Reconcile();
+    expect(reconcileChain.Finalize()).toBeUndefined();
+
+    // Mutate should also return no-op chains when admission disabled
+    const mockMutate: MutateAction<typeof V1Pod, V1Pod> = vi.fn(async () => undefined);
+    const mutateChain = capability.When(a.Pod).IsCreatedOrUpdated().Mutate(mockMutate);
+    const mutateWatch = (
+      mutateChain as unknown as { Watch: () => { Finalize: () => void } }
+    ).Watch();
+    expect(mutateWatch.Finalize()).toBeUndefined();
+
+    const mutateValidate = (
+      mutateChain as unknown as { Validate: () => { Watch: () => { Finalize: () => void } } }
+    ).Validate();
+    const mvWatch = mutateValidate.Watch();
+    expect(mvWatch.Finalize()).toBeUndefined();
+
+    // No bindings should have been added because admission is disabled
+    expect(capability.bindings).toHaveLength(0);
+
+    // Restore module state for subsequent tests
+    vi.resetModules();
+  });
+
+  it("should set regex name filter with WithNameRegex and regex namespaces with InNamespaceRegex", () => {
+    const capability = new Capability(capabilityConfig);
+
+    const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(async () => ({
+      allowed: true,
+    }));
+
+    capability
+      .When(a.Pod)
+      .IsCreatedOrUpdated()
+      .WithNameRegex(/foo-.*/)
+      .Validate(mockValidateCallback);
+
+    expect(capability.bindings).toHaveLength(1);
+    expect(capability.bindings[0].filters.regexName).toBe("foo-.*");
+
+    // Test InNamespaceRegex
+    const capability2 = new Capability(capabilityConfig);
+
+    capability2
+      .When(a.Pod)
+      .IsCreatedOrUpdated()
+      .InNamespaceRegex(/ns-1/, /ns-2/)
+      .Validate(mockValidateCallback);
+
+    expect(capability2.bindings).toHaveLength(1);
+    expect(capability2.bindings[0].filters.regexNamespaces).toContain("ns-1");
+    expect(capability2.bindings[0].filters.regexNamespaces).toContain("ns-2");
+  });
+
+  it("should return no-op chains when admission is disabled", async () => {
+    // Reset modules so registerAdmission is recomputed on import
+    vi.resetModules();
+
+    // Update envChecks mocks to simulate admission disabled (isBuildMode=false, isWatchMode=true)
+    const env = await import("./envChecks");
+    (env.isBuildMode as unknown as Mock).mockReturnValue(false);
+    (env.isWatchMode as unknown as Mock).mockReturnValue(true);
+
+    // Re-import Capability so it picks up the changed envChecks behaviour
+    const { Capability: CapabilityLocal } = await import("./capability");
+
+    const capability = new CapabilityLocal(capabilityConfig);
+
+    const mockValidate: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(async () => ({
+      allowed: true,
+    }));
+    const validateChain = capability.When(a.Pod).IsCreatedOrUpdated().Validate(mockValidate);
+
+    // The returned chain functions are no-ops when admission is disabled; use any-casts to call them
+    const finalizeChain = (
+      validateChain as unknown as { Watch: () => { Finalize: () => void } }
+    ).Watch();
+    expect(finalizeChain.Finalize()).toBeUndefined();
+
+    const reconcileChain = (
+      validateChain as unknown as { Reconcile: () => { Finalize: () => void } }
+    ).Reconcile();
+    expect(reconcileChain.Finalize()).toBeUndefined();
+
+    // Mutate should also return no-op chains when admission disabled
+    const mockMutate: MutateAction<typeof V1Pod, V1Pod> = vi.fn(async () => undefined);
+    const mutateChain = capability.When(a.Pod).IsCreatedOrUpdated().Mutate(mockMutate);
+    const mutateWatch = (
+      mutateChain as unknown as { Watch: () => { Finalize: () => void } }
+    ).Watch();
+    expect(mutateWatch.Finalize()).toBeUndefined();
+
+    const mutateValidate = (
+      mutateChain as unknown as { Validate: () => { Watch: () => { Finalize: () => void } } }
+    ).Validate();
+    const mvWatch = mutateValidate.Watch();
+    expect(mvWatch.Finalize()).toBeUndefined();
+
+    // No bindings should have been added because admission is disabled
+    expect(capability.bindings).toHaveLength(0);
+
+    // Restore module state for subsequent tests
+    vi.resetModules();
+  });
+
+  it("should return no-op Finalize when watch is disabled", async () => {
+    vi.resetModules();
+
+    vi.doMock("./envChecks", () => ({
+      isBuildMode: vi.fn(() => false),
+      isWatchMode: vi.fn(() => false),
+      isDevMode: vi.fn(() => false),
+    }));
+
+    const { Capability: CapabilityLocal } = await import("./capability");
+    const capability = new CapabilityLocal({
+      name: "test",
+      description: "desc",
+      namespaces: [],
+    });
+
+    const noopWatch = capability
+      .When(a.Pod)
+      .IsCreated()
+      .Watch(() => {}) as unknown as { Finalize: () => void | undefined };
+
+    expect(noopWatch.Finalize()).toBeUndefined();
+
+    const noopReconcile = capability
+      .When(a.Pod)
+      .IsCreated()
+      .Reconcile(() => {}) as unknown as { Finalize: () => void | undefined };
+
+    expect(noopReconcile.Finalize()).toBeUndefined();
+
+    vi.resetModules();
+  });
+
+  it("should set regex name filter with WithNameRegex and regex namespaces with InNamespaceRegex", () => {
+    const capability = new Capability(capabilityConfig);
+
+    const mockValidateCallback: ValidateAction<typeof V1Pod, V1Pod> = vi.fn(async () => ({
+      allowed: true,
+    }));
+
+    capability
+      .When(a.Pod)
+      .IsCreatedOrUpdated()
+      .WithNameRegex(/foo-.*/)
+      .Validate(mockValidateCallback);
+
+    expect(capability.bindings).toHaveLength(1);
+    expect(capability.bindings[0].filters.regexName).toBe("foo-.*");
+
+    // Test InNamespaceRegex
+    const capability2 = new Capability(capabilityConfig);
+
+    capability2
+      .When(a.Pod)
+      .IsCreatedOrUpdated()
+      .InNamespaceRegex(/ns-1/, /ns-2/)
+      .Validate(mockValidateCallback);
+
+    expect(capability2.bindings).toHaveLength(1);
+    expect(capability2.bindings[0].filters.regexNamespaces).toContain("ns-1");
+    expect(capability2.bindings[0].filters.regexNamespaces).toContain("ns-2");
   });
 });

--- a/src/lib/core/capability.ts
+++ b/src/lib/core/capability.ts
@@ -10,8 +10,7 @@ import { OnSchedule, Schedule } from "./schedule";
 import { Event } from "../enums";
 import {
   Binding,
-  BindingFilter,
-  BindingWithName,
+  BindingAll,
   CapabilityCfg,
   CapabilityExport,
   MutateAction,
@@ -171,22 +170,214 @@ export class Capability implements CapabilityExport {
     return this.#store;
   };
 
+  private static createAliasLogger(alias?: string): typeof Log {
+    return Log.child({ alias: alias || "no alias provided" });
+  }
+
+  private static logBinding(
+    capabilityPrefix: string,
+    label: string,
+    binding: Binding,
+    fn: (...args: unknown[]) => unknown,
+  ): void {
+    const isNotEmpty = (value: unknown): boolean =>
+      typeof value === "object" && value !== null ? Object.keys(value).length > 0 : true;
+
+    const filteredObj = pickBy(isNotEmpty, binding.filters);
+    Log.info({ prefix: capabilityPrefix }, `${label} configured for ${binding.event}`);
+    Log.info({ prefix: capabilityPrefix }, JSON.stringify(filteredObj));
+    Log.debug({ prefix: capabilityPrefix }, fn.toString());
+  }
+
+  private static registerValidate<T extends GenericClass>(
+    prefix: string,
+    binding: Binding,
+    bindings: Binding[],
+    validateCallback: ValidateAction<T>,
+  ): ValidateActionChain<T> {
+    if (!registerAdmission) {
+      const noopFinalize: FinalizeActionChain<T> = { Finalize: () => undefined };
+      return {
+        Watch: () => noopFinalize,
+        Reconcile: () => noopFinalize,
+      };
+    }
+
+    Capability.logBinding(
+      prefix,
+      "Validate Action",
+      binding,
+      validateCallback as unknown as (...args: unknown[]) => unknown,
+    );
+    const aliasLogger = Capability.createAliasLogger(binding.alias);
+
+    bindings.push({
+      ...binding,
+      isValidate: true,
+      validateCallback: async (req, logger = aliasLogger) => {
+        if (binding.alias) Log.info(`Executing validate action with alias: ${binding.alias}`);
+        return await validateCallback(req, logger);
+      },
+    });
+
+    return {
+      Watch: Capability.registerWatch.bind(Capability, prefix, binding, bindings),
+      Reconcile: Capability.registerReconcile.bind(Capability, prefix, binding, bindings),
+    };
+  }
+
+  private static registerMutate<T extends GenericClass>(
+    prefix: string,
+    binding: Binding,
+    bindings: Binding[],
+    mutateCallback: MutateAction<T>,
+  ): MutateActionChain<T> {
+    if (!registerAdmission) {
+      const noopFinalize: FinalizeActionChain<T> = { Finalize: () => undefined };
+      const noopValidate: ValidateActionChain<T> = {
+        Watch: () => noopFinalize,
+        Reconcile: () => noopFinalize,
+      };
+      return {
+        Watch: () => noopFinalize,
+        Validate: () => noopValidate,
+        Reconcile: () => noopFinalize,
+      };
+    }
+
+    Capability.logBinding(
+      prefix,
+      "Mutate Action",
+      binding,
+      mutateCallback as unknown as (...args: unknown[]) => unknown,
+    );
+    const aliasLogger = Capability.createAliasLogger(binding.alias);
+
+    bindings.push({
+      ...binding,
+      isMutate: true,
+      mutateCallback: async (req, logger = aliasLogger) => {
+        if (binding.alias) Log.info(`Executing mutation action with alias: ${binding.alias}`);
+        await mutateCallback(req, logger);
+      },
+    });
+
+    return {
+      Watch: Capability.registerWatch.bind(Capability, prefix, binding, bindings),
+      Validate: Capability.registerValidate.bind(Capability, prefix, binding, bindings),
+      Reconcile: Capability.registerReconcile.bind(Capability, prefix, binding, bindings),
+    };
+  }
+
+  private static registerWatch<T extends GenericClass>(
+    prefix: string,
+    binding: Binding,
+    bindings: Binding[],
+    watchCallback: WatchLogAction<T>,
+  ): FinalizeActionChain<T> {
+    if (!registerWatch) return { Finalize: () => undefined };
+
+    Capability.logBinding(
+      prefix,
+      "Watch Action",
+      binding,
+      watchCallback as unknown as (...args: unknown[]) => unknown,
+    );
+    const aliasLogger = Capability.createAliasLogger(binding.alias);
+
+    bindings.push({
+      ...binding,
+      isWatch: true,
+      watchCallback: async (update, phase, logger = aliasLogger) => {
+        if (binding.alias) Log.info(`Executing watch action with alias: ${binding.alias}`);
+        await watchCallback(update, phase, logger);
+      },
+    });
+
+    return { Finalize: Capability.registerFinalize.bind(Capability, prefix, binding, bindings) };
+  }
+
+  private static registerReconcile<T extends GenericClass>(
+    prefix: string,
+    binding: Binding,
+    bindings: Binding[],
+    reconcileCallback: WatchLogAction<T>,
+  ): FinalizeActionChain<T> {
+    if (!registerWatch) return { Finalize: () => undefined };
+
+    Capability.logBinding(
+      prefix,
+      "Reconcile Action",
+      binding,
+      reconcileCallback as unknown as (...args: unknown[]) => unknown,
+    );
+    const aliasLogger = Capability.createAliasLogger(binding.alias);
+
+    bindings.push({
+      ...binding,
+      isWatch: true,
+      isQueue: true,
+      watchCallback: async (update, phase, logger = aliasLogger) => {
+        if (binding.alias) Log.info(`Executing reconcile action with alias: ${binding.alias}`);
+        await reconcileCallback(update, phase, logger);
+      },
+    });
+
+    return { Finalize: Capability.registerFinalize.bind(Capability, prefix, binding, bindings) };
+  }
+
+  private static registerFinalize<T extends GenericClass>(
+    prefix: string,
+    binding: Binding,
+    bindings: Binding[],
+    finalizeCallback: FinalizeAction<T>,
+  ): void {
+    Capability.logBinding(
+      prefix,
+      "Finalize Action",
+      binding,
+      finalizeCallback as unknown as (...args: unknown[]) => unknown,
+    );
+    const aliasLogger = Capability.createAliasLogger(binding.alias);
+
+    if (registerAdmission) {
+      bindings.push({
+        ...binding,
+        isMutate: true,
+        isFinalize: true,
+        event: Event.ANY,
+        mutateCallback: addFinalizer,
+      });
+    }
+
+    if (registerWatch) {
+      bindings.push({
+        ...binding,
+        isWatch: true,
+        isFinalize: true,
+        event: Event.UPDATE,
+        finalizeCallback: async (update, logger = aliasLogger): Promise<boolean | void> => {
+          if (binding.alias) Log.info(`Executing finalize action with alias: ${binding.alias}`);
+          return await finalizeCallback(update, logger);
+        },
+      });
+    }
+  }
+
   /**
-   * The When method is used to register a action to be executed when a Kubernetes resource is
-   * processed by Pepr. The action will be executed if the resource matches the specified kind and any
-   * filters that are applied.
+   * Registers actions to execute when Kubernetes resources of a given kind are processed by Pepr.
    *
-   * @param model the KubernetesObject model to match
-   * @param kind if using a custom KubernetesObject not available in `a.*`, specify the GroupVersionKind
-   * @returns
+   * The action is triggered when the resource matches the provided kind and any applied filters.
+   *
+   * @param model The Kubernetes resource model to watch (e.g., a.Deployment).
+   * @param kind  Optional GroupVersionKind for custom resources.
+   * @returns A chainable API for defining filters and actions.
    */
   When = <T extends GenericClass>(model: T, kind?: GroupVersionKind): WhenSelector<T> => {
     const matchedKind = modelToGroupVersionKind(model.name);
 
     // If the kind is not specified and the model is not a KubernetesObject, throw an error
-    if (!matchedKind && !kind) {
-      throw new Error(`Kind not specified for ${model.name}`);
-    }
+    if (!matchedKind && !kind) throw new Error(`Kind not specified for ${model.name}`);
 
     const binding: Binding = {
       model,
@@ -206,235 +397,95 @@ export class Capability implements CapabilityExport {
 
     const bindings = this.#bindings;
     const prefix = `${this.#name}: ${model.name}`;
-    const commonChain = {
-      WithLabel,
-      WithAnnotation,
-      WithDeletionTimestamp,
-      Mutate,
-      Validate,
-      Watch,
-      Reconcile,
-      Alias,
+
+    type FilterChain = {
+      WithLabel: (key: string, value?: string) => FilterChain;
+      WithAnnotation: (key: string, value?: string) => FilterChain;
+      WithDeletionTimestamp: () => FilterChain;
+      Mutate: (action: MutateAction<T, InstanceType<T>>) => MutateActionChain<T>;
+      Alias: (alias: string) => FilterChain;
+      Validate: (action: ValidateAction<T, InstanceType<T>>) => ValidateActionChain<T>;
+      Watch: (action: WatchLogAction<T, InstanceType<T>>) => FinalizeActionChain<T>;
+      Reconcile: (action: WatchLogAction<T, InstanceType<T>>) => FinalizeActionChain<T>;
     };
 
-    type CommonChainType = typeof commonChain;
-    type ExtendedCommonChainType = CommonChainType & {
-      Alias: (alias: string) => CommonChainType;
-      InNamespace: (...namespaces: string[]) => BindingWithName<T>;
-      InNamespaceRegex: (...namespaces: RegExp[]) => BindingWithName<T>;
-      WithName: (name: string) => BindingFilter<T>;
-      WithNameRegex: (regexName: RegExp) => BindingFilter<T>;
-      WithDeletionTimestamp: () => BindingFilter<T>;
+    type WithNameChain = FilterChain & {
+      WithName: (name: string) => FilterChain;
+      WithNameRegex: (regexName: RegExp) => FilterChain;
     };
 
-    const isNotEmpty = (value: object): boolean => Object.keys(value).length > 0;
-    const log = (message: string, cbString: string): void => {
-      const filteredObj = pickBy(isNotEmpty, binding.filters);
+    const filterChain: FilterChain = {
+      WithLabel: (key: string, value = "") => {
+        Log.debug({ prefix }, `Add label filter ${key}=${value}`);
+        binding.filters.labels[key] = value;
+        return filterChain;
+      },
+      WithAnnotation: (key: string, value = "") => {
+        Log.debug({ prefix }, `Add annotation filter ${key}=${value}`);
+        binding.filters.annotations[key] = value;
+        return filterChain;
+      },
+      WithDeletionTimestamp: () => {
+        Log.debug({ prefix }, "Add deletionTimestamp filter");
+        binding.filters.deletionTimestamp = true;
+        return filterChain;
+      },
 
-      Log.info({ prefix }, `${message} configured for ${binding.event}`);
-      Log.info({ prefix }, JSON.stringify(filteredObj));
-      Log.debug({ prefix }, cbString);
+      Mutate: (action: MutateAction<T, InstanceType<T>>) =>
+        Capability.registerMutate<T>(prefix, binding, bindings, action),
+      Validate: (action: ValidateAction<T, InstanceType<T>>) =>
+        Capability.registerValidate<T>(prefix, binding, bindings, action),
+      Watch: (action: WatchLogAction<T, InstanceType<T>>) =>
+        Capability.registerWatch<T>(prefix, binding, bindings, action),
+      Reconcile: (action: WatchLogAction<T, InstanceType<T>>) =>
+        Capability.registerReconcile<T>(prefix, binding, bindings, action),
+      Alias: (alias: string) => {
+        Log.debug({ prefix }, `Adding prefix alias ${alias}`);
+        binding.alias = alias;
+        return filterChain;
+      },
     };
 
-    function Validate(validateCallback: ValidateAction<T>): ValidateActionChain<T> {
-      if (registerAdmission) {
-        log("Validate Action", validateCallback.toString());
+    const withNameChain: WithNameChain = {
+      ...filterChain,
+      WithName: (name: string) => {
+        Log.debug({ prefix }, `Add name filter ${name}`);
+        binding.filters.name = name;
+        return filterChain;
+      },
+      WithNameRegex: (regexName: RegExp) => {
+        Log.debug({ prefix }, `Add regex name filter ${regexName}`);
+        binding.filters.regexName = regexName.source;
+        return filterChain;
+      },
+    };
 
-        // Create the child logger
-        const aliasLogger = Log.child({ alias: binding.alias || "no alias provided" });
-
-        // Push the binding to the list of bindings for this capability as a new BindingAction
-        // with the callback function to preserve
-        bindings.push({
-          ...binding,
-          isValidate: true,
-          validateCallback: async (req, logger = aliasLogger) => {
-            if (binding.alias) {
-              Log.info(`Executing validate action with alias: ${binding.alias}`);
-            }
-            return await validateCallback(req, logger);
-          },
-        });
-      }
-
-      return { Watch, Reconcile };
-    }
-
-    function Mutate(mutateCallback: MutateAction<T>): MutateActionChain<T> {
-      if (registerAdmission) {
-        log("Mutate Action", mutateCallback.toString());
-
-        // Create the child logger
-        const aliasLogger = Log.child({ alias: binding.alias || "no alias provided" });
-
-        // Push the binding to the list of bindings for this capability as a new BindingAction
-        // with the callback function to preserve
-        bindings.push({
-          ...binding,
-          isMutate: true,
-          mutateCallback: async (req, logger = aliasLogger) => {
-            if (binding.alias) {
-              Log.info(`Executing mutation action with alias: ${binding.alias}`);
-            }
-            await mutateCallback(req, logger);
-          },
-        });
-      }
-
-      // Now only allow adding actions to the same binding
-      return { Watch, Validate, Reconcile };
-    }
-
-    function Watch(watchCallback: WatchLogAction<T>): FinalizeActionChain<T> {
-      if (registerWatch) {
-        log("Watch Action", watchCallback.toString());
-
-        // Create the child logger and cast it to the expected type
-        const aliasLogger = Log.child({
-          alias: binding.alias || "no alias provided",
-        }) as typeof Log;
-
-        // Push the binding to the list of bindings for this capability as a new BindingAction
-        // with the callback function to preserve
-        bindings.push({
-          ...binding,
-          isWatch: true,
-          watchCallback: async (update, phase, logger = aliasLogger) => {
-            if (binding.alias) {
-              Log.info(`Executing watch action with alias: ${binding.alias}`);
-            }
-            await watchCallback(update, phase, logger);
-          },
-        });
-      }
-      return { Finalize };
-    }
-
-    function Reconcile(reconcileCallback: WatchLogAction<T>): FinalizeActionChain<T> {
-      if (registerWatch) {
-        log("Reconcile Action", reconcileCallback.toString());
-
-        // Create the child logger and cast it to the expected type
-        const aliasLogger = Log.child({
-          alias: binding.alias || "no alias provided",
-        }) as typeof Log;
-
-        // Push the binding to the list of bindings for this capability as a new BindingAction
-        // with the callback function to preserve
-        bindings.push({
-          ...binding,
-          isWatch: true,
-          isQueue: true,
-          watchCallback: async (update, phase, logger = aliasLogger) => {
-            if (binding.alias) {
-              Log.info(`Executing reconcile action with alias: ${binding.alias}`);
-            }
-            await reconcileCallback(update, phase, logger);
-          },
-        });
-      }
-      return { Finalize };
-    }
-
-    function Finalize(finalizeCallback: FinalizeAction<T>): void {
-      log("Finalize Action", finalizeCallback.toString());
-
-      // Create the child logger and cast it to the expected type
-      const aliasLogger = Log.child({ alias: binding.alias || "no alias provided" }) as typeof Log;
-
-      // Add binding to inject Pepr finalizer during admission (Mutate)
-      if (registerAdmission) {
-        const mutateBinding = {
-          ...binding,
-          isMutate: true,
-          isFinalize: true,
-          event: Event.ANY,
-          mutateCallback: addFinalizer,
-        };
-        bindings.push(mutateBinding);
-      }
-
-      // Add binding to process finalizer callback / remove Pepr finalizer (Watch)
-      if (registerWatch) {
-        const watchBinding = {
-          ...binding,
-          isWatch: true,
-          isFinalize: true,
-          event: Event.UPDATE,
-          finalizeCallback: async (
-            update: InstanceType<T>,
-            logger = aliasLogger,
-          ): Promise<boolean | void> => {
-            if (binding.alias) {
-              Log.info(`Executing finalize action with alias: ${binding.alias}`);
-            }
-            return await finalizeCallback(update, logger);
-          },
-        };
-        bindings.push(watchBinding);
-      }
-    }
-
-    function InNamespace(...namespaces: string[]): BindingWithName<T> {
-      Log.debug({ prefix }, `Add namespaces filter ${namespaces}`);
-      binding.filters.namespaces.push(...namespaces);
-      return { ...commonChain, WithName, WithNameRegex };
-    }
-
-    function InNamespaceRegex(...namespaces: RegExp[]): BindingWithName<T> {
-      Log.debug({ prefix }, `Add regex namespaces filter ${namespaces}`);
-      binding.filters.regexNamespaces.push(...namespaces.map(regex => regex.source));
-      return { ...commonChain, WithName, WithNameRegex };
-    }
-
-    function WithDeletionTimestamp(): BindingFilter<T> {
-      Log.debug({ prefix }, "Add deletionTimestamp filter");
-      binding.filters.deletionTimestamp = true;
-      return commonChain;
-    }
-
-    function WithNameRegex(regexName: RegExp): BindingFilter<T> {
-      Log.debug({ prefix }, `Add regex name filter ${regexName}`);
-      binding.filters.regexName = regexName.source;
-      return commonChain;
-    }
-
-    function WithName(name: string): BindingFilter<T> {
-      Log.debug({ prefix }, `Add name filter ${name}`);
-      binding.filters.name = name;
-      return commonChain;
-    }
-
-    function WithLabel(key: string, value = ""): BindingFilter<T> {
-      Log.debug({ prefix }, `Add label filter ${key}=${value}`);
-      binding.filters.labels[key] = value;
-      return commonChain;
-    }
-
-    function WithAnnotation(key: string, value = ""): BindingFilter<T> {
-      Log.debug({ prefix }, `Add annotation filter ${key}=${value}`);
-      binding.filters.annotations[key] = value;
-      return commonChain;
-    }
-
-    function Alias(alias: string): CommonChainType {
-      Log.debug({ prefix }, `Adding prefix alias ${alias}`);
-      binding.alias = alias;
-      return commonChain;
-    }
-
-    function bindEvent(event: Event): ExtendedCommonChainType {
+    const bindEvent = (event: Event): BindingAll<T> => {
       binding.event = event;
+
       return {
-        ...commonChain,
-        InNamespace,
-        InNamespaceRegex,
-        WithName,
-        WithNameRegex,
-        WithDeletionTimestamp,
-        Alias,
+        WithName: withNameChain.WithName,
+        WithNameRegex: withNameChain.WithNameRegex,
+        InNamespace: (...namespaces: string[]): WithNameChain => {
+          Log.debug({ prefix }, `Add namespaces filter ${namespaces}`);
+          binding.filters.namespaces.push(...namespaces);
+          return withNameChain;
+        },
+        InNamespaceRegex: (...namespaces: RegExp[]): WithNameChain => {
+          Log.debug({ prefix }, `Add regex namespaces filter ${namespaces}`);
+          binding.filters.regexNamespaces.push(...namespaces.map(r => r.source));
+          return withNameChain;
+        },
+        WithLabel: filterChain.WithLabel,
+        WithAnnotation: filterChain.WithAnnotation,
+        WithDeletionTimestamp: filterChain.WithDeletionTimestamp,
+        Mutate: filterChain.Mutate,
+        Validate: filterChain.Validate,
+        Watch: filterChain.Watch,
+        Reconcile: filterChain.Reconcile,
+        Alias: filterChain.Alias,
       };
-    }
+    };
 
     return {
       IsCreatedOrUpdated: () => bindEvent(Event.CREATE_OR_UPDATE),

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -4,82 +4,87 @@ import { clone } from "ramda";
 import { Capability } from "./capability";
 import { Controller } from "../controller";
 import { ValidateError } from "../errors";
-import { CapabilityExport } from "../types";
+import { CapabilityExport, PackageJSON, PeprModuleOptions, ModuleConfig } from "../types";
 import { isBuildMode } from "./envChecks";
-import { PackageJSON, PeprModuleOptions, ModuleConfig } from "../types";
 import { createControllerHooks } from "../controller/createHooks";
 
 export class PeprModule {
   #controller!: Controller;
 
   /**
-   * Create a new Pepr runtime
+   * Initialize a new Pepr runtime module.
    *
-   * @param config The configuration for the Pepr runtime
-   * @param capabilities The capabilities to be loaded into the Pepr runtime
-   * @param opts Options for the Pepr runtime
+   * @param pkg The package.json data containing Pepr configuration.
+   * @param capabilities The list of capabilities to load.
+   * @param opts Options for the Pepr runtime settings (e.g., deferStart).
    */
+
   constructor(
     { description, pepr }: PackageJSON,
     capabilities: Capability[] = [],
     opts: PeprModuleOptions = {},
   ) {
-    const config: ModuleConfig = clone(pepr);
-    config.description = description;
+    const config = PeprModule.#initializeConfig(description, pepr);
+    PeprModule.#validateConfig(config);
 
-    // Need to validate at runtime since TS gets sad about parsing the package.json
-    ValidateError(config.onError);
-
-    // Handle build mode
     if (isBuildMode()) {
-      // Fail if process.send is not defined
-      if (!process.send) {
-        throw new Error("process.send is not defined");
-      }
-
-      const exportedCapabilities: CapabilityExport[] = [];
-
-      // Send capability map to parent process
-      for (const capability of capabilities) {
-        // Convert the capability to a capability config
-        exportedCapabilities.push({
-          name: capability.name,
-          description: capability.description,
-          namespaces: capability.namespaces,
-          bindings: capability.bindings,
-          hasSchedule: capability.hasSchedule,
-        });
-      }
-
-      // Send the capabilities back to the parent process
-      process.send(exportedCapabilities);
-
+      PeprModule.#handleBuildMode(capabilities);
       return;
     }
 
-    const controllerHooks = createControllerHooks(
-      opts,
-      capabilities,
-      pepr?.alwaysIgnore?.namespaces?.length
-        ? pepr.alwaysIgnore.namespaces
-        : config?.watch?.alwaysIgnore?.namespaces,
-    );
-
+    const controllerHooks = PeprModule.#createHooks(opts, capabilities, pepr, config);
     this.#controller = new Controller(config, capabilities, controllerHooks);
 
-    // Stop processing if deferStart is set to true
-    if (opts.deferStart) {
-      return;
+    if (!opts.deferStart) {
+      this.start();
     }
-
-    this.start();
   }
 
+  static #initializeConfig(description: string, pepr: PackageJSON["pepr"]): ModuleConfig {
+    const config: ModuleConfig = clone(pepr);
+    config.description = description;
+    return config;
+  }
+
+  static #validateConfig(config: ModuleConfig): void {
+    ValidateError(config.onError);
+  }
+
+  static #handleBuildMode(capabilities: Capability[]): void {
+    if (!process.send) {
+      throw new Error("process.send is not defined");
+    }
+
+    const exportedCapabilities: CapabilityExport[] = capabilities.map(cap => ({
+      name: cap.name,
+      description: cap.description,
+      namespaces: cap.namespaces,
+      bindings: cap.bindings,
+      hasSchedule: cap.hasSchedule,
+    }));
+
+    process.send(exportedCapabilities);
+  }
+
+  static #createHooks(
+    opts: PeprModuleOptions,
+    capabilities: Capability[],
+    pepr: PackageJSON["pepr"],
+    config: ModuleConfig,
+  ): ReturnType<typeof createControllerHooks> {
+    const ignored = pepr?.alwaysIgnore?.namespaces?.length
+      ? pepr.alwaysIgnore.namespaces
+      : config?.watch?.alwaysIgnore?.namespaces;
+
+    return createControllerHooks(opts, capabilities, ignored);
+  }
   /**
-   * Start the Pepr runtime manually.
-   * Normally this is called automatically when the Pepr module is instantiated, but can be called manually if `deferStart` is set to `true` in the constructor.
+   * Starts the Pepr runtime manually.
    *
-   * @param port
+   * Normally this is called automatically when the Pepr module is instantiated,
+   * but it can be invoked manually if `deferStart` is set to `true` in the constructor.
+   *
+   * @param port - The port number to start the server on (default: 3000).
    */
   start = (port = 3000): void => {
     this.#controller.startServer(port);

--- a/src/lib/processors/mutate-processor.test.ts
+++ b/src/lib/processors/mutate-processor.test.ts
@@ -10,7 +10,7 @@ import { Binding, MutateAction } from "../types";
 import { Event, Operation } from "../enums";
 import { base64Encode } from "../utils";
 import { GenericClass, KubernetesObject } from "kubernetes-fluent-client";
-import { MutateResponse, WebhookIgnore } from "../k8s";
+import { MutateResponse } from "../k8s";
 import { OnError } from "../../cli/init/enums";
 import {
   updateResponsePatchAndWarnings,
@@ -19,13 +19,11 @@ import {
   updateStatus,
   logMutateErrorMessage,
   processRequest,
-  getIgnoreNamespaces,
 } from "./mutate-processor";
 import { Operation as JSONPatchOperation } from "fast-json-patch";
 import { Capability } from "../core/capability";
 import { MeasureWebhookTimeout } from "../telemetry/webhookTimeouts";
 import { decodeData } from "./decode-utils";
-import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
 import { reencodeData } from "./decode-utils";
 import { shouldSkipRequest } from "../filter/filter";
 import { kind } from "kubernetes-fluent-client";
@@ -71,6 +69,7 @@ vi.mock("../utils");
 
 vi.mock("../assets/ignoredNamespaces", () => ({
   resolveIgnoreNamespaces: vi.fn(),
+  getIgnoreNamespaces: vi.fn(),
 }));
 
 const defaultModuleConfig: ModuleConfig = {
@@ -193,14 +192,6 @@ const defaultMutateResponse: MutateResponse = {
   uid: "default-uid",
   allowed: true,
 };
-
-const ignore = (namespaces?: string[]): WebhookIgnore => ({ namespaces });
-
-const baseConfig = (overrides?: Partial<ModuleConfig>): ModuleConfig => ({
-  uuid: "test-uuid",
-  alwaysIgnore: ignore([]), // default: empty list is fine
-  ...overrides,
-});
 
 function capabilityWithMutate(
   mutateFn: Mock,
@@ -508,77 +499,5 @@ describe("mutateProcessor (bindings & branches via DSL)", () => {
     expect(res.warnings && res.warnings.length).toBeGreaterThan(0);
     expect(spyStop).toHaveBeenCalled();
     spyStop.mockRestore();
-  });
-});
-
-describe("getIgnoreNamespaces", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
-  it("prefers config.alwaysIgnore.namespaces when non-empty", () => {
-    const config = baseConfig({
-      alwaysIgnore: ignore(["ns-a", "ns-b"]),
-      admission: { alwaysIgnore: ignore(["fb-1"]) },
-    });
-
-    (resolveIgnoreNamespaces as unknown as Mock).mockReturnValue(["resolved-a", "resolved-b"]);
-
-    const result = getIgnoreNamespaces(config as ModuleConfig);
-
-    expect(resolveIgnoreNamespaces).toHaveBeenCalledWith(["ns-a", "ns-b"]);
-    expect(result).toEqual(["resolved-a", "resolved-b"]);
-  });
-
-  it("falls back to config.admission.alwaysIgnore.namespaces when primary is empty", () => {
-    const config = baseConfig({
-      alwaysIgnore: ignore([]),
-      admission: { alwaysIgnore: ignore(["fb-a", "fb-b"]) },
-    });
-
-    (resolveIgnoreNamespaces as unknown as Mock).mockReturnValue(["resolved-fallback"]);
-
-    const result = getIgnoreNamespaces(config as ModuleConfig);
-
-    expect(resolveIgnoreNamespaces).toHaveBeenCalledWith(["fb-a", "fb-b"]);
-    expect(result).toEqual(["resolved-fallback"]);
-  });
-
-  it("falls back when primary is undefined", () => {
-    const config = baseConfig({
-      // alwaysIgnore present but no namespaces
-      alwaysIgnore: ignore(undefined),
-      admission: { alwaysIgnore: ignore(["fb-only"]) },
-    });
-
-    (resolveIgnoreNamespaces as unknown as Mock).mockReturnValue(["resolved-fb-only"]);
-
-    const result = getIgnoreNamespaces(config as ModuleConfig);
-
-    expect(resolveIgnoreNamespaces).toHaveBeenCalledWith(["fb-only"]);
-    expect(result).toEqual(["resolved-fb-only"]);
-  });
-
-  it("passes undefined when both sources are absent/empty", () => {
-    const config = baseConfig({
-      alwaysIgnore: ignore([]),
-      admission: { alwaysIgnore: ignore([]) },
-    });
-
-    (resolveIgnoreNamespaces as unknown as Mock).mockReturnValue(undefined);
-
-    const result = getIgnoreNamespaces(config as ModuleConfig);
-
-    expect(resolveIgnoreNamespaces).toHaveBeenCalledWith([]);
-    expect(result).toBeUndefined();
-  });
-
-  it("handles undefined config by passing undefined to resolver", () => {
-    (resolveIgnoreNamespaces as unknown as Mock).mockReturnValue(undefined);
-
-    const result = getIgnoreNamespaces(undefined);
-
-    expect(resolveIgnoreNamespaces).toHaveBeenCalledWith(undefined);
-    expect(result).toBeUndefined();
   });
 });

--- a/src/lib/processors/mutate-processor.test.ts
+++ b/src/lib/processors/mutate-processor.test.ts
@@ -19,15 +19,11 @@ import {
   updateStatus,
   logMutateErrorMessage,
   processRequest,
-  getValidBindables,
-  shouldIncludeBinding,
 } from "./mutate-processor";
 import { Operation as JSONPatchOperation } from "fast-json-patch";
 import { Capability } from "../core/capability";
 import { MeasureWebhookTimeout } from "../telemetry/webhookTimeouts";
 import { decodeData } from "./decode-utils";
-import { shouldSkipRequest } from "../filter/filter";
-import Log from "../telemetry/logger";
 
 vi.mock("./decode-utils", () => ({
   decodeData: vi.fn(),
@@ -338,97 +334,5 @@ describe("mutateProcessor", () => {
     await mutateProcessor(config, [capability], req, reqMetadata);
 
     expect(decodeData).toHaveBeenCalled();
-  });
-});
-
-describe("getValidBindables", () => {
-  const config = { uuid: "uuid", alwaysIgnore: {} } as ModuleConfig;
-  const req = defaultAdmissionRequest;
-  const reqMetadata = {};
-
-  const baseCapability: Capability = {
-    name: "cap1",
-    bindings: [{ ...defaultBinding }, { ...defaultBinding, mutateCallback: undefined }],
-    namespaces: [],
-  } as unknown as Capability;
-
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
-  it("returns bindables only for bindings with mutateCallback defined", () => {
-    (shouldSkipRequest as Mock).mockReturnValue("");
-    const result = getValidBindables([baseCapability], config, req, reqMetadata);
-
-    // one binding lacks mutateCallback, so only 1 returned
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("cap1");
-  });
-
-  it("filters out bindings when shouldSkipRequest returns non-empty string", () => {
-    (shouldSkipRequest as Mock).mockReturnValue("skip me");
-
-    const result = getValidBindables([baseCapability], config, req, reqMetadata);
-    expect(result).toHaveLength(0);
-  });
-
-  it("includes bindings when shouldSkipRequest returns empty string", () => {
-    (shouldSkipRequest as Mock).mockReturnValue("");
-    const result = getValidBindables([baseCapability], config, req, reqMetadata);
-    expect(result).toHaveLength(1);
-  });
-});
-
-describe("shouldIncludeBinding", () => {
-  const baseBinding = { ...defaultBinding };
-  const baseConfig = {
-    uuid: "uuid",
-    alwaysIgnore: {},
-    admission: { alwaysIgnore: {} },
-  } as ModuleConfig;
-  const baseBindable: Bindable = {
-    binding: baseBinding,
-    config: baseConfig,
-    req: defaultAdmissionRequest,
-    namespaces: [],
-    actMeta: {},
-    name: "cap",
-  };
-
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
-  it("returns false if mutateCallback is missing", () => {
-    const bindable = { ...baseBindable, binding: { ...baseBinding, mutateCallback: undefined } };
-    expect(shouldIncludeBinding(bindable)).toBe(false);
-  });
-
-  it("returns false and logs if shouldSkipRequest returns message", () => {
-    (shouldSkipRequest as Mock).mockReturnValue("skip");
-    const result = shouldIncludeBinding(baseBindable);
-    expect(result).toBe(false);
-    expect(Log.debug).toHaveBeenCalledWith("skip");
-  });
-
-  it("returns true if shouldSkipRequest returns empty string", () => {
-    (shouldSkipRequest as Mock).mockReturnValue("");
-    expect(shouldIncludeBinding(baseBindable)).toBe(true);
-  });
-
-  it("uses alwaysIgnore.namespaces if defined", () => {
-    const config = { ...baseConfig, alwaysIgnore: { namespaces: ["ns"] } };
-    const bindable = { ...baseBindable, config };
-    (shouldSkipRequest as Mock).mockReturnValue("");
-    const result = shouldIncludeBinding(bindable);
-    expect(result).toBe(true);
-  });
-
-  it("uses admission.alwaysIgnore.namespaces if alwaysIgnore empty", () => {
-    const config = { ...baseConfig, admission: { alwaysIgnore: { namespaces: ["ns"] } } };
-    const bindable = { ...baseBindable, config };
-    (shouldSkipRequest as Mock).mockReturnValue("");
-    const result = shouldIncludeBinding(bindable);
-    expect(result).toBe(true);
   });
 });

--- a/src/lib/processors/mutate-processor.test.ts
+++ b/src/lib/processors/mutate-processor.test.ts
@@ -26,18 +26,30 @@ import { Capability } from "../core/capability";
 import { MeasureWebhookTimeout } from "../telemetry/webhookTimeouts";
 import { decodeData } from "./decode-utils";
 import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
+import { reencodeData } from "./decode-utils";
+import { shouldSkipRequest } from "../filter/filter";
+import { kind } from "kubernetes-fluent-client";
 
 vi.mock("./decode-utils", () => ({
   decodeData: vi.fn(),
+  reencodeData: vi.fn(),
 }));
 
-vi.mock("../telemetry/logger", () => ({
-  default: {
+vi.mock("../telemetry/logger", () => {
+  const childLogger = {
     info: vi.fn(),
     debug: vi.fn(),
     error: vi.fn(),
-  },
-}));
+  };
+  return {
+    default: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => childLogger), // 👈 crucial
+    },
+  };
+});
 
 vi.mock("../telemetry/metrics", () => ({
   metricsCollector: {
@@ -190,10 +202,25 @@ const baseConfig = (overrides?: Partial<ModuleConfig>): ModuleConfig => ({
   ...overrides,
 });
 
+function capabilityWithMutate(
+  mutateFn: Mock,
+  kind: { group: string; version: string; kind: string } = {
+    group: "",
+    version: "v1",
+    kind: "ConfigMap",
+  },
+): Capability {
+  const cap = new Capability({ name: "cap", description: "desc" });
+
+  const FakeModel = function FakeModel() {} as unknown as GenericClass;
+  cap.When(FakeModel, kind).IsCreated().Mutate(mutateFn);
+  return cap;
+}
+
 describe("processRequest", () => {
   it("adds a status annotation on success", async () => {
     const testPeprMutateRequest = defaultPeprMutateRequest();
-    const testMutateResponse = clone(defaultMutateResponse);
+    const testMutateResponse = clone(defaultMutateResponse) as MutateResponse;
     const annote = `${defaultModuleConfig.uuid}.pepr.dev/${defaultBindable.name}`;
 
     const result = await processRequest(defaultBindable, testPeprMutateRequest, testMutateResponse);
@@ -348,6 +375,139 @@ describe("mutateProcessor", () => {
     await mutateProcessor(config, [capability], req, reqMetadata);
 
     expect(decodeData).toHaveBeenCalled();
+  });
+});
+
+describe("mutateProcessor (bindings & branches via DSL)", () => {
+  const reqBase: AdmissionRequest<kind.ConfigMap> = {
+    uid: "uid-123",
+    kind: { kind: "ConfigMap", group: "", version: "v1" },
+    resource: { group: "", version: "v1", resource: "configmaps" },
+    name: "cm-1",
+    object: {
+      apiVersion: "v1",
+      kind: "ConfigMap",
+      metadata: { name: "cm-1", namespace: "ns" },
+      data: { a: "1" },
+    },
+    operation: Operation.CREATE,
+    userInfo: {},
+  };
+
+  let config: ModuleConfig;
+
+  beforeEach(() => {
+    config = {
+      uuid: "mod-uuid",
+      webhookTimeout: 10,
+      alwaysIgnore: {},
+    } as ModuleConfig;
+
+    // Default path: do not skip bindings
+    (shouldSkipRequest as unknown as Mock).mockReturnValue("");
+
+    // Default decode returns a fresh PeprMutateRequest so updateStatus/processRequest can mutate it
+    (decodeData as Mock).mockImplementation((wrappedReq: PeprMutateRequest<KubernetesObject>) => ({
+      wrapped: new PeprMutateRequest(wrappedReq.Request ?? reqBase),
+      skipped: [],
+    }));
+  });
+
+  it("returns allowed=true when there are no bindings (no matches)", async () => {
+    const cap = new Capability({ name: "empty-cap", description: "no bindings" });
+
+    const res = await mutateProcessor(config, [cap], reqBase, {});
+
+    expect(res.allowed).toBe(true);
+    expect(res.patch).toBeUndefined(); // nothing changed
+  });
+
+  it("returns allowed=true early for DELETE and does not invoke mutate callback", async () => {
+    const mutateCb = vi.fn().mockResolvedValue(undefined);
+    const cap = capabilityWithMutate(mutateCb);
+
+    // For DELETE, AdmissionReview usually supplies oldObject (the existing resource)
+    const reqDelete: AdmissionRequest = {
+      ...reqBase,
+      operation: Operation.DELETE,
+      object: reqBase.object, // typical for DELETE
+      oldObject: {
+        // provide the prior object so PeprMutateRequest can populate Raw
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: { name: "cm-1", namespace: "ns" },
+        data: { a: "1" },
+      } as kind.ConfigMap,
+    };
+
+    // Realistically, a CREATE mutate binding should be skipped for a DELETE op.
+    (shouldSkipRequest as unknown as Mock).mockReturnValue("skip: not applicable for DELETE");
+
+    const spyStop = vi.spyOn(MeasureWebhookTimeout.prototype, "stop");
+    const res = await mutateProcessor(config, [cap], reqDelete, {});
+
+    expect(mutateCb).not.toHaveBeenCalled(); // skipped on DELETE
+    expect(res.allowed).toBe(true); // early-allow path
+    expect(res.patch).toBeUndefined();
+    expect(spyStop).toHaveBeenCalled();
+    spyStop.mockRestore();
+  });
+
+  it("sets JSONPatch when reencodeData returns a changed object", async () => {
+    // Ensure binding isn’t skipped
+    (shouldSkipRequest as unknown as Mock).mockReturnValue("");
+
+    // ensure base64Encode actually encodes
+    (base64Encode as unknown as Mock).mockImplementation((s: string) =>
+      Buffer.from(s).toString("base64"),
+    );
+
+    const mutateCb = vi.fn().mockResolvedValue(undefined);
+    const cap = capabilityWithMutate(mutateCb);
+
+    // Clone to isolate from other tests
+    const req = JSON.parse(JSON.stringify(reqBase)) as typeof reqBase;
+
+    // Return a *different* object from reencodeData
+    const transformed = {
+      ...req.object,
+      data: { ...req.object.data, b: "2" },
+    };
+    (reencodeData as unknown as Mock).mockReset();
+    (reencodeData as unknown as Mock).mockReturnValue(transformed);
+
+    const res = await mutateProcessor(config, [cap], req, {});
+
+    expect(reencodeData).toHaveBeenCalled(); // we reached reencode/patch phase
+    expect(res.allowed).toBe(true);
+    expect(res.patchType).toBe("JSONPatch");
+    expect(res.patch).toBeDefined();
+
+    const decoded = JSON.parse(Buffer.from(res.patch!, "base64").toString("utf-8"));
+    expect(Array.isArray(decoded)).toBe(true);
+    expect(
+      (decoded as { op: string; path: string; value?: unknown }[]).some(
+        op => op.op === "add" && op.path === "/data/b" && op.value === "2",
+      ),
+    ).toBe(true);
+  });
+
+  it("early-returns on onError=REJECT when mutate callback throws", async () => {
+    const throwing = vi.fn().mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const cap = capabilityWithMutate(throwing);
+
+    const cfgReject: ModuleConfig = { ...config, onError: OnError.REJECT } as ModuleConfig;
+
+    const spyStop = vi.spyOn(MeasureWebhookTimeout.prototype, "stop");
+    const res = await mutateProcessor(cfgReject, [cap], reqBase, {});
+
+    expect(res.allowed).toBe(false); // early return before allowed flips to true
+    expect(res.result).toBe("Pepr module configured to reject on error");
+    expect(res.warnings && res.warnings.length).toBeGreaterThan(0);
+    expect(spyStop).toHaveBeenCalled();
+    spyStop.mockRestore();
   });
 });
 

--- a/src/lib/processors/mutate-processor.test.ts
+++ b/src/lib/processors/mutate-processor.test.ts
@@ -46,7 +46,7 @@ vi.mock("../telemetry/logger", () => {
       info: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
-      child: vi.fn(() => childLogger), // 👈 crucial
+      child: vi.fn(() => childLogger),
     },
   };
 });

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -110,7 +110,6 @@ export async function processRequest(
   return { wrapped, response };
 }
 
-/* eslint max-statements: ["warn", 25] */
 export async function mutateProcessor(
   config: ModuleConfig,
   capabilities: Capability[],
@@ -119,84 +118,64 @@ export async function mutateProcessor(
 ): Promise<MutateResponse> {
   const webhookTimer = new MeasureWebhookTimeout(WebhookType.MUTATE);
   webhookTimer.start(config.webhookTimeout);
-  let response: MutateResponse = {
-    uid: req.uid,
-    warnings: [],
-    allowed: false,
-  };
 
+  const response: MutateResponse = initResponse(req);
   const decoded = decodeData(new PeprMutateRequest(req));
   let wrapped = decoded.wrapped;
 
   Log.info(reqMetadata, `Processing request`);
-  const bindables: Bindable[] = capabilities
-    .flatMap(capa =>
-      capa.bindings.map(bind => ({
-        req,
-        config,
-        name: capa.name,
-        namespaces: capa.namespaces,
-        binding: bind,
-        actMeta: { ...reqMetadata, name: capa.name },
-      })),
-    )
-    .filter(bind => {
-      if (!bind.binding.mutateCallback) {
-        return false;
-      }
 
-      const shouldSkip = shouldSkipRequest(
-        bind.binding,
-        bind.req,
-        bind.namespaces,
-        resolveIgnoreNamespaces(
-          bind?.config?.alwaysIgnore?.namespaces?.length
-            ? bind.config?.alwaysIgnore?.namespaces
-            : bind.config?.admission?.alwaysIgnore?.namespaces,
-        ),
-      );
-      if (shouldSkip !== "") {
-        Log.debug(shouldSkip);
-        return false;
-      }
+  const bindables = getValidBindables(capabilities, config, req, reqMetadata);
 
-      return true;
-    });
+  const processed = await handleBindables(bindables, config, wrapped, response);
+  wrapped = processed.wrapped;
+  const result = processed.response;
 
-  for (const bindable of bindables) {
-    ({ wrapped, response } = await processRequest(bindable, wrapped, response));
-    if (config.onError === OnError.REJECT && response?.warnings!.length > 0) {
-      webhookTimer.stop();
-      return response;
-    }
-  }
-
-  // The request is allowed
-
-  // If no capability matched the request, exit early
-  if (bindables.length === 0) {
-    Log.info(reqMetadata, `No matching actions found`);
+  if (shouldExitEarly(bindables, req)) {
     webhookTimer.stop();
-    return { ...response, allowed: true };
+    return { ...result, allowed: true };
   }
 
-  // delete operations can't be mutate, just return before the transformation
-  if (req.operation === "DELETE") {
-    webhookTimer.stop();
-    return { ...response, allowed: true };
-  }
-
-  // unskip base64-encoded data fields that were skipDecode'd
-  const transformed = reencodeData(wrapped, decoded.skipped);
-
-  // Compare the original request to the modified request to get the patches
-  const patches = jsonPatch.compare(req.object, transformed);
-
-  updateResponsePatchAndWarnings(patches, response);
+  const patches = generatePatches(req, wrapped, decoded, result);
+  webhookTimer.stop();
 
   Log.debug({ ...reqMetadata, patches }, `Patches generated`);
-  webhookTimer.stop();
-  return { ...response, allowed: true };
+  return { ...result, allowed: true };
+}
+
+function initResponse(req: AdmissionRequest): MutateResponse {
+  return { uid: req.uid, warnings: [], allowed: false };
+}
+
+async function handleBindables(
+  bindables: Bindable[],
+  config: ModuleConfig,
+  wrapped: PeprMutateRequest<KubernetesObject>,
+  response: MutateResponse,
+): Promise<Result> {
+  for (const bindable of bindables) {
+    ({ wrapped, response } = await processRequest(bindable, wrapped, response));
+    if (config.onError === OnError.REJECT && response?.warnings?.length) {
+      break;
+    }
+  }
+  return { wrapped, response };
+}
+
+function shouldExitEarly(bindables: Bindable[], req: AdmissionRequest): boolean {
+  return bindables.length === 0 || req.operation === "DELETE";
+}
+
+function generatePatches(
+  req: AdmissionRequest,
+  wrapped: PeprMutateRequest<KubernetesObject>,
+  decoded: ReturnType<typeof decodeData>,
+  response: MutateResponse,
+): Operation[] {
+  const transformed = reencodeData(wrapped, decoded.skipped);
+  const patches = jsonPatch.compare(req.object, transformed);
+  updateResponsePatchAndWarnings(patches, response);
+  return patches;
 }
 
 export function updateResponsePatchAndWarnings(
@@ -215,4 +194,49 @@ export function updateResponsePatchAndWarnings(
   if (response.warnings && response.warnings.length < 1) {
     delete response.warnings;
   }
+}
+
+export function getValidBindables(
+  capabilities: Capability[],
+  config: ModuleConfig,
+  req: AdmissionRequest,
+  reqMetadata: Record<string, string>,
+): Bindable[] {
+  return capabilities
+    .flatMap(capa =>
+      capa.bindings.map(bind => ({
+        req,
+        config,
+        name: capa.name,
+        namespaces: capa.namespaces,
+        binding: bind,
+        actMeta: { ...reqMetadata, name: capa.name },
+      })),
+    )
+    .filter(bind => shouldIncludeBinding(bind));
+}
+
+export function shouldIncludeBinding(bind: Bindable): boolean {
+  if (!bind.binding.mutateCallback) return false;
+
+  const ignoreNamespaces = getIgnoreNamespaces(bind.config);
+  const shouldSkip = shouldSkipRequest(
+    bind.binding,
+    bind.req,
+    bind.namespaces,
+    resolveIgnoreNamespaces(ignoreNamespaces),
+  );
+
+  if (shouldSkip) {
+    Log.debug(shouldSkip);
+    return false;
+  }
+
+  return true;
+}
+
+function getIgnoreNamespaces(config: ModuleConfig): string[] | undefined {
+  const alwaysIgnore = config?.alwaysIgnore?.namespaces;
+  if (alwaysIgnore && alwaysIgnore.length) return alwaysIgnore;
+  return config?.admission?.alwaysIgnore?.namespaces;
 }

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -13,7 +13,7 @@ import { ModuleConfig } from "../types";
 import { PeprMutateRequest } from "../mutate-request";
 import { base64Encode } from "../utils";
 import { OnError } from "../../cli/init/enums";
-import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
+import { getIgnoreNamespaces } from "../assets/ignoredNamespaces";
 import { Operation } from "fast-json-patch";
 import { WebhookType } from "../enums";
 
@@ -211,12 +211,4 @@ export function updateResponsePatchAndWarnings(
   if (response.warnings && response.warnings.length < 1) {
     delete response.warnings;
   }
-}
-
-export function getIgnoreNamespaces(config?: ModuleConfig): string[] | undefined {
-  const fromConfig = config?.alwaysIgnore?.namespaces?.length
-    ? config.alwaysIgnore.namespaces
-    : config?.admission?.alwaysIgnore?.namespaces;
-
-  return resolveIgnoreNamespaces(fromConfig);
 }

--- a/src/lib/processors/mutate-processor.ts
+++ b/src/lib/processors/mutate-processor.ts
@@ -213,7 +213,7 @@ export function updateResponsePatchAndWarnings(
   }
 }
 
-function getIgnoreNamespaces(config?: ModuleConfig): string[] | undefined {
+export function getIgnoreNamespaces(config?: ModuleConfig): string[] | undefined {
   const fromConfig = config?.alwaysIgnore?.namespaces?.length
     ? config.alwaysIgnore.namespaces
     : config?.admission?.alwaysIgnore?.namespaces;

--- a/src/lib/processors/validate-processor.test.ts
+++ b/src/lib/processors/validate-processor.test.ts
@@ -11,7 +11,6 @@ import { AdmissionRequest } from "../common-types";
 import {
   processRequest,
   validateProcessor,
-  getIgnoreNamespaces,
   shouldSkipBinding,
   processBinding,
   handleCapability,
@@ -391,26 +390,6 @@ describe("helper functions", () => {
     });
   });
 
-  describe("getIgnoreNamespaces", () => {
-    it("should resolve from alwaysIgnore.namespaces if provided", () => {
-      const config = {
-        alwaysIgnore: { namespaces: ["foo", "bar"] },
-        admission: { alwaysIgnore: { namespaces: ["baz"] } },
-      } as unknown as ModuleConfig;
-
-      const result = getIgnoreNamespaces(config);
-      expect(result).toEqual(expect.arrayContaining(["foo", "bar"]));
-    });
-
-    it("should fall back to admission.alwaysIgnore.namespaces", () => {
-      const config = {
-        admission: { alwaysIgnore: { namespaces: ["baz"] } },
-      } as unknown as ModuleConfig;
-
-      const result = getIgnoreNamespaces(config);
-      expect(result).toEqual(expect.arrayContaining(["baz"]));
-    });
-  });
   describe("processBinding", () => {
     const mockBinding = {
       isValidate: true,

--- a/src/lib/processors/validate-processor.ts
+++ b/src/lib/processors/validate-processor.ts
@@ -10,7 +10,7 @@ import Log from "../telemetry/logger";
 import { convertFromBase64Map } from "../utils";
 import { PeprValidateRequest } from "../validate-request";
 import { ModuleConfig } from "../types";
-import { resolveIgnoreNamespaces } from "../assets/ignoredNamespaces";
+import { getIgnoreNamespaces } from "../assets/ignoredNamespaces";
 import { MeasureWebhookTimeout } from "../telemetry/webhookTimeouts";
 import { WebhookType } from "../enums";
 import { AdmissionRequest } from "../common-types";
@@ -117,12 +117,6 @@ export async function handleCapability(
   }
 
   return results;
-}
-
-export function getIgnoreNamespaces(config: ModuleConfig): string[] {
-  const alwaysIgnore = config?.alwaysIgnore?.namespaces;
-  const admissionIgnore = config?.admission?.alwaysIgnore?.namespaces;
-  return resolveIgnoreNamespaces(alwaysIgnore?.length ? alwaysIgnore : admissionIgnore);
 }
 
 export async function processBinding(

--- a/src/lib/processors/watch-processor.ts
+++ b/src/lib/processors/watch-processor.ts
@@ -89,7 +89,7 @@ const eventToPhaseMap = {
 export function setupWatch(capabilities: Capability[], ignoredNamespaces?: string[]): void {
   for (const capability of capabilities) {
     for (const binding of capability.bindings.filter(b => b.isWatch)) {
-      runBinding(binding, capability.namespaces, ignoredNamespaces);
+      void runBinding(binding, capability.namespaces, ignoredNamespaces);
     }
   }
 }


### PR DESCRIPTION
## Description

Feedback example to #2712 

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
