### PR TITLE
chore: added 7 day cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -55,16 +57,22 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /config
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     registries:
       - rapidfort
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,8 +71,6 @@ updates:
     directory: /config
     schedule:
       interval: daily
-    cooldown:
-      default-days: 7
     registries:
       - rapidfort
 


### PR DESCRIPTION
## Description
- Added `cooldown: default-days: 7` to all dependabot configurations. This will delay dependabot from opening a PR for dependency updates until they have matured 7 days.   Most security patches will be released within days of a vulnerability being discovered on a new release.  A 7 day cooldown will allow those patches to be applied before implementing with Pepr. 
- Security patches are not affected by the cooldown.  Dependabot will continue to open PRs immediately (unchanged workflow) for security patches.
- Grouped dependencies PRs will open once all dependencies have  individually cleared their cooldown period. This is expected behavior and may add a few extra days of delay for some updates, but keeps PR volume low. If a specific dependency frequently holds up a group, it can be pulled out into its own entry.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #2935 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
