### PR TITLE
chore: added metrics summary

### DIFF
--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -164,10 +164,13 @@ jobs:
             cat logs/informer-log.txt
             cat logs/auditor-log.txt
 
-            # Parse and record metrics to TSV
+            # Parse and record metrics to CSV
+            # watch_controller_failures_total: simple counter, take the value directly
             cf=$(grep -v "^#" logs/auditor-log.txt | grep "watch_controller_failures_total" | awk '{print $NF}' | tail -1)
-            cm=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | awk '{print $NF}' | tail -1)
-            rf=$(grep -v "^#" logs/informer-log.txt | grep "pepr_resync_failure_count" | awk '{print $NF}' | tail -1)
+            # pepr_cache_miss: gauge per time window e.g. pepr_cache_miss{window="..."} 16 — sum all windows
+            cm=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | awk '{sum += $NF} END {print sum+0}')
+            # pepr_resync_failure_count: label holds failure count e.g. {count="0"} 1 — sum non-zero count labels
+            rf=$(grep -v "^#" logs/informer-log.txt | grep "pepr_resync_failure_count" | sed 's/.*count="\([^"]*\)".*/\1/' | awk '$1+0 > 0 {sum += $1+0} END {print sum+0}')
             cf=${cf:-0}; cm=${cm:-0}; rf=${rf:-0}
             echo "${i},$(date -u +%Y-%m-%dT%H:%M:%SZ),${cf},${cm},${rf}" >> logs/metrics.csv
             if [ $((i % 2)) -eq 0 ]; then  # Every 10 minutes 
@@ -210,17 +213,31 @@ jobs:
           final_rf=$(echo "$final" | cut -d',' -f5)
 
           cf_status=$([ "${final_cf}" = "0" ] && echo "✅" || echo "❌")
-          cm_status=$([ "${final_cm}" = "0" ] && echo "✅" || echo "⚠️")
           rf_status=$([ "${final_rf}" = "0" ] && echo "✅" || echo "❌")
+
+          # cache miss: split into startup (first window) and mid-run (all other windows)
+          startup_misses=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | head -1 | awk '{print $NF}')
+          midrun_misses=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | tail -n +2 | awk '{sum += $NF} END {print sum+0}')
+          startup_misses=${startup_misses:-0}
+          if [ "${final_cm}" = "0" ]; then
+            cm_display="0"
+          else
+            cm_display="${final_cm} total (${startup_misses} startup, ${midrun_misses} mid-run)"
+          fi
+          cm_status=$([ "${midrun_misses}" = "0" ] && echo "✅" || echo "⚠️")
+
+          # resync: total resyncs = sum of all gauge values across resync_failure_count lines
+          resync_total=$(grep -v "^#" logs/informer-log.txt | grep "pepr_resync_failure_count" | awk '{sum += $NF} END {print sum+0}')
+          rf_display="${final_rf} failures across ${resync_total} resyncs"
 
           {
             echo "## Soak Test Results"
             echo ""
-            echo "| Metric | Final Value | Status |"
-            echo "|--------|-------------|--------|"
+            echo "| Metric | Value | Status |"
+            echo "|--------|-------|--------|"
             echo "| \`watch_controller_failures_total\` | ${final_cf} | ${cf_status} |"
-            echo "| \`pepr_cache_miss\` | ${final_cm} | ${cm_status} |"
-            echo "| \`pepr_resync_failure_count\` | ${final_rf} | ${rf_status} |"
+            echo "| \`pepr_cache_miss\` | ${cm_display} | ${cm_status} |"
+            echo "| \`pepr_resync_failure_count\` | ${rf_display} | ${rf_status} |"
             echo ""
             echo "**Iterations completed:** ${iters} / 70 | **Duration:** ~$((iters * 5)) minutes"
             echo ""

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -148,6 +148,7 @@ jobs:
           touch logs/auditor-log.txt
           touch logs/informer-log.txt
           touch logs/watch-logs.txt
+          echo "iteration,timestamp,watch_controller_failures_total,pepr_cache_miss,pepr_resync_failure_count" > logs/metrics.csv
 
           update_pod_map
 
@@ -162,6 +163,13 @@ jobs:
             collect_metrics
             cat logs/informer-log.txt
             cat logs/auditor-log.txt
+
+            # Parse and record metrics to TSV
+            cf=$(grep -v "^#" logs/auditor-log.txt | grep "watch_controller_failures_total" | awk '{print $NF}' | tail -1)
+            cm=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | awk '{print $NF}' | tail -1)
+            rf=$(grep -v "^#" logs/informer-log.txt | grep "pepr_resync_failure_count" | awk '{print $NF}' | tail -1)
+            cf=${cf:-0}; cm=${cm:-0}; rf=${rf:-0}
+            echo "${i},$(date -u +%Y-%m-%dT%H:%M:%SZ),${cf},${cm},${rf}" >> logs/metrics.csv
             if [ $((i % 2)) -eq 0 ]; then  # Every 10 minutes 
               update_pod_map
 
@@ -174,6 +182,7 @@ jobs:
                 echo "$pod: ${pod_map[$pod]}"
                 if [ "${pod_map[$pod]}" -gt 1 ]; then
                   echo "Test failed: Pod $pod has count ${pod_map[$pod]}"
+                  echo "Pod $pod was recreated (seen ${pod_map[$pod]} times) at iteration ${i} (~$((i * 5)) minutes into the run." > logs/failure-reason.txt
                   kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system
                   exit 1
                 fi
@@ -185,8 +194,48 @@ jobs:
           echo "Soak test passed successfully!"
         shell: bash
 
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ ! -f logs/metrics.csv ] || [ "$(wc -l < logs/metrics.csv)" -lt 2 ]; then
+            echo "## Soak Test Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "No metrics collected." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          final=$(tail -1 logs/metrics.csv)
+          iters=$(echo "$final" | cut -d',' -f1)
+          final_cf=$(echo "$final" | cut -d',' -f3)
+          final_cm=$(echo "$final" | cut -d',' -f4)
+          final_rf=$(echo "$final" | cut -d',' -f5)
+
+          cf_status=$([ "${final_cf}" = "0" ] && echo "✅" || echo "❌")
+          cm_status=$([ "${final_cm}" = "0" ] && echo "✅" || echo "⚠️")
+          rf_status=$([ "${final_rf}" = "0" ] && echo "✅" || echo "❌")
+
+          {
+            echo "## Soak Test Results"
+            echo ""
+            echo "| Metric | Final Value | Status |"
+            echo "|--------|-------------|--------|"
+            echo "| \`watch_controller_failures_total\` | ${final_cf} | ${cf_status} |"
+            echo "| \`pepr_cache_miss\` | ${final_cm} | ${cm_status} |"
+            echo "| \`pepr_resync_failure_count\` | ${final_rf} | ${rf_status} |"
+            echo ""
+            echo "**Iterations completed:** ${iters} / 70 | **Duration:** ~$((iters * 5)) minutes"
+            echo ""
+            if [ -f logs/failure-reason.txt ]; then
+              echo "### ❌ Failure Reason"
+              echo "$(cat logs/failure-reason.txt)"
+            else
+              echo "### ✅ Test Passed"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+
       - name: Upload logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
         with:
           name: soak-test-logs
           path: logs

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -114,9 +114,6 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Create logs directory
-        run: mkdir -p logs
-
       - name: Deploy applications
         run: |
           kubectl apply -f hack/auditor.ci.yaml
@@ -131,123 +128,12 @@ jobs:
           kubectl wait --for=condition=ready -n pepr-system pod -l app=pepr-soak-ci-watcher
 
       - name: Run the soak test and collect metrics
-        run: |
-          # Initialize the map to store pod counts
-          declare -A pod_map
-          
-          update_pod_map() {
-            for pod in $(kubectl get pods -n pepr-demo -o jsonpath='{.items[*].metadata.name}'); do
-              count=${pod_map[$pod]}
-              if [ -z "$count" ]; then
-                pod_map[$pod]=1
-              else
-                pod_map[$pod]=$((count + 1))
-              fi
-            done
-          }
-          touch logs/auditor-log.txt
-          touch logs/informer-log.txt
-          touch logs/watch-logs.txt
-          echo "iteration,timestamp,watch_controller_failures_total,pepr_cache_miss,pepr_resync_failure_count" > logs/metrics.csv
-
-          update_pod_map
-
-          collect_metrics() {
-            kubectl exec metrics-collector -n watch-auditor -- curl watch-auditor:8080/metrics | grep watch_controller_failures_total > logs/auditor-log.txt
-            kubectl exec metrics-collector -n watch-auditor -- curl -k https://pepr-soak-ci-watcher.pepr-system.svc.cluster.local/metrics | egrep -E "pepr_cache_miss|pepr_resync_failure_count" > logs/informer-log.txt
-            kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system > logs/watch-logs.txt
-          }
-
-          # Start collecting metrics every 5 minutes and checking pod counts every 30 minutes
-          for i in {1..70}; do  # 70 iterations cover 350 minutes (5 hours and 50 minutes)
-            collect_metrics
-            cat logs/informer-log.txt
-            cat logs/auditor-log.txt
-
-            # Parse and record metrics to CSV
-            # watch_controller_failures_total: simple counter, take the value directly
-            cf=$(grep -v "^#" logs/auditor-log.txt | grep "watch_controller_failures_total" | awk '{print $NF}' | tail -1)
-            # pepr_cache_miss: gauge per time window e.g. pepr_cache_miss{window="..."} 16 — sum all windows
-            cm=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | awk '{sum += $NF} END {print sum+0}')
-            # pepr_resync_failure_count: label holds failure count e.g. {count="0"} 1 — sum non-zero count labels
-            rf=$(grep -v "^#" logs/informer-log.txt | grep "pepr_resync_failure_count" | sed 's/.*count="\([^"]*\)".*/\1/' | awk '$1+0 > 0 {sum += $1+0} END {print sum+0}')
-            cf=${cf:-0}; cm=${cm:-0}; rf=${rf:-0}
-            echo "${i},$(date -u +%Y-%m-%dT%H:%M:%SZ),${cf},${cm},${rf}" >> logs/metrics.csv
-            if [ $((i % 2)) -eq 0 ]; then  # Every 10 minutes 
-              update_pod_map
-
-              kubectl get pods -n pepr-demo 
-              kubectl top po -n pepr-system
-              kubectl get po -n pepr-system
-              
-              # Verify that no pod's count exceeds 1
-              for pod in "${!pod_map[@]}"; do
-                echo "$pod: ${pod_map[$pod]}"
-                if [ "${pod_map[$pod]}" -gt 1 ]; then
-                  echo "Test failed: Pod $pod has count ${pod_map[$pod]}"
-                  echo "Pod $pod was recreated (seen ${pod_map[$pod]} times) at iteration ${i} (~$((i * 5)) minutes into the run." > logs/failure-reason.txt
-                  kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system
-                  exit 1
-                fi
-              done
-            fi
-            sleep 300s  # Sleep for 5 minutes before the next iteration
-          done
-
-          echo "Soak test passed successfully!"
+        run: bash scripts/soak-test.sh
         shell: bash
 
       - name: Write job summary
         if: always()
-        run: |
-          if [ ! -f logs/metrics.csv ] || [ "$(wc -l < logs/metrics.csv)" -lt 2 ]; then
-            echo "## Soak Test Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "No metrics collected." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          final=$(tail -1 logs/metrics.csv)
-          iters=$(echo "$final" | cut -d',' -f1)
-          final_cf=$(echo "$final" | cut -d',' -f3)
-          final_cm=$(echo "$final" | cut -d',' -f4)
-          final_rf=$(echo "$final" | cut -d',' -f5)
-
-          cf_status=$([ "${final_cf}" = "0" ] && echo "✅" || echo "❌")
-          rf_status=$([ "${final_rf}" = "0" ] && echo "✅" || echo "❌")
-
-          # cache miss: split into startup (first window) and mid-run (all other windows)
-          startup_misses=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | head -1 | awk '{print $NF}')
-          midrun_misses=$(grep -v "^#" logs/informer-log.txt | grep "pepr_cache_miss" | tail -n +2 | awk '{sum += $NF} END {print sum+0}')
-          startup_misses=${startup_misses:-0}
-          if [ "${final_cm}" = "0" ]; then
-            cm_display="0"
-          else
-            cm_display="${final_cm} total (${startup_misses} startup, ${midrun_misses} mid-run)"
-          fi
-          cm_status=$([ "${midrun_misses}" = "0" ] && echo "✅" || echo "⚠️")
-
-          # resync: total resyncs = sum of all gauge values across resync_failure_count lines
-          resync_total=$(grep -v "^#" logs/informer-log.txt | grep "pepr_resync_failure_count" | awk '{sum += $NF} END {print sum+0}')
-          rf_display="${final_rf} failures across ${resync_total} resyncs"
-
-          {
-            echo "## Soak Test Results"
-            echo ""
-            echo "| Metric | Value | Status |"
-            echo "|--------|-------|--------|"
-            echo "| \`watch_controller_failures_total\` | ${final_cf} | ${cf_status} |"
-            echo "| \`pepr_cache_miss\` | ${cm_display} | ${cm_status} |"
-            echo "| \`pepr_resync_failure_count\` | ${rf_display} | ${rf_status} |"
-            echo ""
-            echo "**Iterations completed:** ${iters} / 70 | **Duration:** ~$((iters * 5)) minutes"
-            echo ""
-            if [ -f logs/failure-reason.txt ]; then
-              echo "### ❌ Failure Reason"
-              echo "$(cat logs/failure-reason.txt)"
-            else
-              echo "### ✅ Test Passed"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: bash scripts/soak-summary.sh logs/metrics.csv logs/informer-log.txt logs/failure-reason.txt
         shell: bash
 
       - name: Upload logs

--- a/scripts/soak-record-metrics.sh
+++ b/scripts/soak-record-metrics.sh
@@ -15,14 +15,16 @@ INFORMER_LOG="${3:?informer log path required}"
 METRICS_CSV="${4:?metrics csv path required}"
 
 # watch_controller_failures_total: simple counter, take the value directly
-cf=$(grep -v "^#" "$AUDITOR_LOG" | grep "watch_controller_failures_total" | awk '{print $NF}' | tail -1) || true
+ctrl_failures=$(grep -v "^#" "$AUDITOR_LOG" | grep "watch_controller_failures_total" | awk '{print $NF}' | tail -1) || true
 
 # pepr_cache_miss: gauge per time window e.g. pepr_cache_miss{window="..."} 16 — sum all windows
-cm=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | awk '{sum += $NF} END {print sum+0}') || true
+cache_misses=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | awk '{sum += $NF} END {print sum+0}') || true
 
 # pepr_resync_failure_count: label holds failure count e.g. {count="0"} 1 — sum non-zero count labels
-rf=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_resync_failure_count" | sed 's/.*count="\([^"]*\)".*/\1/' | awk '$1+0 > 0 {sum += $1+0} END {print sum+0}') || true
+resync_failures=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_resync_failure_count" | sed 's/.*count="\([^"]*\)".*/\1/' | awk '$1+0 > 0 {sum += $1+0} END {print sum+0}') || true
 
-cf="${cf:-0}"; cm="${cm:-0}"; rf="${rf:-0}"
+ctrl_failures="${ctrl_failures:-0}"
+cache_misses="${cache_misses:-0}"
+resync_failures="${resync_failures:-0}"
 
-printf "%s,%s,%s,%s,%s\n" "$ITERATION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$cf" "$cm" "$rf" >> "$METRICS_CSV"
+printf "%s,%s,%s,%s,%s\n" "$ITERATION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ctrl_failures" "$cache_misses" "$resync_failures" >> "$METRICS_CSV"

--- a/scripts/soak-record-metrics.sh
+++ b/scripts/soak-record-metrics.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-Present The Pepr Authors
+
+# Parses Prometheus metrics from soak test log files and appends a row to the metrics CSV.
+#
+# Usage: soak-record-metrics.sh <iteration> <auditor-log> <informer-log> <metrics-csv>
+
+set -uo pipefail
+
+ITERATION="${1:?iteration number required}"
+AUDITOR_LOG="${2:?auditor log path required}"
+INFORMER_LOG="${3:?informer log path required}"
+METRICS_CSV="${4:?metrics csv path required}"
+
+# watch_controller_failures_total: simple counter, take the value directly
+cf=$(grep -v "^#" "$AUDITOR_LOG" | grep "watch_controller_failures_total" | awk '{print $NF}' | tail -1) || true
+
+# pepr_cache_miss: gauge per time window e.g. pepr_cache_miss{window="..."} 16 — sum all windows
+cm=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | awk '{sum += $NF} END {print sum+0}') || true
+
+# pepr_resync_failure_count: label holds failure count e.g. {count="0"} 1 — sum non-zero count labels
+rf=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_resync_failure_count" | sed 's/.*count="\([^"]*\)".*/\1/' | awk '$1+0 > 0 {sum += $1+0} END {print sum+0}') || true
+
+cf="${cf:-0}"; cm="${cm:-0}"; rf="${rf:-0}"
+
+printf "%s,%s,%s,%s,%s\n" "$ITERATION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$cf" "$cm" "$rf" >> "$METRICS_CSV"

--- a/scripts/soak-summary.sh
+++ b/scripts/soak-summary.sh
@@ -21,39 +21,39 @@ fi
 
 final=$(tail -1 "$METRICS_CSV")
 iters=$(echo "$final" | cut -d',' -f1)
-final_cf=$(echo "$final" | cut -d',' -f3)
-final_cm=$(echo "$final" | cut -d',' -f4)
-final_rf=$(echo "$final" | cut -d',' -f5)
+final_ctrl_failures=$(echo "$final" | cut -d',' -f3)
+final_cache_misses=$(echo "$final" | cut -d',' -f4)
+final_resync_failures=$(echo "$final" | cut -d',' -f5)
 
-cf_status=$([ "${final_cf}" = "0" ] && echo "✅" || echo "❌")
-rf_status=$([ "${final_rf}" = "0" ] && echo "✅" || echo "❌")
+ctrl_failures_status=$([ "${final_ctrl_failures}" = "0" ] && echo "✅" || echo "❌")
+resync_failures_status=$([ "${final_resync_failures}" = "0" ] && echo "✅" || echo "❌")
 
 # cache miss: split into startup (first window) and mid-run (all other windows)
-startup_misses=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | head -1 | awk '{print $NF}') || true
+startup_misses=$(grep x-v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | head -1 | awk '{print $NF}') || true
 midrun_misses=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | tail -n +2 | awk '{sum += $NF} END {print sum+0}') || true
 startup_misses="${startup_misses:-0}"
 midrun_misses="${midrun_misses:-0}"
 
-if [ "${final_cm}" = "0" ]; then
-  cm_display="0"
+if [ "${final_cache_misses}" = "0" ]; then
+  cache_misses_display="0"
 else
-  cm_display="${final_cm} total (${startup_misses} startup, ${midrun_misses} mid-run)"
+  cache_misses_display="${final_cache_misses} total (${startup_misses} startup, ${midrun_misses} mid-run)"
 fi
-cm_status=$([ "${midrun_misses}" = "0" ] && echo "✅" || echo "⚠️")
+cache_misses_status=$([ "${midrun_misses}" = "0" ] && echo "✅" || echo "⚠️")
 
 # resync: total resyncs = sum of all gauge values across resync_failure_count lines
 resync_total=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_resync_failure_count" | awk '{sum += $NF} END {print sum+0}') || true
 resync_total="${resync_total:-0}"
-rf_display="${final_rf} failures across ${resync_total} resyncs"
+resync_failures_display="${final_resync_failures} failures across ${resync_total} resyncs"
 
 {
   echo "## Soak Test Results"
   echo ""
   echo "| Metric | Value | Status |"
   echo "|--------|-------|--------|"
-  echo "| \`watch_controller_failures_total\` | ${final_cf} | ${cf_status} |"
-  echo "| \`pepr_cache_miss\` | ${cm_display} | ${cm_status} |"
-  echo "| \`pepr_resync_failure_count\` | ${rf_display} | ${rf_status} |"
+  echo "| \`watch_controller_failures_total\` | ${final_ctrl_failures} | ${ctrl_failures_status} |"
+  echo "| \`pepr_cache_miss\` | ${cache_misses_display} | ${cache_misses_status} |"
+  echo "| \`pepr_resync_failure_count\` | ${resync_failures_display} | ${resync_failures_status} |"
   echo ""
   echo "**Iterations completed:** ${iters} / 70 | **Duration:** ~$((iters * 5)) minutes"
   echo ""

--- a/scripts/soak-summary.sh
+++ b/scripts/soak-summary.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-Present The Pepr Authors
+
+# Reads soak test metrics and writes a Markdown summary to $GITHUB_STEP_SUMMARY.
+#
+# Usage: soak-summary.sh <metrics-csv> <informer-log> <failure-reason>
+
+set -uo pipefail
+
+METRICS_CSV="${1:?metrics csv path required}"
+INFORMER_LOG="${2:?informer log path required}"
+FAILURE_REASON="${3:?failure reason path required}"
+
+if [ ! -f "$METRICS_CSV" ] || [ "$(wc -l < "$METRICS_CSV")" -lt 2 ]; then
+  echo "## Soak Test Results" >> "$GITHUB_STEP_SUMMARY"
+  echo "No metrics collected." >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+final=$(tail -1 "$METRICS_CSV")
+iters=$(echo "$final" | cut -d',' -f1)
+final_cf=$(echo "$final" | cut -d',' -f3)
+final_cm=$(echo "$final" | cut -d',' -f4)
+final_rf=$(echo "$final" | cut -d',' -f5)
+
+cf_status=$([ "${final_cf}" = "0" ] && echo "✅" || echo "❌")
+rf_status=$([ "${final_rf}" = "0" ] && echo "✅" || echo "❌")
+
+# cache miss: split into startup (first window) and mid-run (all other windows)
+startup_misses=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | head -1 | awk '{print $NF}') || true
+midrun_misses=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | tail -n +2 | awk '{sum += $NF} END {print sum+0}') || true
+startup_misses="${startup_misses:-0}"
+midrun_misses="${midrun_misses:-0}"
+
+if [ "${final_cm}" = "0" ]; then
+  cm_display="0"
+else
+  cm_display="${final_cm} total (${startup_misses} startup, ${midrun_misses} mid-run)"
+fi
+cm_status=$([ "${midrun_misses}" = "0" ] && echo "✅" || echo "⚠️")
+
+# resync: total resyncs = sum of all gauge values across resync_failure_count lines
+resync_total=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_resync_failure_count" | awk '{sum += $NF} END {print sum+0}') || true
+resync_total="${resync_total:-0}"
+rf_display="${final_rf} failures across ${resync_total} resyncs"
+
+{
+  echo "## Soak Test Results"
+  echo ""
+  echo "| Metric | Value | Status |"
+  echo "|--------|-------|--------|"
+  echo "| \`watch_controller_failures_total\` | ${final_cf} | ${cf_status} |"
+  echo "| \`pepr_cache_miss\` | ${cm_display} | ${cm_status} |"
+  echo "| \`pepr_resync_failure_count\` | ${rf_display} | ${rf_status} |"
+  echo ""
+  echo "**Iterations completed:** ${iters} / 70 | **Duration:** ~$((iters * 5)) minutes"
+  echo ""
+  if [ -f "${FAILURE_REASON}" ]; then
+    echo "### ❌ Failure Reason"
+    cat "${FAILURE_REASON}"
+  else
+    echo "### ✅ Test Passed"
+  fi
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024-Present The Pepr Authors
+
+# Runs the soak test loop: collects metrics every 5 minutes and checks pod stability every 10 minutes.
+# Produces logs/ artifacts consumed by soak-summary.sh.
+#
+# Usage: soak-test.sh
+
+set -uo pipefail
+
+LOGS_DIR="logs"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$LOGS_DIR"
+touch "$LOGS_DIR/auditor-log.txt"
+touch "$LOGS_DIR/informer-log.txt"
+touch "$LOGS_DIR/watch-logs.txt"
+echo "iteration,timestamp,watch_controller_failures_total,pepr_cache_miss,pepr_resync_failure_count" > "$LOGS_DIR/metrics.csv"
+
+# Initialize the map to store pod counts
+declare -A pod_map
+
+update_pod_map() {
+  for pod in $(kubectl get pods -n pepr-demo -o jsonpath='{.items[*].metadata.name}'); do
+    count=${pod_map[$pod]}
+    if [ -z "$count" ]; then
+      pod_map[$pod]=1
+    else
+      pod_map[$pod]=$((count + 1))
+    fi
+  done
+}
+
+collect_metrics() {
+  kubectl exec metrics-collector -n watch-auditor -- curl watch-auditor:8080/metrics | grep watch_controller_failures_total > "$LOGS_DIR/auditor-log.txt"
+  kubectl exec metrics-collector -n watch-auditor -- curl -k https://pepr-soak-ci-watcher.pepr-system.svc.cluster.local/metrics | grep -E "pepr_cache_miss|pepr_resync_failure_count" > "$LOGS_DIR/informer-log.txt"
+  kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system > "$LOGS_DIR/watch-logs.txt"
+}
+
+update_pod_map
+
+# Start collecting metrics every 5 minutes and checking pod counts every 10 minutes
+for i in {1..70}; do  # 70 iterations cover 350 minutes (5 hours and 50 minutes)
+  collect_metrics
+  cat "$LOGS_DIR/informer-log.txt"
+  cat "$LOGS_DIR/auditor-log.txt"
+
+  bash "$SCRIPT_DIR/soak-record-metrics.sh" "$i" "$LOGS_DIR/auditor-log.txt" "$LOGS_DIR/informer-log.txt" "$LOGS_DIR/metrics.csv"
+
+  if [ $((i % 2)) -eq 0 ]; then  # Every 10 minutes
+    update_pod_map
+
+    kubectl get pods -n pepr-demo
+    kubectl top po -n pepr-system
+    kubectl get po -n pepr-system
+
+    # Verify that no pod's count exceeds 1
+    for pod in "${!pod_map[@]}"; do
+      echo "$pod: ${pod_map[$pod]}"
+      if [ "${pod_map[$pod]}" -gt 1 ]; then
+        echo "Test failed: Pod $pod has count ${pod_map[$pod]}"
+        echo "Pod $pod was recreated (seen ${pod_map[$pod]} times) at iteration ${i} (~$((i * 5)) minutes into the run." > "$LOGS_DIR/failure-reason.txt"
+        kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system
+        exit 1
+      fi
+    done
+  fi
+
+  sleep 300s  # Sleep for 5 minutes before the next iteration
+done
+
+echo "Soak test passed successfully!"


### PR DESCRIPTION
## Description
Improves soak test observability by adding structured metric output to the Workdlow Summary and a downloadable CSV artifact.                                                                                    
                                                                                                              
  Previously, metrics were only visible by digging through raw log artifacts.                                                 
                           
  CSV artifact (logs/metrics.csv) records all three metrics once per iteration (~every 5 minutes) with a UTC timestamp.                                                                       
                                                                                                                
  The summary table is generated and displays metric totals.  
- pepr_cache_miss is a gauge per time window — cache misses are split into startup vs mid-run, since startup  
  misses are expected and should not indicate a problem                                                         
  - pepr_resync_failure_count uses a label to encode the failure count ({count="0"}) — the label value is
  extracted rather than the gauge value                                                                         
                                                                                                                
  Example output on a run (either Test Passed or Failure Reason will display):
          
<img width="774" height="288" alt="Screenshot 2026-04-15 at 4 45 55 PM" src="https://github.com/user-attachments/assets/8b0ce3ca-ddad-4587-a239-6a645406c30a" />

  
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
