### PR TITLE
chore: upgrade node-forge to 1.4.0

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -25,3 +25,4 @@ ignore:
   - vulnerability: GHSA-9ppj-qmqm-q256
   - vulnerability: CVE-2026-2673
   - vulnerability: GHSA-c2c7-rcm5-vvqj
+  - vulnerability: GHSA-j3q9-mxjg-w52f

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       "peerDependencies": {
         "@types/prompts": "2.4.9",
         "esbuild": "0.25.10",
-        "node-forge": "1.3.2",
+        "node-forge": "1.4.0",
         "prettier": "3.6.2",
         "prompts": "2.4.2",
         "typescript": "5.8.3",
@@ -7813,9 +7813,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "peerDependencies": {
     "@types/prompts": "2.4.9",
     "esbuild": "0.25.10",
-    "node-forge": "1.3.2",
+    "node-forge": "1.4.0",
     "prettier": "3.6.2",
     "prompts": "2.4.2",
     "typescript": "5.8.3",


### PR DESCRIPTION
## Description
upgrade node-forge to 1.4.0 for CVEs

`node-forge       1.3.2              1.4.0     npm   GHSA-2328-f5f3-gj25     High       N/A            N/A    
  node-forge       1.3.2              1.4.0     npm   GHSA-5m6q-g25r-mvwx  High      N/A            N/A    
  node-forge       1.3.2              1.4.0     npm   GHSA-ppp5-5v6c-4jwp    High      N/A            N/A    
  node-forge       1.3.2              1.4.0     npm   GHSA-q67f-28xg-22rw     High      N/A            N/A `

Suppressed `- vulnerability: GHSA-j3q9-mxjg-w52f` . This is a transitive of express. The vulnerable route patterns are not used. Route patterns are hardcoded at build time, and not user controlled.  The controller is not at risk.
`path-to-regexp   8.3.0              8.4.0     npm   GHSA-j3q9-mxjg-w52f  High   `
End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
