### PR TITLE
chore: minimatch cve suppression

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -20,3 +20,5 @@ ignore:
   - vulnerability: GHSA-7h2j-956f-4vf2
   - vulnerability: GHSA-3ppc-4f35-3m26
   - vulnerability: GHSA-83g3-92jg-28cx
+  - vulnerability: GHSA-7r86-cg39-jmmj
+  - vulnerability: GHSA-23c5-xmqv-rm74


### PR DESCRIPTION
## Description
`- vulnerability: GHSA-7r86-cg39-jmmj` - minimatch
`- vulnerability: GHSA-23c5-xmqv-rm74` - minimatch
Not vulnerable because minimatch is transitive for other dependencies that are used only during buildtime.  There is no exposure during runtime and Pepr controller is not at risk. 

Reviewed all previously ignored cves. `.grype.yaml ` up to date.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
