### PR TITLE
chore: pre-install dependencies in update test

### DIFF
--- a/integration/cli/update.test.ts
+++ b/integration/cli/update.test.ts
@@ -54,7 +54,7 @@ describe("update", () => {
       expect(packageJson.name).toBe(name);
       expect(packageJson.description).toBe(desc);
       expect(packageJson.pepr.onError).toBe(errorBehavior);
-      await pepr.cli(`${workdir.path()}/${name}`, { cmd: `npm install` });
+      await pepr.cli(`${workdir.path()}/${name}`, { cmd: `npm install pepr@latest` });
     },
     time.toMs("2m"),
   );

--- a/integration/cli/update.test.ts
+++ b/integration/cli/update.test.ts
@@ -54,7 +54,6 @@ describe("update", () => {
       expect(packageJson.name).toBe(name);
       expect(packageJson.description).toBe(desc);
       expect(packageJson.pepr.onError).toBe(errorBehavior);
-      await pepr.cli(`${workdir.path()}/${name}`, { cmd: `npm install pepr@latest` });
     },
     time.toMs("2m"),
   );

--- a/integration/cli/update.test.ts
+++ b/integration/cli/update.test.ts
@@ -54,6 +54,7 @@ describe("update", () => {
       expect(packageJson.name).toBe(name);
       expect(packageJson.description).toBe(desc);
       expect(packageJson.pepr.onError).toBe(errorBehavior);
+      await pepr.cli(`${workdir.path()}/${name}`, { cmd: `npm install` });
     },
     time.toMs("2m"),
   );

--- a/src/cli/update/index.test.ts
+++ b/src/cli/update/index.test.ts
@@ -36,10 +36,10 @@ describe("Pepr CLI Update Command", () => {
 
     expect(prompt).toHaveBeenCalled();
     expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
-      stdio: "inherit",
+      stdio: "pipe",
     });
     expect(child_process.execSync).toHaveBeenCalledWith("npx pepr update-templates", {
-      stdio: "inherit",
+      stdio: "pipe",
     });
     expect(Log.info).toHaveBeenCalledWith("Updating the Pepr module...");
     expect(Log.info).toHaveBeenCalledWith("✅ Module updated successfully");
@@ -52,7 +52,7 @@ describe("Pepr CLI Update Command", () => {
 
     expect(prompt).not.toHaveBeenCalled();
     expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
-      stdio: "inherit",
+      stdio: "pipe",
     });
     expect(Log.info).toHaveBeenCalledWith("Updating the Pepr module...");
     expect(Log.info).toHaveBeenCalledWith("✅ Module updated successfully");
@@ -64,7 +64,7 @@ describe("Pepr CLI Update Command", () => {
 
     expect(prompt).not.toHaveBeenCalled();
     expect(child_process.execSync).toHaveBeenCalledWith("npm install pepr@latest", {
-      stdio: "inherit",
+      stdio: "pipe",
     });
     expect(child_process.execSync).not.toHaveBeenCalledWith(
       "npx pepr update-templates",

--- a/src/cli/update/index.ts
+++ b/src/cli/update/index.ts
@@ -45,13 +45,13 @@ export default function (program: Command): void {
       try {
         // Update Pepr for the module
         execSync("npm install pepr@latest", {
-          stdio: "inherit",
+          stdio: "pipe",
         });
 
         // Don't update the template files if the user specified the --skip-template-update flag
         if (!opts.skipTemplateUpdate) {
           execSync("npx pepr update-templates", {
-            stdio: "inherit",
+            stdio: "pipe",
           });
         }
 


### PR DESCRIPTION
## Description
  Fixes flaky `npx pepr update` integration test by suppressing npm output to prevent interference with test assertions expecting pepr log output.  The test was intermittently failing because npm's verbose output was interfering with Pepr's log messages in stdout:
  - **First run**: npm downloads packages, verbose output appears, test fails
  - **Second run**: packages cached, less npm output, test passes

  The `stdio: "inherit"` allowed npm's output to mix with or bypass Pepr's log messages, making test assertions unreliable.  Changed `stdio: "inherit"` to `stdio: "pipe"` in `src/cli/update/index.ts` for the npm install commands. Now only pepr's output is logged.

  GitHub workflow logs now show expected output:
  [00:13:12.801] INFO (8022): Updating the Pepr module...
  [00:13:15.763] INFO (8022): ✅ Module updated successfully

  - `src/cli/update/index.ts`: Changed `execSync` calls to use `stdio: "pipe"` instead of `stdio: "inherit"`
  - `src/cli/update/index.test.ts`: Updated unit test expectations to match new stdio configuration

...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
