### PR TITLE
chore: update grype yaml ignores

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -17,9 +17,9 @@ ignore:
   - vulnerability: CVE-2025-59464
   - vulnerability: CVE-2026-21637
   - vulnerability: CVE-2025-59466
-  - vulnerability: GHSA-7h2j-956f-4vf2
   - vulnerability: GHSA-3ppc-4f35-3m26
   - vulnerability: GHSA-83g3-92jg-28cx
   - vulnerability: GHSA-7r86-cg39-jmmj
   - vulnerability: GHSA-23c5-xmqv-rm74
   - vulnerability: GHSA-qffp-2rhf-9h96
+  - vulnerability: GHSA-9ppj-qmqm-q256


### PR DESCRIPTION
## Description

removed:   `- vulnerability: GHSA-7h2j-956f-4vf2` - outdated
added:  `- vulnerability: GHSA-9ppj-qmqm-q256` - tar is a transitive dependency of semantic-release (devDep).
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
