### PR TITLE
chore: suppress CVE-2026-2673

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -23,3 +23,4 @@ ignore:
   - vulnerability: GHSA-23c5-xmqv-rm74
   - vulnerability: GHSA-qffp-2rhf-9h96
   - vulnerability: GHSA-9ppj-qmqm-q256
+  - vulnerability: CVE-2026-2673


### PR DESCRIPTION
## Description
Suppressed CVE-2026-2673. 

This CVE affects Alpine OS packages (libssl3/libcrypto3) inside the container image, not Pepr's application code.
The vulnerability causes a TLS connection to use a slightly weaker (but still secure) encryption method. No data is exposed and no authentication can be bypassed. The OpenSSL project itself rates this Low severity.
The bug only triggers when OpenSSL is configured in a specific way that Node.js does not use, making it unlikely to be reachable in Pepr's normal operation. The affected connection is also internal to the cluster and never internet-facing.
No upstream fix is available yet. This suppression will be removed once Alpine ships a patched base image.

```
libcrypto3     3.5.1-r0                                              apk     CVE-2026-2673        High      < 0.1% (13th)  < 0.1  
libssl3        3.5.1-r0                                              apk     CVE-2026-2673        High      < 0.1% (13th)  < 0.1  
```
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
