### PR TITLE
fix: fast json import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2549,22 +2549,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@semantic-release/npm/node_modules/type-fest": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.2.0.tgz",
-      "integrity": "sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -13297,6 +13281,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "heredoc": "^1.3.1",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "3.11.5",
+        "kubernetes-fluent-client": "3.11.6",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
         "prom-client": "15.1.3",
@@ -7185,20 +7185,18 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.11.5.tgz",
-      "integrity": "sha512-uMsV7idPDXeSuyf6wPS3ivqT0LoHJVWySwn3UCv9vW8OJ6KK4T0qKJQY5EVH7saygkmvC1k2xv2ifHuYS1c1Rw==",
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.11.6.tgz",
+      "integrity": "sha512-lUSNfiUEoYpmPQyvKULKgITT38L5TQjl6SDqyCmcrc3sMlsG4qd6AfDSXGOpSwburvh5SJOd3aR4FFfMS3SyLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.4.0",
-        "fast-json-patch": "3.1.1",
         "http-status-codes": "2.3.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "4.1.1",
         "node-fetch": "2.7.0",
         "quicktype-core": "23.2.6",
-        "tsx": "^4.21.0",
-        "type-fest": "^5.0.0",
-        "undici": "^7.7.0",
+        "tsx": "4.21.0",
+        "undici": "7.24.1",
         "yargs": "18.0.0"
       },
       "bin": {
@@ -7270,6 +7268,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/kubernetes-fluent-client/node_modules/undici": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
+      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/kubernetes-fluent-client/node_modules/wrap-ansi": {
@@ -12399,6 +12406,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -13291,21 +13299,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.1.0.tgz",
-      "integrity": "sha512-wQ531tuWvB6oK+pchHIu5lHe5f5wpSCqB8Kf4dWQRbOYc9HTge7JL0G4Qd44bh6QuJCccIzL3bugb8GI0MwHrg==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -13409,6 +13402,7 @@
       "version": "7.24.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.2.tgz",
       "integrity": "sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "heredoc": "^1.3.1",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "3.11.5",
+    "kubernetes-fluent-client": "3.11.6",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",

--- a/src/lib/controller/migrateStore.ts
+++ b/src/lib/controller/migrateStore.ts
@@ -3,7 +3,7 @@ import { startsWith } from "ramda";
 import Log, { redactedStore } from "../telemetry/logger";
 import { K8s } from "kubernetes-fluent-client";
 import { Store } from "../k8s";
-import { Operation } from "fast-json-patch";
+import { Operation } from "kubernetes-fluent-client";
 import { fillStoreCache, sendUpdatesAndFlushCache } from "./storeCache";
 
 export interface StoreMigration {

--- a/src/lib/controller/store.ts
+++ b/src/lib/controller/store.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { Operation } from "fast-json-patch";
+import { Operation } from "kubernetes-fluent-client";
 import { K8s } from "kubernetes-fluent-client";
 import { startsWith } from "ramda";
 

--- a/src/lib/controller/storeCache.ts
+++ b/src/lib/controller/storeCache.ts
@@ -3,7 +3,7 @@ import Log from "../telemetry/logger";
 import { K8s } from "kubernetes-fluent-client";
 import { Store } from "../k8s";
 import { StatusCodes } from "http-status-codes";
-import { Operation } from "fast-json-patch";
+import { Operation } from "kubernetes-fluent-client";
 
 export const sendUpdatesAndFlushCache = async (
   cache: Record<string, Operation>,

--- a/src/lib/telemetry/logger.ts
+++ b/src/lib/telemetry/logger.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { Operation } from "fast-json-patch";
+import { Operation } from "kubernetes-fluent-client";
 import { pino, stdTimeFunctions } from "pino";
 import { Store } from "../k8s";
 


### PR DESCRIPTION
## Description
https://github.com/defenseunicorns/kubernetes-fluent-client/pull/1058 removed `fast-json-patch`.  This caused a build failure in pepr.  Updated to import from KFC instead of fast-json-patch.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
