### PR TITLE
fix: webhook keepalive and timeout

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -63,6 +63,15 @@ The Watch configuration is a part of the Pepr module that allows you to watch fo
 | `PEPR_LAST_SEEN_LIMIT_SECONDS` | Max seconds to go without receiving a watch event before re-establishing the watch                                 | default: `"300"` (5 mins)         |
 | `PEPR_RELIST_INTERVAL_SECONDS` | Amount of seconds to wait before a relist of the watched resources                                                 | default: `"600"` (10 mins)        |
 
+## Customizing Webhook Server Timeouts
+
+The admission webhook server's HTTP timeouts can be tuned via environment variables on the Admission Deployment.
+
+| Field                        | Description                                                        | Example Values           |
+| ---------------------------- | ------------------------------------------------------------------ | ------------------------ |
+| `PEPR_KEEP_ALIVE_TIMEOUT_MS` | Idle timeout on persistent connections (`server.keepAliveTimeout`) | default: `"90000"` (90s) |
+| `PEPR_HEADERS_TIMEOUT_MS`    | Max time to receive full HTTP headers (`server.headersTimeout`)    | default: `"32000"` (32s) |
+
 ## Configuring Reconcile
 
 The [Reconcile Action](../actions/reconcile.md) allows you to maintain ordering of resource updates processed by a Pepr controller. The Reconcile configuration can be customized via environment variable on the Watcher Deployment, which can be set in the `package.json` or in the helm `values.yaml` file.

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -289,8 +289,11 @@ export class Controller {
   static #applyTimeouts(server: https.Server): {
     keepAliveTimeoutMs: number;
     headersTimeoutMs: number;
-    const keepAliveTimeoutMs = parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10) || 90000;
+  } {
+    const keepAliveTimeoutMs =
+      parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10) || 90000;
     const headersTimeoutMs = parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS ?? "32000", 10) || 32000;
+    server.keepAliveTimeout = keepAliveTimeoutMs;
     server.headersTimeout = headersTimeoutMs;
     return { keepAliveTimeoutMs, headersTimeoutMs };
   }

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -14,7 +14,12 @@ import { ModuleConfig } from "../types";
 import { mutateProcessor } from "../processors/mutate-processor";
 import { validateProcessor } from "../processors/validate-processor";
 import { StoreController } from "./store";
-import { karForMutate, karForValidate, KubeAdmissionReview } from "./index.util";
+import {
+  karForMutate,
+  karForValidate,
+  KubeAdmissionReview,
+  parseWebhookTimeouts,
+} from "./index.util";
 import { AdmissionRequest } from "../common-types";
 import { featureFlagStore } from "../features/store";
 import { GroupVersionKind } from "kubernetes-fluent-client";
@@ -280,24 +285,27 @@ export class Controller {
   };
 
   /**
+   * Parse and apply HTTP timeout settings to the server.
+   *
+   * @param server the HTTPS server to configure
+   */
+  static #applyTimeouts(server: https.Server): {
+    keepAliveTimeoutMs: number;
+    headersTimeoutMs: number;
+  } {
+    const { keepAliveTimeoutMs, headersTimeoutMs } = parseWebhookTimeouts();
+    server.keepAliveTimeout = keepAliveTimeoutMs;
+    server.headersTimeout = headersTimeoutMs;
+    return { keepAliveTimeoutMs, headersTimeoutMs };
+  }
+
+  /**
    * Middleware for logging requests
    *
    * @param req the incoming request
    * @param res the outgoing response
    * @param next the next middleware function
    */
-  static #applyTimeouts(server: https.Server): {
-    keepAliveTimeoutMs: number;
-    headersTimeoutMs: number;
-  } {
-    const keepAliveTimeoutMs =
-      parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10) || 90000;
-    const headersTimeoutMs = parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS ?? "32000", 10) || 32000;
-    server.keepAliveTimeout = keepAliveTimeoutMs;
-    server.headersTimeout = headersTimeoutMs;
-    return { keepAliveTimeoutMs, headersTimeoutMs };
-  }
-
   static #logger(req: express.Request, res: express.Response, next: express.NextFunction): void {
     const startTime = Date.now();
 

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -289,10 +289,8 @@ export class Controller {
   static #applyTimeouts(server: https.Server): {
     keepAliveTimeoutMs: number;
     headersTimeoutMs: number;
-  } {
-    const keepAliveTimeoutMs = parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10);
-    const headersTimeoutMs = parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS ?? "32000", 10);
-    server.keepAliveTimeout = keepAliveTimeoutMs;
+    const keepAliveTimeoutMs = parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10) || 90000;
+    const headersTimeoutMs = parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS ?? "32000", 10) || 32000;
     server.headersTimeout = headersTimeoutMs;
     return { keepAliveTimeoutMs, headersTimeoutMs };
   }

--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -118,11 +118,16 @@ export class Controller {
     }
 
     // Create HTTPS server
-    const server = https.createServer(options, this.#app).listen(port);
+    const server = https.createServer(options, this.#app);
+
+    // Tune HTTP timeouts (defaults align with controller-runtime's webhook server)
+    const { keepAliveTimeoutMs, headersTimeoutMs } = Controller.#applyTimeouts(server);
+
+    server.listen(port);
 
     // Handle server listening event
     server.on("listening", () => {
-      Log.debug(`Server listening on port ${port}`);
+      Log.debug({ port, keepAliveTimeoutMs, headersTimeoutMs }, `Server listening on port ${port}`);
       // Track that the server is running
       this.#running = true;
     });
@@ -281,6 +286,17 @@ export class Controller {
    * @param res the outgoing response
    * @param next the next middleware function
    */
+  static #applyTimeouts(server: https.Server): {
+    keepAliveTimeoutMs: number;
+    headersTimeoutMs: number;
+  } {
+    const keepAliveTimeoutMs = parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10);
+    const headersTimeoutMs = parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS ?? "32000", 10);
+    server.keepAliveTimeout = keepAliveTimeoutMs;
+    server.headersTimeout = headersTimeoutMs;
+    return { keepAliveTimeoutMs, headersTimeoutMs };
+  }
+
   static #logger(req: express.Request, res: express.Response, next: express.NextFunction): void {
     const startTime = Date.now();
 

--- a/src/lib/controller/index.util.test.ts
+++ b/src/lib/controller/index.util.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { MutateResponse, ValidateResponse } from "../k8s";
 import * as sut from "./index.util";
 import { AdmissionRequest } from "../common-types";
@@ -188,5 +188,63 @@ describe("karForValidate()", () => {
       const result = sut.karForValidate(ar, vrs);
       expect(result).toEqual(kar);
     });
+  });
+});
+
+describe("parseWebhookTimeouts()", () => {
+  const originalKeepAlive = process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+  const originalHeaders = process.env.PEPR_HEADERS_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalKeepAlive === undefined) {
+      delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+    } else {
+      process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = originalKeepAlive;
+    }
+    if (originalHeaders === undefined) {
+      delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+    } else {
+      process.env.PEPR_HEADERS_TIMEOUT_MS = originalHeaders;
+    }
+  });
+
+  it.each([
+    {
+      name: "returns defaults when env vars are not set",
+      keepAliveEnv: undefined,
+      headersEnv: undefined,
+      expected: { keepAliveTimeoutMs: 90000, headersTimeoutMs: 32000 },
+    },
+    {
+      name: "uses both env vars when set",
+      keepAliveEnv: "120000",
+      headersEnv: "60000",
+      expected: { keepAliveTimeoutMs: 120000, headersTimeoutMs: 60000 },
+    },
+    {
+      name: "defaults keepAlive when only headers env is set",
+      keepAliveEnv: undefined,
+      headersEnv: "45000",
+      expected: { keepAliveTimeoutMs: 90000, headersTimeoutMs: 45000 },
+    },
+    {
+      name: "defaults headers when only keepAlive env is set",
+      keepAliveEnv: "120000",
+      headersEnv: undefined,
+      expected: { keepAliveTimeoutMs: 120000, headersTimeoutMs: 32000 },
+    },
+  ])("$name", ({ keepAliveEnv, headersEnv, expected }) => {
+    if (keepAliveEnv !== undefined) {
+      process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = keepAliveEnv;
+    } else {
+      delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+    }
+    if (headersEnv !== undefined) {
+      process.env.PEPR_HEADERS_TIMEOUT_MS = headersEnv;
+    } else {
+      delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+    }
+
+    expect(sut.parseWebhookTimeouts()).toEqual(expected);
   });
 });

--- a/src/lib/controller/index.util.ts
+++ b/src/lib/controller/index.util.ts
@@ -19,6 +19,16 @@ export function karForMutate(mr: MutateResponse): KubeAdmissionReview {
   };
 }
 
+export function parseWebhookTimeouts(): { keepAliveTimeoutMs: number; headersTimeoutMs: number } {
+  const keepAliveTimeoutMs = process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS
+    ? parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS, 10)
+    : 90000;
+  const headersTimeoutMs = process.env.PEPR_HEADERS_TIMEOUT_MS
+    ? parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS, 10)
+    : 32000;
+  return { keepAliveTimeoutMs, headersTimeoutMs };
+}
+
 export function karForValidate(ar: AdmissionRequest, vr: ValidateResponse[]): KubeAdmissionReview {
   const isAllowed = vr.filter(r => !r.allowed).length === 0;
 


### PR DESCRIPTION
## Description

Adds overrides for webhook keep alive and header timeouts. The default values copy [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/internal/httpserver/server.go)

They are also exposed as envs for more advanced users to override if needed based on the environment.

## Related Issue

No open issue, can open if needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
