### PR TITLE
fix: added log warning and updated docs for default admin mode

### DIFF
--- a/docs/user-guide/rbac.md
+++ b/docs/user-guide/rbac.md
@@ -10,7 +10,14 @@ During the build phase of Pepr (`npx pepr build --rbac-mode [admin|scoped]`), yo
 npx pepr build --rbac-mode admin
 ```
 
-**Description:** The service account is given cluster-admin permissions, granting it full, unrestricted access across the entire cluster. This can be useful for administrative tasks where broad permissions are necessary. However, use this mode with caution, as it can pose security risks if misused. This is the default mode.
+**Description:** The service account is given cluster-admin permissions, granting it full, unrestricted access across the entire cluster.
+This is the default mode.
+
+> [!CAUTION]
+> **This mode is intended for demo and proof-of-concept purposes only and should NOT be used in production environments.**
+
+The `hello-pepr` capability included with `npx pepr init` is designed to help new users quickly get started without worrying about RBAC configuration.
+However, running with cluster-admin level permissions violates the principle of least privilege and poses significant security risks.
 
 ### scoped
 

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -72,7 +72,7 @@ export default function (program: Command): void {
             validateCapabilityNames(webhook.capabilities);
           } catch (error) {
             Log.error(
-              `CapabilityValidation Error - Unable to valide capability name(s) in: '${webhook.capabilities.map(item => item.name)}'\n${error}`,
+              `CapabilityValidation Error - Unable to validate capability name(s) in: '${webhook.capabilities.map(item => item.name)}'\n${error}`,
             );
             process.exit(1);
           }

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -71,6 +71,12 @@ export default function (): Command {
           }
 
           Log.info(`New Pepr module created at ${dirName}`);
+          Log.warn(
+            `The default RBAC mode (admin) generates a ClusterRole with cluster-admin level ` +
+              `permissions for the hello-pepr capability. This is intended for demo/POC purposes only ` +
+              `and should NOT be used in production.` +
+              `See https://docs.pepr.dev/user-guide/rbac/ for more details.`,
+          );
           Log.info(`Open VSCode or your editor of choice in ${dirName} to get started!`);
         } catch (error) {
           throw new Error(`Error creating Pepr module:`, { cause: error });


### PR DESCRIPTION
## Description
Added warning log to `src/cli/index.ts` warning users not to use the default `admin` role in production.  Expanded the docs to also include a callout to warn users of the risk of admin level permissions. Corrected a typo in `src/cli/dev.ts` log error message.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
