### PR TITLE
chore: updated internal links to relative and callouts to github syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Welcome to Pepr! To learn more about contributing to the [project](https://github.com/defenseunicorns/pepr), check out the [Contributor's Guide](contribute/contributor-guide).
+Welcome to Pepr! To learn more about contributing to the [project](https://github.com/defenseunicorns/pepr), check out the [Contributor's Guide](/docs/contribute/contributor-guide).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ With Pepr, you can efficiently convert organizational knowledge into code, impro
 </div>
 </td>
 <td width="35%" align="center" style="vertical-align: middle; border: none;">
-<img alt="The Pepr Logo" width="100%" src="/assets/pepr.png" />
+<img alt="The Pepr Logo" width="100%" src="_images/pepr.png" />
 </td>
 </tr>
 </table>
@@ -32,7 +32,7 @@ With Pepr, you can efficiently convert organizational knowledge into code, impro
 
 - Zero-config K8s Mutating and Validating Webhooks plus Controller generation
 - Automatic leader-elected K8s resource watching
-- Lightweight async key-value store backed by K8s for stateful operations with the [Pepr Store](/user-guide/store)
+- Lightweight async key-value store backed by K8s for stateful operations with the [Pepr Store](docs/user-guide/store.md)
 - Human-readable fluent API for generating [Pepr Capabilities](#capability)
 - A fluent API for creating/modifying/watching and server-side applying K8s resources via [Kubernetes Fluent Client](https://github.com/defenseunicorns/kubernetes-fluent-client)
 - Generate new K8s resources based off of cluster resource changes
@@ -41,7 +41,7 @@ With Pepr, you can efficiently convert organizational knowledge into code, impro
 - Entire NPM ecosystem available for advanced operations
 - Realtime K8s debugging system for testing/reacting to cluster changes
 - Controller network isolation and tamper-resistant module execution
-- Least-privilege [RBAC](/user-guide/rbac) generation
+- Least-privilege [RBAC](docs/user-guide/rbac.md) generation
 - AMD64 and ARM64 support
 
 ## Example Pepr Action
@@ -50,7 +50,7 @@ This quick sample shows how to react to a ConfigMap being created or updated in 
 It adds a label and annotation to the ConfigMap and adds some data to the ConfigMap.
 It also creates a Validating Webhook to make sure the "pepr" label still exists.
 Finally, after the ConfigMap is created, it logs a message to the Pepr controller and creates or updates a separate ConfigMap with the [kubernetes-fluent-client](https://github.com/defenseunicorns/kubernetes-fluent-client) using server-side apply.
-For more details see [actions](/actions/) section.
+For more details see [actions](docs/actions/README.md) section.
 
 ```ts
 When(a.ConfigMap)
@@ -123,11 +123,10 @@ npx pepr dev
 kubectl apply -f capabilities/hello-pepr.samples.yaml
 ```
 
-:::tip
-Don't use IP as your `--host`, it's not supported. Make sure to check your
-local k8s distro documentation how to reach your localhost, which is where
-`pepr dev` is serving the code from.
-:::
+> [!TIP]
+> Don't use IP as your `--host`, it's not supported. Make sure to check your
+> local k8s distro documentation how to reach your localhost, which is where
+> `pepr dev` is serving the code from.
 
   <video controls width="100%">
     <source src="https://user-images.githubusercontent.com/882485/230895880-c5623077-f811-4870-bb9f-9bb8e5edc118.mp4" type="video/mp4">
@@ -143,7 +142,7 @@ It is a single, complete TypeScript project that includes an entry point to load
 During the Pepr build process, each module produces a unique Kubernetes MutatingWebhookConfiguration and ValidatingWebhookConfiguration, along with a secret containing the transpiled and compressed TypeScript code.
 The webhooks and secret are deployed into the Kubernetes cluster with their own isolated controller.
 
-See [Module](/user-guide/pepr-modules) for more details.
+See [Module](docs/user-guide/pepr-modules.md) for more details.
 
 ### Capability
 
@@ -152,7 +151,7 @@ Capabilities are user-defined and can include one or more actions.
 They are defined within a Pepr module and can be used in both MutatingWebhookConfigurations and ValidatingWebhookConfigurations.
 A Capability can have a specific scope, such as mutating or validating, and can be reused in multiple Pepr modules.
 
-See [Capabilities](/user-guide/capabilities) for more details.
+See [Capabilities](docs/user-guide/capabilities.md) for more details.
 
 ### Action
 
@@ -166,7 +165,7 @@ There are both `Mutate()` and `Validate()` Actions that can be used to modify or
 There are also `Watch()` and `Reconcile()` actions that can be used to watch for changes to Kubernetes resources that already exist.
 Finally, the `Finalize()` can be used after `Watch()` or `Reconcile()` to perform cleanup operations when the resource is deleted.
 
-See [actions](/actions/) for more details.
+See [actions](docs/actions/README.md) for more details.
 
 ## Logical Pepr Flow
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | :--- | :--- | :--- |
 | [![Pepr Documentation](https://img.shields.io/badge/docs--d25ba1)](https://docs.pepr.dev) | [![Npm package license](https://img.shields.io/npm/l/pepr)](https://npmjs.com/package/pepr) | [![Known Vulnerabilities](https://snyk.io/test/npm/pepr/badge.svg)](https://snyk.io/advisor/npm-package/pepr) |
 | [![Npm package version](https://img.shields.io/npm/v/pepr)](https://npmjs.com/package/pepr) | [![Npm package total downloads](https://img.shields.io/npm/dy/pepr)](https://npmjs.com/package/pepr) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/pepr/badge)](https://securityscorecards.dev/viewer/?uri=github.com/defenseunicorns/pepr) |
-| [![codecov](https://codecov.io/github/defenseunicorns/pepr/graph/badge.svg?token=7679Y9K1HB)](https://codecov.io/github/defenseunicorns/pepr) | [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](/contribute/code-of-conduct) | |
+| [![codecov](https://codecov.io/github/defenseunicorns/pepr/graph/badge.svg?token=7679Y9K1HB)](https://codecov.io/github/defenseunicorns/pepr) | [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](/docs/contribute/code-of-conduct) | |
 
 ## **_Type safe Kubernetes middleware for humans_**
 

--- a/docs/actions/README.md
+++ b/docs/actions/README.md
@@ -8,7 +8,7 @@ For example, an action could be responsible for adding a specific label to a Kub
 
 Actions are `Mutate()`, `Validate()`, `Watch()`, `Reconcile()`, and `Finalize()`. Both Mutate and Validate actions run during the admission controller lifecycle, while Watch and Reconcile actions run in a separate controller that tracks changes to resources, including existing resource; the Finalize action spans both the admission & afterward.
 
-Let's look at some example actions that are included in the `HelloPepr` capability that is created for you when you [`npx pepr init`](/user-guide/pepr-cli#pepr-init):
+Let's look at some example actions that are included in the `HelloPepr` capability that is created for you when you [`npx pepr init`](../user-guide/pepr-cli.md#pepr-init):
 
 ---
 
@@ -66,7 +66,7 @@ When(a.ConfigMap)
   });
 ```
 
-There are many more examples in the `HelloPepr` capability that you can use as a reference when creating your own actions. Note that each time you run [`npx pepr update`](/user-guide/pepr-cli#pepr-update), Pepr will automatically update the `HelloPepr` capability with the latest examples and best practices for you to reference and test directly in your Pepr Module.
+There are many more examples in the `HelloPepr` capability that you can use as a reference when creating your own actions. Note that each time you run [`npx pepr update`](../user-guide/pepr-cli.md#pepr-update), Pepr will automatically update the `HelloPepr` capability with the latest examples and best practices for you to reference and test directly in your Pepr Module.
 
 ---
 

--- a/docs/actions/finalize.md
+++ b/docs/actions/finalize.md
@@ -1,6 +1,6 @@
 # Finalize
 
-A specialized combination of Pepr's [Mutate](/actions/mutate) & [Watch](/actions/watch) functionalities that allow a module author to run logic while Kubernetes is [Finalizing](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) a resource (i.e. cleaning up related resources _after_ a deletion request has been accepted). `Finalize()` can only be accessed after a `Watch()` or `Reconcile()`.
+A specialized combination of Pepr's [Mutate](./mutate.md) & [Watch](./watch.md) functionalities that allow a module author to run logic while Kubernetes is [Finalizing](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) a resource (i.e. cleaning up related resources _after_ a deletion request has been accepted). `Finalize()` can only be accessed after a `Watch()` or `Reconcile()`.
 
 This method will:
 

--- a/docs/actions/mutate.md
+++ b/docs/actions/mutate.md
@@ -80,4 +80,4 @@ When(a.ConfigMap)
 
 ## See Also
 
-Looking for some more generic helpers? Check out the [Module Author SDK](/user-guide/sdk) for information on other things that Pepr can help with.
+Looking for some more generic helpers? Check out the [Module Author SDK](../user-guide/sdk.md) for information on other things that Pepr can help with.

--- a/docs/actions/reconcile.md
+++ b/docs/actions/reconcile.md
@@ -4,7 +4,7 @@ Reconcile functions the same as Watch but is tailored for building Kubernetes Co
 
 Ordering can be configured to operate in one of two ways: as a single queue that maintains ordering of operations across all resources of a kind (default) or with separate processing queues per resource instance.
 
-See [Configuring Reconcile](/user-guide/customization#configuring-reconcile) for more on configuring how Reconcile behaves.
+See [Configuring Reconcile](../user-guide/customization.md#configuring-reconcile) for more on configuring how Reconcile behaves.
 
 ```ts
 When(WebApp)

--- a/docs/actions/using-alias-child-logger.md
+++ b/docs/actions/using-alias-child-logger.md
@@ -80,10 +80,10 @@ This will result in log entries when creating a Pod with the that include the al
 {"level":30,"time":1726798510466,"pid":16,"hostname":"pepr-static-test-watcher-6dc69654c9-5ql6b","alias":"reconcile","msg":"alias: reconcile red"}
 ```
 
-:::note
-The Alias function is optional and can be used to provide additional context in the logs. You must pass the logger object as shown above to the action to use the Alias function.
-:::
+> [!NOTE]
+> The Alias function is optional and can be used to provide additional context in the logs.
+> You must pass the logger object as shown above to the action to use the Alias function.
 
 ## See Also
 
-Looking for some more generic helpers? Check out the [Module Author SDK](/user-guide/sdk) for information on other things that Pepr can help with.
+Looking for some more generic helpers? Check out the [Module Author SDK](../user-guide/sdk.md) for information on other things that Pepr can help with.

--- a/docs/actions/validate.md
+++ b/docs/actions/validate.md
@@ -2,7 +2,7 @@
 
 After the Mutation phase comes the Validation phase where the validating admission webhooks are invoked and can reject requests to enforce custom policies.
 
-Validate does not annotate the objects that are allowed into the cluster, but the validation webhook can be audited with `npx pepr monitor`. Read the [monitoring docs](/reference/best-practices/#monitoring) for more information.
+Validate does not annotate the objects that are allowed into the cluster, but the validation webhook can be audited with `npx pepr monitor`. Read the [monitoring docs](../reference/best-practices.md#monitoring) for more information.
 
 ## Basic Validation
 

--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -8,16 +8,16 @@ Pepr is a community-driven project. We welcome contributions of all kinds, from 
 
 You can find all the details on contributing to Pepr at:
 
-* [Contributing to Pepr](/contribute/contributor-guide)
+* [Contributing to Pepr](../contribute/contributor-guide.md)
 
 ### Reporting Bugs
 
 Information on reporting bugs can be found at:
 
-* [Reporting Bugs](/community/support)
+* [Reporting Bugs](../../SUPPORT.md)
 
 ### Reporting Security Issues
 
 Information on reporting security issues can be found at:
 
-* [Reporting Security Issues](/community/security)
+* [Reporting Security Issues](../../security.md)

--- a/docs/contribute/contributor-guide.md
+++ b/docs/contribute/contributor-guide.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to Pepr! We welcome all contribution
 
 ## Code of Conduct
 
-Please follow our [Code of Conduct](/contribute/code-of-conduct) to maintain a respectful and collaborative environment.
+Please follow our [Code of Conduct](../../code-of-conduct.md) to maintain a respectful and collaborative environment.
 
 ## Getting Started
 
@@ -106,9 +106,8 @@ Please follow the coding conventions and style used in the project. Use ESLint a
       You'll need to re-run the installation after every build, though.
 3. Run `npx pepr dev` inside your module's directory to run the modified version of pepr.
 
-:::tip
-Make sure to re-run `npm run build` after you modify any of the pepr source files.
-:::
+> [!TIP]
+> Make sure to re-run `npm run build` after you modify any of the pepr source files.
 
 ## Contact
 

--- a/docs/reference/best-practices.md
+++ b/docs/reference/best-practices.md
@@ -29,7 +29,7 @@ admission:
   antiAffinity: true
 ```
 
-Due to the nature of having two different instances of the Admission Controller, it is important to ensure that the modules are idempotent and do not store ephemeral data since there is no guarantee which replica will serve the request. When state must be saved, use the [`PeprStore`](/user-guide/store).
+Due to the nature of having two different instances of the Admission Controller, it is important to ensure that the modules are idempotent and do not store ephemeral data since there is no guarantee which replica will serve the request. When state must be saved, use the [`PeprStore`](../user-guide/store.md).
 
 ## Mutating Webhook Errors
 
@@ -44,7 +44,7 @@ By validating the mutated resource, you ensure it adheres to expected formats, s
 1. Catch Logic Errors in Mutations:
 A mutation may not always produce the intended output due to edge cases, unexpected inputs, or incorrect assumptions in the mutation logic.
 
-Validation helps catch such issues early and becomes _particularly_ important if your Module is [configured](/user-guide/customization/#admission-and-watcher-subparameters) to use a Webhook [failurePolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) of `ignore`. In that case, admission requests failures _won't prevent further processing and/or acceptance_ of mutate-failed requests and could result in undesirable resources getting into your cluster!
+Validation helps catch such issues early and becomes _particularly_ important if your Module is [configured](../user-guide/customization.md#admission-and-watcher-subparameters) to use a Webhook [failurePolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) of `ignore`. In that case, admission requests failures _won't prevent further processing and/or acceptance_ of mutate-failed requests and could result in undesirable resources getting into your cluster!
 
 1. Comply with Kubernetes Best Practices:
 Kubernetes resources must meet specific structural and functional requirements. Validating ensures compliance, preventing the risk of deployment failures or runtime errors.
@@ -80,15 +80,15 @@ The workflow for developing features in Pepr is:
 
 ## Debugging
 
-- [Debugging During Module Development](/reference/best-practices/#debugging-during-module-development)
-- [Logging](/reference/best-practices/#logging)
-- [Internal Error Occurred](/reference/best-practices/#internal-error-occurred)
-- [Pepr Store](/reference/best-practices/#pepr-store)
+- [Debugging During Module Development](#debugging-during-module-development)
+- [Logging](#logging)
+- [Internal Error Occurred](#internal-error-occurred)
+- [Pepr Store](#pepr-store)
 
 Pepr is composed of `Modules`, `Capabilities`, and `Actions`:
 
-- [Actions](/actions/) are the blocks of code containing filters, `Mutate`, `Validate`, `Watch`, `Reconcile`, and `OnSchedule`.
-- [Capabilities](/user-guide/capabilities/) such as `hello-pepr.ts`.
+- [Actions](../actions/README.md) are the blocks of code containing filters, `Mutate`, `Validate`, `Watch`, `Reconcile`, and `OnSchedule`.
+- [Capabilities](../user-guide/capabilities.md) such as `hello-pepr.ts`.
 - `Modules` are the result of `npx pepr init`. You can have as many Capabilities as you would like in a Module.
 
 Pepr is a webhook-based system, meaning it is event-driven.
@@ -154,7 +154,7 @@ When(a.Pod)
 
 ### Logging
 
-Pepr can deploy two types of controllers: Admission and Watch. The controllers deployed are dictated by the [Actions](/actions/) called for by a given set of Capabilities (Pepr only deploys what is necessary). Within those controllers, the default log level is `info` but that can be changed to `debug` by setting the `LOG_LEVEL` environment variable to `debug`.
+Pepr can deploy two types of controllers: Admission and Watch. The controllers deployed are dictated by the [Actions](../actions/README.md) called for by a given set of Capabilities (Pepr only deploys what is necessary). Within those controllers, the default log level is `info` but that can be changed to `debug` by setting the `LOG_LEVEL` environment variable to `debug`.
 
 To pull logs for all controller pods:
 
@@ -170,7 +170,7 @@ If the focus of the debug is on a `Mutate()` or `Validate()`, the relevant logs 
 kubectl logs -l pepr.dev/controller=admission -n pepr-system
 ```
 
-More refined admission logs -- which can be optionally filtered by the module UUID -- can be obtained with [`npx pepr monitor`](/reference/best-practices/#monitoring)
+More refined admission logs -- which can be optionally filtered by the module UUID -- can be obtained with [`npx pepr monitor`](#monitoring)
 
 ```bash
 npx pepr monitor 
@@ -210,7 +210,7 @@ The failurePolicy and timeouts can be set in the Module's `package.json` file, u
   }
 ```
 
-Read [more on customization](/user-guide/customization/).
+Read [more on customization](../user-guide/customization.md).
 
 ### Pepr Store Custom Resource
 
@@ -220,7 +220,7 @@ If you need to read all store keys, or you think the PeprStore is malfunctioning
 kubectl get peprstore  -n pepr-system -o yaml
 ```
 
-You should run in `npx pepr dev` mode to debug the issue, see the [Debugging During Module Development](/reference/best-practices/#debugging-during-module-development) section for more information.
+You should run in `npx pepr dev` mode to debug the issue, see the [Debugging During Module Development](#debugging-during-module-development) section for more information.
 
 ## Deployment
 
@@ -269,7 +269,7 @@ However, there are some cases where multiple modules makes sense. For instance d
 To enhance the security of your Pepr Controller, we recommend following these best practices:
 
 - Regularly update Pepr to the latest stable release.
-- Secure Pepr through RBAC using [scoped mode](/user-guide/rbac/#scoped) taking into account access to the Kubernetes API server needed in the callbacks.
+- Secure Pepr through RBAC using [scoped mode](../user-guide/rbac.md#scoped) taking into account access to the Kubernetes API server needed in the callbacks.
 - Practice the principle of least privilege when assigning roles and permissions and avoid giving the service account more permissions than necessary.
 - Use NetworkPolicy to restrict traffic from Pepr Controllers to the minimum required.
 - Limit calls from Pepr to the Kubernetes API server to the minimum required.

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -41,7 +41,7 @@ You can configure `.Reconcile()` with different queue granularities depending on
 
 ## What is a module author?
 
-A module author is someone who creates a [Pepr Module](/user-guide/pepr-modules) , which defines capabilities to enforce or apply desired state in a Kubernetes cluster.
+A module author is someone who creates a [Pepr Module](../user-guide/pepr-modules.md) , which defines capabilities to enforce or apply desired state in a Kubernetes cluster.
 If you’ve run `npx pepr init` to create a module, congratulations — you’re a module author.
 
 ## How do I remove the punycode warning?
@@ -76,9 +76,9 @@ Similarities:
 
 Differences:
 
-- **Main Goals**: Operator SDK is mainly focused on building operators and later included support for Webhooks. In contrast, Pepr started out as a framework for building Webhooks and later added support for building operators via [Kubernetes-Fluent-Client](https://github.com/defenseunicorns/kubernetes-fluent-client) through [Watch](/actions/watch) and [Reconcile](/actions/reconcile).
+- **Main Goals**: Operator SDK is mainly focused on building operators and later included support for Webhooks. In contrast, Pepr started out as a framework for building Webhooks and later added support for building operators via [Kubernetes-Fluent-Client](https://github.com/defenseunicorns/kubernetes-fluent-client) through [Watch](../actions/watch.md) and [Reconcile](../actions/reconcile.md).
 - **Language Support**: Operator SDK supports Go, Ansible, and Helm, while Pepr is written in TypeScript and designed with an English style fluent API for simplicity.
-- **Lifecycle Management**: Operator SDK provides tools for managing the lifecycle of operators through OLM (Operator Lifecycle Manager), while Pepr relies on [Helm](/user-guide/customization) for upgrades.
+- **Lifecycle Management**: Operator SDK provides tools for managing the lifecycle of operators through OLM (Operator Lifecycle Manager), while Pepr relies on [Helm](../user-guide/customization.md) for upgrades.
 - **Complexity**: Operator SDK uses native Kubernetes Go libraries for deep integration with Kubernetes resources, while Pepr exposes a high-level abstraction allowing users to focus on business logic.
 - **Easy Setup**: While both make it easy to initialize a new project, Pepr comes with an out-of-the-box `hello-pepr.ts` example which demonstrates how to use Pepr effectively.
 
@@ -94,7 +94,7 @@ Similarities:
 
 Differences:
 
-- Pepr is more like a "framework" than a tool. In Pepr you create a Pepr [Module](/user-guide/pepr-modules). In the Pepr module you define [capabilities](/user-guide/capabilities) that enforce / apply desired cluster state.
+- Pepr is more like a "framework" than a tool. In Pepr you create a Pepr [Module](../user-guide/pepr-modules.md). In the Pepr module you define [capabilities](../user-guide/capabilities.md) that enforce / apply desired cluster state.
 - Pepr is written in TypeScript. Kyverno is written in Go.
 - Pepr provides the flexibility of a full-fledged, strongly typed programming language to decide what decisions to make based on events happening in the cluster. With Kyverno, you are limited to the constraints of YAML.
 - Pepr can be used to reconcile events in order, similar to Kube-Builder or Operator SDK.
@@ -104,7 +104,7 @@ Both Pepr and Kyverno are great tools. Which one to use for your project depends
 
 ## How do I add custom labels to Pepr's Kubernetes manifests?
 
-During the build process, custom labels can be added the `pepr-system` namespace based on the `package.json`. Checkout the [Customizing with package.json](/user-guide/customization#packagejson-configurations-table).
+During the build process, custom labels can be added the `pepr-system` namespace based on the `package.json`. Checkout the [Customizing with package.json](../user-guide/customization.md#packagejson-configurations-table).
 
 The following example shows how to add custom namespace labels.
 
@@ -146,9 +146,8 @@ npx clear-npx-cache
 
 If you want to ensure the cache has been cleared, you can check the cache directory. The location of this directory varies based on your operating system and configuration. However, you can generally find it in your system's home directory under `.npm`.
 
-:::note
-If you are inside of the Pepr Core repo (<https://github.com/defenseunicorns/pepr>), then it is normal for `npx pepr -V` to return `0.0.0-development`
-:::
+> [!NOTE]
+> If you are inside of the Pepr Core repo (<https://github.com/defenseunicorns/pepr>), then it is normal for `npx pepr -V` to return `0.0.0-development`.
 
 ## I've found a bug, what should I do?
 

--- a/docs/tutorials/create-pepr-dashboard.md
+++ b/docs/tutorials/create-pepr-dashboard.md
@@ -16,7 +16,7 @@ An example of what the dashboard will look like is shown below:
 
 ### Step 1: Get Cluster Running With Your Pepr Module Deployed
 
-You can learn more about how to create a Pepr module and deploy it in the [Create a Pepr Module](/tutorials/create-pepr-module) tutorial. The short version is:
+You can learn more about how to create a Pepr module and deploy it in the [Create a Pepr Module](./create-pepr-module.md) tutorial. The short version is:
 
 ```bash
 #Create your cluster
@@ -850,17 +850,15 @@ password: secret
 
 By clicking on the Prometheus data source, you should be able to test the connection to Prometheus by clicking the "Test" button at the bottom of the screen.
 
-:::note
-The Prometheus server URL should be something like:
-:::
+> [!NOTE]
+> The Prometheus server URL should be something like:
 
 <http://monitoring-kube-prometh-prometheus.default:9090/>
 
 You should now be able to select the Pepr Dashboard from the Grafana UI in the "Dashboards" section.
 
-:::note
-The dashboard may take a few minutes to populate with data.
-:::
+> [!NOTE]
+> The dashboard may take a few minutes to populate with data.
 
 ## Summary
 

--- a/docs/tutorials/create-pepr-module.md
+++ b/docs/tutorials/create-pepr-module.md
@@ -12,7 +12,7 @@ Each Pepr Module is it's own Typescript project, produced by [`npx pepr init`](/
 
 ### Step 1: Create the module
 
-   Use [`npx pepr init`](/user-guide/pepr-cli#pepr-init) to generate a new module.
+   Use [`npx pepr init`](../user-guide/pepr-cli.md#pepr-init) to generate a new module.
 
 ### Step 2: Quickly validate system setup
 
@@ -40,7 +40,7 @@ Each Pepr Module is it's own Typescript project, produced by [`npx pepr init`](/
 
 ### Step 3: Create your custom Pepr Capabilities
 
-   Now that you have confirmed Pepr is working, you can now create new [capabilities](/user-guide/capabilities). You'll also want to disable the `HelloPepr` capability in your module (`pepr.ts`) before pushing to production. You can disable by commenting out or deleting the `HelloPepr` variable below:
+   Now that you have confirmed Pepr is working, you can now create new [capabilities](../user-guide/capabilities.md). You'll also want to disable the `HelloPepr` capability in your module (`pepr.ts`) before pushing to production. You can disable by commenting out or deleting the `HelloPepr` variable below:
 
    ```typescript
    new PeprModule(cfg, [
@@ -51,14 +51,14 @@ Each Pepr Module is it's own Typescript project, produced by [`npx pepr init`](/
    ]);
    ```
 
-   _Note: if you also delete the `capabilities/hello-pepr.ts` file, it will be added again on the next [`npx pepr update`](/user-guide/pepr-cli#pepr-update) so you have the latest examples usages from the Pepr SDK. Therefore, it is sufficient to remove the entry from your `pepr.ts` module
+   _Note: if you also delete the `capabilities/hello-pepr.ts` file, it will be added again on the next [`npx pepr update`](../user-guide/pepr-cli.md#pepr-update) so you have the latest examples usages from the Pepr SDK. Therefore, it is sufficient to remove the entry from your `pepr.ts` module
    config._
 
 ### Step 4: Build and deploy the Pepr Module
 
    Most of the time, you'll likely be iterating on a module with `npx pepr dev` for real-time feedback and validation Once you are ready to move beyond the local dev environment, Pepr provides deployment and build tools you can use.
 
-   `npx pepr deploy` - you can use this command to build your module and deploy it into any K8s cluster your current `kubecontext` has access to. This setup is ideal for CI systems during testing, but is not recommended for production use. See [`npx pepr deploy`](/user-guide/pepr-cli#pepr-deploy) for more info.
+   `npx pepr deploy` - you can use this command to build your module and deploy it into any K8s cluster your current `kubecontext` has access to. This setup is ideal for CI systems during testing, but is not recommended for production use. See [`npx pepr deploy`](../user-guide/pepr-cli.md#pepr-deploy) for more info.
 
 ## Additional Information
 

--- a/docs/tutorials/create-pepr-operator.md
+++ b/docs/tutorials/create-pepr-operator.md
@@ -283,9 +283,9 @@ Make sure Pepr is updated to the latest version:
 npx pepr update --skip-template-update
 ```
 
-:::caution
-Be cautious when updating Pepr in an existing project as it could potentially override custom configurations. The `--skip-template-update` flag helps prevent this.
-:::
+> [!CAUTION]
+> Be cautious when updating Pepr in an existing project as it could potentially override custom configurations.
+> The `--skip-template-update` flag helps prevent this.
 
 #### Building the Operator
 
@@ -429,9 +429,9 @@ FIELDS:
     Theme defines the theme of the web application, either dark or light.
 ```
 
-:::note
-`wa` is the short form of `webapp` that kubectl recognizes. This resource structure directly matches the TypeScript interface we defined earlier in our code.
-:::
+> [!NOTE]
+> `wa` is the short form of `webapp` that kubectl recognizes.
+> This resource structure directly matches the TypeScript interface we defined earlier in our code.
 
 [Back to top](#introduction)
 
@@ -676,9 +676,8 @@ kubectl apply -f webapp-dark-es.yaml
 ```
 <!-- End Block -->
 
-:::note
-We've changed the theme from light to dark and the language from English (en) to Spanish (es).
-:::
+> [!NOTE]
+> We've changed the theme from light to dark and the language from English (en) to Spanish (es).
 
 Your port-forward should still be active, so you can refresh your browser to see the changes.
 If your port-forward is no longer active for some reason, create a new one:

--- a/docs/user-guide/capabilities.md
+++ b/docs/user-guide/capabilities.md
@@ -1,12 +1,12 @@
 # Pepr Capabilities
 
-A capability is set of related [actions](/actions/) that work together to achieve a specific transformation or operation on Kubernetes resources. Capabilities are user-defined and can include one or more actions. They are defined within a Pepr module and can be used in both MutatingWebhookConfigurations and ValidatingWebhookConfigurations. A Capability can have a specific scope, such as mutating or validating, and can be reused in multiple Pepr modules.
+A capability is set of related [actions](../actions/README.md) that work together to achieve a specific transformation or operation on Kubernetes resources. Capabilities are user-defined and can include one or more actions. They are defined within a Pepr module and can be used in both MutatingWebhookConfigurations and ValidatingWebhookConfigurations. A Capability can have a specific scope, such as mutating or validating, and can be reused in multiple Pepr modules.
 
-When you [`npx pepr init`](/user-guide/pepr-cli#pepr-init), a `capabilities` directory is created for you. This directory is where you will define your capabilities. You can create as many capabilities as you need, and each capability can contain one or more actions. Pepr also automatically creates a `HelloPepr` capability with a number of example actions to help you get started.
+When you [`npx pepr init`](./pepr-cli.md#pepr-init), a `capabilities` directory is created for you. This directory is where you will define your capabilities. You can create as many capabilities as you need, and each capability can contain one or more actions. Pepr also automatically creates a `HelloPepr` capability with a number of example actions to help you get started.
 
 ## Creating a Capability
 
-Defining a new capability can be done via a [VSCode Snippet](https://code.visualstudio.com/docs/editor/userdefinedsnippets) generated during [`npx pepr init`](/user-guide/pepr-cli#pepr-init).
+Defining a new capability can be done via a [VSCode Snippet](https://code.visualstudio.com/docs/editor/userdefinedsnippets) generated during [`npx pepr init`](./pepr-cli.md#pepr-init).
 
 1. Create a new file in the `capabilities` directory with the name of your capability. For example, `capabilities/my-capability.ts`.
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -65,7 +65,7 @@ The Watch configuration is a part of the Pepr module that allows you to watch fo
 
 ## Configuring Reconcile
 
-The [Reconcile Action](/actions/reconcile) allows you to maintain ordering of resource updates processed by a Pepr controller. The Reconcile configuration can be customized via environment variable on the Watcher Deployment, which can be set in the `package.json` or in the helm `values.yaml` file.
+The [Reconcile Action](../actions/reconcile.md) allows you to maintain ordering of resource updates processed by a Pepr controller. The Reconcile configuration can be customized via environment variable on the Watcher Deployment, which can be set in the `package.json` or in the helm `values.yaml` file.
 
 | Field                     | Description                                                 | Example Values          |
 | -                         | -                                                           | -                       |

--- a/docs/user-guide/feature-flags.md
+++ b/docs/user-guide/feature-flags.md
@@ -55,11 +55,9 @@ Pepr's feature flag system supports:
 Feature flags in Pepr are defined in the `FeatureFlags` object.
 The `FeatureFlags` object is the source of truth for all available feature flags.
 
-:::caution
-To reduce complexity, Pepr enforces a limit of 4 active feature flags.
-Exceeding this limit results in an error (e.g., `Error: Too many feature
-flags active: 5 (maximum: 4).`)
-:::
+> [!CAUTION]
+> To reduce complexity, Pepr enforces a limit of 4 active feature flags.
+> Exceeding this limit results in an error (e.g., `Error: Too many feature flags active: 5 (maximum: 4).`)
 
 Feature Flags have:
 

--- a/docs/user-guide/generating-crds.md
+++ b/docs/user-guide/generating-crds.md
@@ -16,9 +16,9 @@ npx pepr crd create \
 
 This command will create a TypeScript file in the `crds` directory with the generated types for the specified CRD. The generated file will include the necessary type definitions for the CRD.
 
-:::note
-The comments in the interface spec and condition type become descriptions for the CRD properties, so you can add comments to your properties to provide additional context or documentation for the generated types.
-:::
+> [!NOTE]
+> The comments in the interface spec and condition type become descriptions for the CRD properties.
+> You can add comments to your properties to provide additional context or documentation for the generated types.
 
 After adding the required types for your CRD, you can then generate the CRD YAML file using the `pepr crd generate` command. This command will create a YAML file that defines the CRD in Kubernetes format.
 

--- a/docs/user-guide/pepr-cli.md
+++ b/docs/user-guide/pepr-cli.md
@@ -110,12 +110,12 @@ Setup a local webhook development environment
 
 Connect a local cluster to a local version of the Pepr Controller to do real-time debugging of your module. Note the `npx pepr dev` assumes a K3d cluster is running by default. If you are working with Kind or another docker-based K8s distro, you will need to pass the `--host host.docker.internal` option to `npx pepr dev`. If working with a remote cluster you will have to give Pepr a host path to your machine that is reachable from the K8s cluster.
 
-:::note
-This command, by necessity, installs resources into the cluster you run it against.  Generally, these resources are removed once the `pepr dev` session ends but there are two notable exceptions:
-:::
-
-- the `pepr-system` namespace, and
-- the `PeprStore` CRD.
+> [!NOTE]
+> This command, by necessity, installs resources into the cluster you run it against.
+> Generally, these resources are removed once the `pepr dev` session ends but there are two notable exceptions:
+>
+> - the `pepr-system` namespace, and
+> - the `PeprStore` CRD.
 
 These can't be auto-removed because they're global in scope & doing so would risk wrecking any other Pepr deployments that are already running in-cluster.  If (for some strange reason) you're _not_ `pepr dev`-ing against an ephemeral dev cluster and need to keep the cluster clean, you'll have to remove these hold-overs yourself (or not)!
 

--- a/docs/user-guide/sdk.md
+++ b/docs/user-guide/sdk.md
@@ -106,4 +106,4 @@ const sanitizedResourceName = sanitizeResourceName(resourceName)
 
 ## See Also
 
-Looking for information on the Pepr mutate helpers? See [Mutate Helpers](/actions/mutate#mutate-helpers) for information on those.
+Looking for information on the Pepr mutate helpers? See [Mutate Helpers](../actions/mutate.md#mutate-helpers) for information on those.


### PR DESCRIPTION
## Description
Updated internal links in .md files to use relative paths. Updated logo link in <img> tag to _images and converted starlight alert callout syntax to github. 
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
