### PR TITLE
fix: update node build & base images in dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ coverage/
 *~
 doug
 Dockerfile.controller
+Dockerfile.kfc

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -24,3 +24,4 @@ ignore:
   - vulnerability: GHSA-qffp-2rhf-9h96
   - vulnerability: GHSA-9ppj-qmqm-q256
   - vulnerability: CVE-2026-2673
+  - vulnerability: GHSA-c2c7-rcm5-vvqj

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 ARG REQUIRE_CHOWN="true"
-ARG BUILD_IMAGE=docker.io/library/node@sha256:37c7b4cd8867313fc17ba76c1a6676414c61e2aac113694072bb8e3ef6d0a4c8
-ARG BASE_IMAGE=docker.io/library/node@sha256:e8e882c692a08878d55ec8ff6c5a4a71b3edca25eda0af4406e2a160d8a93cf2
+ARG BUILD_IMAGE=docker.io/library/node@sha256:bb20cf73b3ad7212834ec48e2174cdcb5775f6550510a5336b842ae32741ce6c
+ARG BASE_IMAGE=docker.io/library/node@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b
 
 FROM ${BUILD_IMAGE} AS build
 

--- a/Dockerfile.kfc
+++ b/Dockerfile.kfc
@@ -1,8 +1,8 @@
 ### BUILD ###
 
 ARG REQUIRE_CHOWN="true"
-ARG BUILD_IMAGE=docker.io/library/node@sha256:37c7b4cd8867313fc17ba76c1a6676414c61e2aac113694072bb8e3ef6d0a4c8
-ARG BASE_IMAGE=docker.io/library/node@sha256:e8e882c692a08878d55ec8ff6c5a4a71b3edca25eda0af4406e2a160d8a93cf2
+ARG BUILD_IMAGE=docker.io/library/node@sha256:bb20cf73b3ad7212834ec48e2174cdcb5775f6550510a5336b842ae32741ce6c
+ARG BASE_IMAGE=docker.io/library/node@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b
 
 FROM ${BUILD_IMAGE} AS build
 WORKDIR /app


### PR DESCRIPTION
## Description

This PR updates the dockerfile to mitigate CVEs and use a recent version of the node container.

## Related Issue

Hotfix

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
