### PR TITLE
Fix 2879: Overly Permissive RBAC ClusterRole in Admin Mode 

### DIFF
--- a/docs/user-guide/rbac.md
+++ b/docs/user-guide/rbac.md
@@ -10,7 +10,7 @@ During the build phase of Pepr (`npx pepr build --rbac-mode [admin|scoped]`), yo
 npx pepr build --rbac-mode admin
 ```
 
-**Description:** The service account is given cluster-admin permissions, granting it full, unrestricted access across the entire cluster. This can be useful for administrative tasks where broad permissions are necessary. However, use this mode with caution, as it can pose security risks if misused. This is the default mode.
+**Description:** The service account is given cluster-admin permissions, granting it full, unrestricted access across the entire cluster. This is the default mode. [!CAUTION] **This mode is intended for demo and proof-of-concept purposes only and should NOT be used in production environments. **The `hello-pepr` capability included with `npx pepr init` is designed to help new users quickly get started without worrying about RBAC configuration. However, running with cluster-admin level permissions violates the principle of least privilege and poses significant security risks.
 
 ### scoped
 

--- a/src/cli/build/index.test.ts
+++ b/src/cli/build/index.test.ts
@@ -82,6 +82,7 @@ vi.mock("../../lib/telemetry/logger", () => ({
   __esModule: true,
   default: {
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn(),
   },
 }));
@@ -367,6 +368,36 @@ describe("build CLI command", () => {
     it("should create the output directory", async () => {
       await runProgramWithArgs([outputFlag, "some-directory"]);
       expect(createOutputDirectory).toBeCalled();
+    });
+  });
+
+  describe("RBAC mode warnings", () => {
+    it("should warn when using default admin RBAC mode", async () => {
+      await runProgramWithArgs([]);
+
+      expect(Log.warn).toBeCalledWith(
+        expect.stringContaining('RBAC mode "admin"'),
+      );
+      expect(Log.warn).toBeCalledWith(
+        expect.stringContaining("NOT recommended for production"),
+      );
+      expect(Log.warn).toBeCalledWith(
+        expect.stringContaining("--rbac-mode=scoped"),
+      );
+    });
+
+    it("should warn when explicitly using admin RBAC mode", async () => {
+      await runProgramWithArgs(["--rbac-mode", "admin"]);
+
+      expect(Log.warn).toBeCalledWith(
+        expect.stringContaining('RBAC mode "admin"'),
+      );
+    });
+
+    it("should not warn when using scoped RBAC mode", async () => {
+      await runProgramWithArgs(["--rbac-mode", "scoped"]);
+
+      expect(Log.warn).not.toBeCalled();
     });
   });
 

--- a/src/cli/build/index.ts
+++ b/src/cli/build/index.ts
@@ -122,6 +122,17 @@ export default function (program: Command): void {
         return;
       }
 
+      // Determine RBAC mode and warn if using admin mode
+      const rbacMode = determineRbacMode(opts, cfg);
+      if (rbacMode === "admin") {
+        Log.warn(
+          `Building with RBAC mode "admin" which grants cluster-admin level permissions. ` +
+            `This is NOT recommended for production deployments. ` +
+            `Consider using "--rbac-mode=scoped" for least-privilege RBAC. ` +
+            `See https://docs.pepr.dev/user-guide/rbac/ for more details.`,
+        );
+      }
+
       // Generate a secret for the module
       const assets = new Assets(
         {
@@ -131,8 +142,7 @@ export default function (program: Command): void {
           alwaysIgnore: {
             namespaces: cfg.pepr.alwaysIgnore?.namespaces,
           },
-          // Can override the rbacMode with the CLI option
-          rbacMode: determineRbacMode(opts, cfg),
+          rbacMode,
         },
         path,
         opts.withPullSecret === "" ? [] : [opts.withPullSecret],

--- a/src/cli/init/index.test.ts
+++ b/src/cli/init/index.test.ts
@@ -160,6 +160,20 @@ describe("init CLI command", () => {
     );
   });
 
+  it("should warn about default admin RBAC mode after module creation", async () => {
+    await runProgramWithArgs(DEFAULT_ARGS.long);
+
+    expect(Log.warn).toBeCalledWith(
+      expect.stringContaining('default RBAC mode "admin"'),
+    );
+    expect(Log.warn).toBeCalledWith(
+      expect.stringContaining("NOT recommended for production"),
+    );
+    expect(Log.warn).toBeCalledWith(
+      expect.stringContaining("--rbac-mode=scoped"),
+    );
+  });
+
   it("should throw an error if module creation fails", async () => {
     mockedSetupProjectStructure.mockImplementationOnce(() => Promise.reject(new Error("an error")));
     expect(runProgramWithError(DEFAULT_ARGS.long, "Error creating Pepr module:"));

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -71,6 +71,12 @@ export default function (): Command {
           }
 
           Log.info(`New Pepr module created at ${dirName}`);
+          Log.warn(
+            `This module uses the default RBAC mode "admin" which grants cluster-admin level permissions. ` +
+              `This is suitable for development and learning, but NOT recommended for production. ` +
+              `For production deployments, use "npx pepr build --rbac-mode=scoped" to generate least-privilege RBAC. ` +
+              `See https://docs.pepr.dev/user-guide/rbac/ for more details.`,
+          );
           Log.info(`Open VSCode or your editor of choice in ${dirName} to get started!`);
         } catch (error) {
           throw new Error(`Error creating Pepr module:`, { cause: error });


### PR DESCRIPTION
  ## Summary

  Adds warning messages to alert users that the default RBAC mode "admin" grants cluster-admin level permissions and is not recommended for production deployments.

  Closes #2879

  ## Changes

  ### `pepr init`
  After creating a new module, users now see a warning:

  ```
WARN: This module uses the default RBAC mode "admin" which grants cluster-admin
  level permissions. This is suitable for development and learning, but NOT
  recommended for production. For production deployments, use
  "npx pepr build --rbac-mode=scoped" to generate least-privilege RBAC.
  See https://docs.pepr.dev/user-guide/rbac/ for more details.
```

  ### `pepr build`
  When building with admin RBAC mode (default or explicit), users now see a warning:

  ```
  WARN: Building with RBAC mode "admin" which grants cluster-admin level permissions.
  This is NOT recommended for production deployments. Consider using
  "--rbac-mode=scoped" for least-privilege RBAC.
  See https://docs.pepr.dev/user-guide/rbac/ for more details.
  ```
  No warning is shown when using `--rbac-mode=scoped`.

  ## Files Changed

  | File | Change |
  |------|--------|
  | `src/cli/init/index.ts` | Added RBAC warning after module creation |
  | `src/cli/build/index.ts` | Added RBAC warning when using admin mode |
  | `src/cli/init/index.test.ts` | Added test for init warning |
  | `src/cli/build/index.test.ts` | Added tests for build warnings |

  ## Testing

  ```bash
  npm run test:unit -- --run -t "RBAC" src/cli/init/index.test.ts src/cli/build/index.test.ts

  All 4 new tests pass.
  ```
 ## Checklist

  - Warning shown during npx pepr init
  - Warning shown during npx pepr build with admin mode
  - No warning when using --rbac-mode=scoped
  - Unit tests added
  - Links to RBAC documentation included