### PR TITLE
chore: fix soak test scripts

### DIFF
--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -136,6 +136,13 @@ jobs:
         run: bash scripts/soak-summary.sh logs/metrics.csv logs/informer-log.txt logs/failure-reason.txt
         shell: bash
 
+      - name: Upload metrics CSV
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: soak-metrics.csv
+          path: logs/metrics.csv
+
       - name: Upload logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()

--- a/scripts/soak-summary.sh
+++ b/scripts/soak-summary.sh
@@ -28,10 +28,11 @@ final_resync_failures=$(echo "$final" | cut -d',' -f5)
 ctrl_failures_status=$([ "${final_ctrl_failures}" = "0" ] && echo "✅" || echo "❌")
 resync_failures_status=$([ "${final_resync_failures}" = "0" ] && echo "✅" || echo "❌")
 
-# cache miss: split into startup (first window) and mid-run (all other windows)
-startup_misses=$(grep x-v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | head -1 | awk '{print $NF}') || true
-midrun_misses=$(grep -v "^#" "$INFORMER_LOG" | grep "pepr_cache_miss" | tail -n +2 | awk '{sum += $NF} END {print sum+0}') || true
+# cache miss: split into startup (first iteration) and mid-run (sum of positive increments thereafter)
+# Derived from the CSV so the breakdown reflects the full run, not just the final scrape snapshot.
+startup_misses=$(awk -F',' 'NR==2{print $4; exit}' "$METRICS_CSV")
 startup_misses="${startup_misses:-0}"
+midrun_misses=$(awk -F',' 'NR==2{prev=$4; next} NR>2{delta=$4-prev; if(delta>0) sum+=delta; prev=$4} END{print sum+0}' "$METRICS_CSV")
 midrun_misses="${midrun_misses:-0}"
 
 if [ "${final_cache_misses}" = "0" ]; then

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -24,12 +24,7 @@ declare -A pod_map
 
 update_pod_map() {
   for pod in $(kubectl get pods -n pepr-demo -o jsonpath='{.items[*].metadata.name}'); do
-    count=${pod_map[$pod]}
-    if [ -z "$count" ]; then
-      pod_map[$pod]=1
-    else
-      pod_map[$pod]=$((count + 1))
-    fi
+    pod_map[$pod]=$(( ${pod_map[$pod]:-0} + 1 ))
   done
 }
 


### PR DESCRIPTION
  The soak test ran overnight after merging #3049 (soak-test-metrics) and failed. The test itself ran cleanly for ~4.5 hours with zero watch controller failures, zero cache misses during the run, and zero resync failures — but two scripting bugs caused the job to exit with code 1 and produced a misleading summary.

  What failed

  1. soak-test.sh — unbound variable crash- set -u makes bash fatal-error on unset variables. The first time `update_pod_map runs`, `pod_map` is empty — so reading `${pod_map[$pod]}` for any pod crashes the script. The fix `${pod_map[$pod]:-0}` tells bash "use 0 if this key doesn't exist yet," which both satisfies set -u and correctly initializes new pods to a count of 1 on their first increment.   

2. soak-summary.sh — The summary table metric `papr_cache_miss` had a value of `16 total (0 startup, 0 mid-run)`.  The variables needed to identify when the misses occurred were no longer accessible when the summary was generated, so they were recorded as 0. Now it collects the data from the csv instead.

3. soak.yaml — Added a separate artifact for the soak-metrics.csv so it isn't buried in the zipfile (soak-test-logs.zip). 
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #3049 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
