### PR TITLE
fix: bump node-forge to fix cve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@typescript-eslint/parser": "8.45.0",
         "esbuild": "0.25.10",
         "eslint": "9.36.0",
-        "node-forge": "1.3.1",
+        "node-forge": "1.3.2",
         "prettier": "3.6.2",
         "prompts": "2.4.2",
         "typescript": "5.8.3",
@@ -7681,9 +7681,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@typescript-eslint/parser": "8.45.0",
     "esbuild": "0.25.10",
     "eslint": "9.36.0",
-    "node-forge": "1.3.1",
+    "node-forge": "1.3.2",
     "prettier": "3.6.2",
     "prompts": "2.4.2",
     "typescript": "5.8.3",


### PR DESCRIPTION
## Description

Remediates two high sev node-forge cves by bumping the version

```bash
node-forge     1.3.1       1.3.2       npm   GHSA-554w-wpv2-vw27  High      < 0.1% (25th)  < 0.1  
node-forge     1.3.1       1.3.2       npm   GHSA-5gfm-wpxj-wjgq  High      < 0.1% (22nd)  < 0.1 
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed