### PR TITLE
docs: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pepr
 
 [![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](https://docs.pepr.dev)
-[![Npm package license](https://badgen.net/npm/license/pepr)](https://npmjs.com/package/pepr)
+[![Npm package license](https://img.shields.io/npm/l/pepr)](https://npmjs.com/package/pepr)
 [![Known Vulnerabilities](https://snyk.io/test/npm/pepr/badge.svg)](https://snyk.io/advisor/npm-package/pepr)
-[![Npm package version](https://badgen.net/npm/v/pepr)](https://npmjs.com/package/pepr)
-[![Npm package total downloads](https://badgen.net/npm/dt/pepr)](https://npmjs.com/package/pepr)
+[![Npm package version](https://img.shields.io/npm/v/pepr)](https://npmjs.com/package/pepr)
+[![Npm package total downloads](https://img.shields.io/npm/dy/pepr)](https://npmjs.com/package/pepr)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/pepr/badge)](https://securityscorecards.dev/viewer/?uri=github.com/defenseunicorns/pepr)
 [![codecov](https://codecov.io/github/defenseunicorns/pepr/graph/badge.svg?token=7679Y9K1HB)](https://codecov.io/github/defenseunicorns/pepr)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](/contribute/code-of-conduct)


### PR DESCRIPTION
## Description

https://badgen.net/ appears to be down so this switches to shields.io badges for everything. Unfortunately they do not have a total downloads, so this uses downloads per year instead.

## Related Issue

Broken images on main.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)