### PR TITLE
chore: unblock pipeline

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -35,6 +35,8 @@ jobs:
           echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml
           echo "  - vulnerability: GHSA-5j98-mcp5-4vw2" >> ~/.grype.yaml
           echo "  - vulnerability: CVE-2026-22184" >> ~/.grype.yaml
+          echo "  - vulnerability: GHSA-8qq5-rm4j-mr97" >> ~/.grype.yaml
+          " >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@62b74fb7bb810d2c45b1865f47a77655621862a5 # v7.2.3
         with:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -36,7 +36,6 @@ jobs:
           echo "  - vulnerability: GHSA-5j98-mcp5-4vw2" >> ~/.grype.yaml
           echo "  - vulnerability: CVE-2026-22184" >> ~/.grype.yaml
           echo "  - vulnerability: GHSA-8qq5-rm4j-mr97" >> ~/.grype.yaml
-          " >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@62b74fb7bb810d2c45b1865f47a77655621862a5 # v7.2.3
         with:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -34,6 +34,7 @@ jobs:
           echo "ignore:" > ~/.grype.yaml
           echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml
           echo "  - vulnerability: GHSA-5j98-mcp5-4vw2" >> ~/.grype.yaml
+          echo "  - vulnerability: CVE-2026-22184" >> ~/.grype.yaml
       - name: Vulnerability Scan
         uses: anchore/scan-action@62b74fb7bb810d2c45b1865f47a77655621862a5 # v7.2.3
         with:


### PR DESCRIPTION
## Description

There is a vulnerability if you are using the cli in `zlib` - we have carefully investigated to ensure that Pepr is not vulnerable. The vulnerability needs to be silenced in our upstream image as it is blocking our CI pipeline.

The other is a node-tar CVE but the attack vector is not exposed in Pepr. https://nvd.nist.gov/vuln/detail/CVE-2026-23745

## Related Issue

Fixes #2890 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
