### PR TITLE
chore: added GHSA-qffp-2rhf-9h96 to suppression list

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -22,3 +22,4 @@ ignore:
   - vulnerability: GHSA-83g3-92jg-28cx
   - vulnerability: GHSA-7r86-cg39-jmmj
   - vulnerability: GHSA-23c5-xmqv-rm74
+  - vulnerability: GHSA-qffp-2rhf-9h96


### PR DESCRIPTION
## Description
Reviewed and suppressed: GHSA-qffp-2rhf-9h96 - tar is a transitive dependency of semantic-release (devDep)
Reviews and confirmed suppression list in `grype.yaml` is current and accurate.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
