### PR TITLE
chore: suppress node cve due to risk reward ratio

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -32,10 +32,11 @@ jobs:
         run: |
           mkdir -p ~/.grype
           echo "ignore:" > ~/.grype.yaml
-          echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml
-          echo "  - vulnerability: GHSA-5j98-mcp5-4vw2" >> ~/.grype.yaml
-          echo "  - vulnerability: CVE-2026-22184" >> ~/.grype.yaml
           echo "  - vulnerability: GHSA-8qq5-rm4j-mr97" >> ~/.grype.yaml
+          echo "  - vulnerability: CVE-2025-59465" >> ~/.grype.yaml
+          echo "  - vulnerability: CVE-2025-55131" >> ~/.grype.yaml          
+          echo "  - vulnerability: GHSA-r6q2-hw4h-h46w" >> ~/.grype.yaml                    
+          echo "  - vulnerability: CVE-2025-55130" >> ~/.grype.yaml                              
       - name: Vulnerability Scan
         uses: anchore/scan-action@62b74fb7bb810d2c45b1865f47a77655621862a5 # v7.2.3
         with:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -36,7 +36,12 @@ jobs:
           echo "  - vulnerability: CVE-2025-59465" >> ~/.grype.yaml
           echo "  - vulnerability: CVE-2025-55131" >> ~/.grype.yaml          
           echo "  - vulnerability: GHSA-r6q2-hw4h-h46w" >> ~/.grype.yaml                    
-          echo "  - vulnerability: CVE-2025-55130" >> ~/.grype.yaml                              
+          echo "  - vulnerability: CVE-2025-55130" >> ~/.grype.yaml     
+          echo "  - vulnerability: GHSA-8qq5-rm4j-mr97" >> ~/.grype.yaml   
+          echo "  - vulnerability: GHSA-5j98-mcp5-4vw2" >> ~/.grype.yaml   
+          echo "  - vulnerability: CVE-2025-9230" >> ~/.grype.yaml   
+
+
       - name: Vulnerability Scan
         uses: anchore/scan-action@62b74fb7bb810d2c45b1865f47a77655621862a5 # v7.2.3
         with:


### PR DESCRIPTION
## Description

There is a new Node.js CVE that is fixed in Node 24.13.0, however if we switch to this new image then we introduce _many_ more CVEs. In this case this does not make sense. We have researched these CVEs and feel confident moving forward.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
