### PR TITLE
fix: update doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | :--- | :--- | :--- |
 | [![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](https://docs.pepr.dev) | [![Npm package license](https://img.shields.io/npm/l/pepr)](https://npmjs.com/package/pepr) | [![Known Vulnerabilities](https://snyk.io/test/npm/pepr/badge.svg)](https://snyk.io/advisor/npm-package/pepr) |
 | [![Npm package version](https://img.shields.io/npm/v/pepr)](https://npmjs.com/package/pepr) | [![Npm package total downloads](https://img.shields.io/npm/dy/pepr)](https://npmjs.com/package/pepr) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/pepr/badge)](https://securityscorecards.dev/viewer/?uri=github.com/defenseunicorns/pepr) |
-| [![codecov](https://codecov.io/github/defenseunicorns/pepr/graph/badge.svg?token=7679Y9K1HB)](https://codecov.io/github/defenseunicorns/pepr) | [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](/contribute/code-of-conduct) | |
+| [![codecov](https://codecov.io/github/defenseunicorns/pepr/graph/badge.svg?token=7679Y9K1HB)](https://codecov.io/github/defenseunicorns/pepr) | [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE-OF-CONDUCT) | |
 
 ## **_Type safe Kubernetes middleware for humans_**
 
@@ -21,7 +21,7 @@ With Pepr, you can efficiently convert organizational knowledge into code, impro
 </div>
 </td>
 <td width="35%" align="center" style="vertical-align: middle; border: none;">
-<img alt="The Pepr Logo" width="100%" src="/assets/pepr.png" />
+<img alt="The Pepr Logo" width="100%" src="_images\pepr.png" />
 </td>
 </tr>
 </table>
@@ -32,7 +32,7 @@ With Pepr, you can efficiently convert organizational knowledge into code, impro
 
 - Zero-config K8s Mutating and Validating Webhooks plus Controller generation
 - Automatic leader-elected K8s resource watching
-- Lightweight async key-value store backed by K8s for stateful operations with the [Pepr Store](/user-guide/store)
+- Lightweight async key-value store backed by K8s for stateful operations with the [Pepr Store](docs/user-guide/store)
 - Human-readable fluent API for generating [Pepr Capabilities](#capability)
 - A fluent API for creating/modifying/watching and server-side applying K8s resources via [Kubernetes Fluent Client](https://github.com/defenseunicorns/kubernetes-fluent-client)
 - Generate new K8s resources based off of cluster resource changes
@@ -41,7 +41,7 @@ With Pepr, you can efficiently convert organizational knowledge into code, impro
 - Entire NPM ecosystem available for advanced operations
 - Realtime K8s debugging system for testing/reacting to cluster changes
 - Controller network isolation and tamper-resistant module execution
-- Least-privilege [RBAC](/user-guide/rbac) generation
+- Least-privilege [RBAC](docs/user-guide/rbac) generation
 - AMD64 and ARM64 support
 
 ## Example Pepr Action
@@ -50,7 +50,7 @@ This quick sample shows how to react to a ConfigMap being created or updated in 
 It adds a label and annotation to the ConfigMap and adds some data to the ConfigMap.
 It also creates a Validating Webhook to make sure the "pepr" label still exists.
 Finally, after the ConfigMap is created, it logs a message to the Pepr controller and creates or updates a separate ConfigMap with the [kubernetes-fluent-client](https://github.com/defenseunicorns/kubernetes-fluent-client) using server-side apply.
-For more details see [actions](/actions/) section.
+For more details see [actions](docs/actions/) section.
 
 ```ts
 When(a.ConfigMap)
@@ -143,7 +143,7 @@ It is a single, complete TypeScript project that includes an entry point to load
 During the Pepr build process, each module produces a unique Kubernetes MutatingWebhookConfiguration and ValidatingWebhookConfiguration, along with a secret containing the transpiled and compressed TypeScript code.
 The webhooks and secret are deployed into the Kubernetes cluster with their own isolated controller.
 
-See [Module](/user-guide/pepr-modules) for more details.
+See [Module](docs/user-guide/pepr-modules) for more details.
 
 ### Capability
 
@@ -152,7 +152,7 @@ Capabilities are user-defined and can include one or more actions.
 They are defined within a Pepr module and can be used in both MutatingWebhookConfigurations and ValidatingWebhookConfigurations.
 A Capability can have a specific scope, such as mutating or validating, and can be reused in multiple Pepr modules.
 
-See [Capabilities](/user-guide/capabilities) for more details.
+See [Capabilities](docs/user-guide/capabilities) for more details.
 
 ### Action
 
@@ -166,7 +166,7 @@ There are both `Mutate()` and `Validate()` Actions that can be used to modify or
 There are also `Watch()` and `Reconcile()` actions that can be used to watch for changes to Kubernetes resources that already exist.
 Finally, the `Finalize()` can be used after `Watch()` or `Reconcile()` to perform cleanup operations when the resource is deleted.
 
-See [actions](/actions/) for more details.
+See [actions](docs/actions/) for more details.
 
 ## Logical Pepr Flow
 

--- a/docs/contribute/contributor-guide.md
+++ b/docs/contribute/contributor-guide.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to Pepr! We welcome all contribution
 
 ## Code of Conduct
 
-Please follow our [Code of Conduct](/contribute/code-of-conduct) to maintain a respectful and collaborative environment.
+Please follow our [Code of Conduct](../../CODE-OF-CONDUCT) to maintain a respectful and collaborative environment.
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

Was reading through the documentation and noticed some broken links.

...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
