### PR TITLE
fix: nightly watch test for aks disconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "heredoc": "^1.3.1",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "^3.10.10-nightly.17",
+        "kubernetes-fluent-client": "^3.10.11-nightly.0",
         "pino": "10.1.0",
         "pino-pretty": "13.1.3",
         "prom-client": "15.1.3",
@@ -7043,9 +7043,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.10.10-nightly.17",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.10-nightly.17.tgz",
-      "integrity": "sha512-A7zeHcr/lko2sxVTqXiEN/xlK40O3iQFvhAHq2tz0GX1N0hW15xYuB7cCuUcVmQLgIDpwKHfkWADkWDXVMVZgw==",
+      "version": "3.10.11-nightly.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.11-nightly.0.tgz",
+      "integrity": "sha512-PAPSPc6x9/etbpDpmkZf7qtZ/xzP3E/KljSwLeDek5sR7rdqdK1orIOK6r88F1aGCu+dJ2SqSeidT9vLgDJ1CA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "heredoc": "^1.3.1",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "^3.10.10-nightly.14",
+        "kubernetes-fluent-client": "^3.10.10-nightly.17",
         "pino": "10.1.0",
         "pino-pretty": "13.1.3",
         "prom-client": "15.1.3",
@@ -7043,9 +7043,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.10.10-nightly.14",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.10-nightly.14.tgz",
-      "integrity": "sha512-7WZPt0WmdJ934Sw2ajOlkrZrA7/nhb41GmeOKKKhJXwhHK0XRe4kzHZHvAnkzuLRwUBwfT6fjU4g5wgKsZQyKQ==",
+      "version": "3.10.10-nightly.17",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.10-nightly.17.tgz",
+      "integrity": "sha512-A7zeHcr/lko2sxVTqXiEN/xlK40O3iQFvhAHq2tz0GX1N0hW15xYuB7cCuUcVmQLgIDpwKHfkWADkWDXVMVZgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "heredoc": "^1.3.1",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "3.10.10",
+        "kubernetes-fluent-client": "^3.10.10-nightly.14",
         "pino": "10.1.0",
         "pino-pretty": "13.1.3",
         "prom-client": "15.1.3",
@@ -7043,9 +7043,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.10.10",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.10.tgz",
-      "integrity": "sha512-PH54g55CArT8E39U2j4z5amTYA+sJPjw3OHBfSsga0rNDsEkB7V9oWXLKwHj9/dbUYHXGlmXjw+V9Cojbs+oDw==",
+      "version": "3.10.10-nightly.14",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.10-nightly.14.tgz",
+      "integrity": "sha512-7WZPt0WmdJ934Sw2ajOlkrZrA7/nhb41GmeOKKKhJXwhHK0XRe4kzHZHvAnkzuLRwUBwfT6fjU4g5wgKsZQyKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "heredoc": "^1.3.1",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "^3.10.11-nightly.0",
+        "kubernetes-fluent-client": "^3.10.11-nightly.1",
         "pino": "10.1.0",
         "pino-pretty": "13.1.3",
         "prom-client": "15.1.3",
@@ -7043,9 +7043,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.10.11-nightly.0",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.11-nightly.0.tgz",
-      "integrity": "sha512-PAPSPc6x9/etbpDpmkZf7qtZ/xzP3E/KljSwLeDek5sR7rdqdK1orIOK6r88F1aGCu+dJ2SqSeidT9vLgDJ1CA==",
+      "version": "3.10.11-nightly.1",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.10.11-nightly.1.tgz",
+      "integrity": "sha512-bSucA4Ymnezb00v/2W1xbgp49LwwufQlXL3zo7uhgKkHkcYtaYDhfmAX6nDNRFmX9AcIu+AMYQ2dgUpboVdhCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "heredoc": "^1.3.1",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "^3.10.10-nightly.17",
+    "kubernetes-fluent-client": "^3.10.11-nightly.0",
     "pino": "10.1.0",
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "heredoc": "^1.3.1",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "3.10.10",
+    "kubernetes-fluent-client": "^3.10.10-nightly.14",
     "pino": "10.1.0",
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "heredoc": "^1.3.1",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "^3.10.10-nightly.14",
+    "kubernetes-fluent-client": "^3.10.10-nightly.17",
     "pino": "10.1.0",
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "heredoc": "^1.3.1",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "^3.10.11-nightly.0",
+    "kubernetes-fluent-client": "^3.10.11-nightly.1",
     "pino": "10.1.0",
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",


### PR DESCRIPTION
## Description

We are getting some suspicious error codes in AKS. This _does_ seem somewhat specific to AKS at the moment but we are going to replicate the timeout/keepAlive options from `@kubernetes/client-node` to see if this makes a difference. This is _only going to be a nightly_ for now because we are experiencing other 429 issues from the kube-apiserver in other Kubernetes flavors that is likely tied to the lists, this PR will likely increase those errors as it will connect and disconnect more often. We have a solution for the lists by tweaking watch config so this is really just a test for now.


[Docs](https://github.com/nodejs/undici/blob/80756cab3f1abad9d50cb387aafcea972e04ac65/docs/docs/api/Client.md?plain=1#L20)

## Related Issue


Relates to https://github.com/defenseunicorns/kubernetes-fluent-client/pull/971

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
