### PR TITLE
fix: the t and s in typescript should be capitalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ See [actions](docs/actions/README.md) for more details.
 It provides optional static typing and a rich type system, allowing developers to write more robust code.
 TypeScript is transpiled to JavaScript, enabling it to run in any environment that supports JavaScript.
 Pepr allows you to use JavaScript or TypeScript to write capabilities, but TypeScript is recommended for its type safety and rich type system.
-See the [Typescript docs](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) to learn more.
+See the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) to learn more.
 
 ## Community
 

--- a/src/cli/crd/create/createCRDscaffold.test.ts
+++ b/src/cli/crd/create/createCRDscaffold.test.ts
@@ -19,6 +19,7 @@ describe("generateCRDScaffold", () => {
   describe("when generating a CRD scaffold with valid inputs", () => {
     let result: string;
 
+    // Create the scaffold before each test
     beforeEach(() => {
       result = createCRDscaffold(group, version, kind, data);
     });


### PR DESCRIPTION
## Description

fix the casing for the letters in "TypeScript" and also trigger release.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
