### PR TITLE
chore: suppress not vul cves

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -26,3 +26,8 @@ ignore:
   - vulnerability: CVE-2026-2673
   - vulnerability: GHSA-c2c7-rcm5-vvqj
   - vulnerability: GHSA-j3q9-mxjg-w52f
+  - vulnerability: CVE-2026-31790
+  - vulnerability: CVE-2026-28388
+  - vulnerability: CVE-2026-28389
+  - vulnerability: CVE-2026-28390
+  - vulnerability: CVE-2026-40200


### PR DESCRIPTION
## Description

CVE-2026-40200 - Not Vul -  The vulnerability requires sorting the 64th Leonardo number of array elements on 64-bit platforms, which the CVE itself describes as not practical. 

CVE-2026-31790 - Not Vul -   The pepr controller is not at risk because Node.js does not expose the RSASVE KEM interface (EVP_PKEY_encapsulate), making this code path unreachable at runtime.

CVE-2026-28388 - Not Vul - The pepr controller is not at risk because Node.js does not expose delta CRL processing (X509_V_FLAG_USE_DELTAS), and the vulnerable code is outside the FIPS module boundary used by the production image.    

CVE-2026-28389 & CVE-2026-28390 - Not Vul - The pepr controller is not at risk because Node.js does not expose CMS_decrypt(), pepr processes no CMS/S/MIME data, and the vulnerable code is outside the FIPS module boundary used by the production image. 


End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
