### PR TITLE
chore: catch invalid regex in `mismatchedNameRegex`, `mismatchedNamespaceRegex`

### DIFF
--- a/src/lib/filter/adjudicators/mismatch.test.ts
+++ b/src/lib/filter/adjudicators/mismatch.test.ts
@@ -182,6 +182,51 @@ describe("mismatchedNamespaceRegex", () => {
   });
 });
 
+describe("mismatchedNameRegex with invalid regex", () => {
+  it("returns true (mismatch) instead of crashing when regexName is invalid", () => {
+    const binding = {
+      ...defaultBinding,
+      filters: { ...defaultFilters, regexName: "[invalid(regex" },
+    };
+    const kubernetesObject: KubernetesObject = {
+      ...defaultKubernetesObject,
+      metadata: { name: "anything" },
+    };
+
+    // An invalid regex should be treated as a mismatch (binding is skipped),
+    // not crash the filter pipeline.
+    expect(mismatchedNameRegex(binding, kubernetesObject)).toBe(true);
+  });
+});
+
+describe("mismatchedNamespaceRegex with invalid regex", () => {
+  it("returns true (mismatch) instead of crashing when a regexNamespaces entry is invalid", () => {
+    const binding: Binding = {
+      ...defaultBinding,
+      filters: { ...defaultFilters, regexNamespaces: ["[invalid(regex"] },
+    };
+    const kubernetesObject: KubernetesObject = {
+      ...defaultKubernetesObject,
+      metadata: { namespace: "anything" },
+    };
+
+    expect(mismatchedNamespaceRegex(binding, kubernetesObject)).toBe(true);
+  });
+
+  it("returns true (mismatch) when any entry in regexNamespaces is invalid, even if others are valid", () => {
+    const binding: Binding = {
+      ...defaultBinding,
+      filters: { ...defaultFilters, regexNamespaces: ["^valid$", "[broken("] },
+    };
+    const kubernetesObject: KubernetesObject = {
+      ...defaultKubernetesObject,
+      metadata: { namespace: "no-match" },
+    };
+
+    expect(mismatchedNamespaceRegex(binding, kubernetesObject)).toBe(true);
+  });
+});
+
 describe("mismatchedAnnotations", () => {
   //[ Binding, KubernetesObject, result ]
   it.each([

--- a/src/lib/filter/adjudicators/mismatch.test.ts
+++ b/src/lib/filter/adjudicators/mismatch.test.ts
@@ -225,6 +225,21 @@ describe("mismatchedNamespaceRegex with invalid regex", () => {
 
     expect(mismatchedNamespaceRegex(binding, kubernetesObject)).toBe(true);
   });
+
+  it("returns true (mismatch) when an invalid regex follows a valid one that matches the namespace", () => {
+    const binding: Binding = {
+      ...defaultBinding,
+      filters: { ...defaultFilters, regexNamespaces: ["^valid$", "[broken("] },
+    };
+    const kubernetesObject: KubernetesObject = {
+      ...defaultKubernetesObject,
+      // The first regex "^valid$" would match this namespace, but the
+      // invalid second entry must still cause a mismatch.
+      metadata: { namespace: "valid" },
+    };
+
+    expect(mismatchedNamespaceRegex(binding, kubernetesObject)).toBe(true);
+  });
 });
 
 describe("mismatchedAnnotations", () => {

--- a/src/lib/filter/adjudicators/mismatch.ts
+++ b/src/lib/filter/adjudicators/mismatch.ts
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
 import { Binding } from "../../types";
-import { allPass, any, anyPass, equals, not, nthArg, pipe } from "ramda";
+import { allPass, anyPass, equals, not, nthArg, pipe } from "ramda";
+import Log from "../../telemetry/logger";
 import {
   definedAnnotations,
   definedEvent,
@@ -53,11 +54,14 @@ export const mismatchedName = allPass([
 
 export const mismatchedNameRegex = allPass([
   pipe(nthArg(0), definesNameRegex),
-  pipe(
-    (binding, kubernetesObject) =>
-      new RegExp(definedNameRegex(binding)).test(carriedName(kubernetesObject)),
-    not,
-  ),
+  (binding: Binding, kubernetesObject: { metadata?: { name?: string } }): boolean => {
+    try {
+      return !new RegExp(definedNameRegex(binding)).test(carriedName(kubernetesObject));
+    } catch (e) {
+      Log.warn(`Invalid regexName pattern "${definedNameRegex(binding)}": ${e}`);
+      return true;
+    }
+  },
 ]);
 
 export const mismatchedNamespace = allPass([
@@ -71,12 +75,17 @@ export const mismatchedNamespace = allPass([
 
 export const mismatchedNamespaceRegex = allPass([
   pipe(nthArg(0), definesNamespaceRegexes),
-  pipe((binding, kubernetesObject) =>
-    pipe(
-      any((regEx: string) => new RegExp(regEx).test(carriedNamespace(kubernetesObject))),
-      not,
-    )(definedNamespaceRegexes(binding)),
-  ),
+  (binding: Binding, kubernetesObject: { metadata?: { namespace?: string } }): boolean => {
+    const namespace = carriedNamespace(kubernetesObject);
+    try {
+      return !definedNamespaceRegexes(binding).some((regEx: string) =>
+        new RegExp(regEx).test(namespace),
+      );
+    } catch (e) {
+      Log.warn(`Invalid regexNamespaces pattern in binding: ${e}`);
+      return true;
+    }
+  },
 ]);
 
 export const metasMismatch = pipe(

--- a/src/lib/filter/adjudicators/mismatch.ts
+++ b/src/lib/filter/adjudicators/mismatch.ts
@@ -77,14 +77,16 @@ export const mismatchedNamespaceRegex = allPass([
   pipe(nthArg(0), definesNamespaceRegexes),
   (binding: Binding, kubernetesObject: { metadata?: { namespace?: string } }): boolean => {
     const namespace = carriedNamespace(kubernetesObject);
+    // Compile all patterns upfront so an invalid regex anywhere in the array
+    // is caught before short-circuit matching can skip over it.
+    let compiled: RegExp[];
     try {
-      return !definedNamespaceRegexes(binding).some((regEx: string) =>
-        new RegExp(regEx).test(namespace),
-      );
+      compiled = definedNamespaceRegexes(binding).map((regEx: string) => new RegExp(regEx));
     } catch (e) {
       Log.warn(`Invalid regexNamespaces pattern in binding: ${e}`);
       return true;
     }
+    return !compiled.some((re: RegExp) => re.test(namespace));
   },
 ]);
 


### PR DESCRIPTION
## Description

`mismatchedNameRegex` and `mismatchedNamespaceRegex` in `src/lib/filter/adjudicators/mismatch.ts` passed user-provided binding filter patterns directly to `new RegExp()` without a try/catch. An invalid pattern threw an unhandled `SyntaxError` that crashed the entire filter pipeline and caused the admission webhook to return an error to the API server.

Wrap both `new RegExp()` call sites in try/catch. On a `SyntaxError`, log a warning with the offending pattern and return
`true` (mismatch), which causes the binding to be skipped. This is the safe default since a misconfigured filter pattern should not match all resources and accidentally trigger mutations or validations.

Three tests cover the new behavior: invalid `regexName`, invalid `regexNamespaces` entry, and a mixed array where one valid and one invalid pattern coexist.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
