### PR TITLE
chore: update grype ignore

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -13,10 +13,10 @@ ignore:
   - vulnerability: GHSA-34x7-hfp2-rc4v
   - vulnerability: CVE-2025-69419
   - vulnerability: CVE-2025-15467
-  - vulnerability: CVE-2026-0775
   - vulnerability: CVE-2025-69421
   - vulnerability: CVE-2025-59464
   - vulnerability: CVE-2026-21637
   - vulnerability: CVE-2025-59466
-  - vulnerability: GHSA-3966-f6p6-2qr9
   - vulnerability: GHSA-7h2j-956f-4vf2
+  - vulnerability: GHSA-3ppc-4f35-3m26
+  - vulnerability: GHSA-83g3-92jg-28cx


### PR DESCRIPTION
## Description
Removed outdated CVEs `CVE-2026-0775` and `GHSA-3966-f6p6-2qr9`
Suppressed: `GHSA-3ppc-4f35-3m26` - minimatch
                      `GHSA-83g3-92jg-28cx` - tar
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
