### PR TITLE
chore: log reports deltas instead of cumulative values

### DIFF
--- a/scripts/soak-record-metrics.sh
+++ b/scripts/soak-record-metrics.sh
@@ -27,17 +27,20 @@ ctrl_failures="${ctrl_failures:-0}"
 cache_misses="${cache_misses:-0}"
 resync_failures="${resync_failures:-0}"
 
-# Compute deltas against the previous row so each CSV row shows what changed in this interval
-prev_row=$(tail -1 "$METRICS_CSV" 2>/dev/null || true)
-if [[ "$prev_row" == iteration,* ]] || [[ -z "$prev_row" ]]; then
-  # First data row: no previous values to diff against
-  ctrl_failures_delta="$ctrl_failures"
-  cache_misses_delta="$cache_misses"
+# Compute deltas using a state file that tracks the previous cumulative values.
+# Reading deltas back from the CSV would give the wrong base (delta_N-1 != cumulative_N-1).
+PREV_STATE="${METRICS_CSV%.csv}.prev"
+if [ -f "$PREV_STATE" ]; then
+  prev_ctrl=$(cut -d',' -f1 "$PREV_STATE")
+  prev_cache=$(cut -d',' -f2 "$PREV_STATE")
 else
-  prev_ctrl=$(echo "$prev_row" | cut -d',' -f3)
-  prev_cache=$(echo "$prev_row" | cut -d',' -f4)
-  ctrl_failures_delta=$(( ctrl_failures - ${prev_ctrl:-0} ))
-  cache_misses_delta=$(( cache_misses - ${prev_cache:-0} ))
+  prev_ctrl=0
+  prev_cache=0
 fi
+
+ctrl_failures_delta=$(( ctrl_failures - prev_ctrl ))
+cache_misses_delta=$(( cache_misses - prev_cache ))
+
+printf "%s,%s\n" "$ctrl_failures" "$cache_misses" > "$PREV_STATE"
 
 printf "%s,%s,%s,%s,%s\n" "$ITERATION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ctrl_failures_delta" "$cache_misses_delta" "$resync_failures" >> "$METRICS_CSV"

--- a/scripts/soak-record-metrics.sh
+++ b/scripts/soak-record-metrics.sh
@@ -27,4 +27,17 @@ ctrl_failures="${ctrl_failures:-0}"
 cache_misses="${cache_misses:-0}"
 resync_failures="${resync_failures:-0}"
 
-printf "%s,%s,%s,%s,%s\n" "$ITERATION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ctrl_failures" "$cache_misses" "$resync_failures" >> "$METRICS_CSV"
+# Compute deltas against the previous row so each CSV row shows what changed in this interval
+prev_row=$(tail -1 "$METRICS_CSV" 2>/dev/null || true)
+if [[ "$prev_row" == iteration,* ]] || [[ -z "$prev_row" ]]; then
+  # First data row: no previous values to diff against
+  ctrl_failures_delta="$ctrl_failures"
+  cache_misses_delta="$cache_misses"
+else
+  prev_ctrl=$(echo "$prev_row" | cut -d',' -f3)
+  prev_cache=$(echo "$prev_row" | cut -d',' -f4)
+  ctrl_failures_delta=$(( ctrl_failures - ${prev_ctrl:-0} ))
+  cache_misses_delta=$(( cache_misses - ${prev_cache:-0} ))
+fi
+
+printf "%s,%s,%s,%s,%s\n" "$ITERATION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ctrl_failures_delta" "$cache_misses_delta" "$resync_failures" >> "$METRICS_CSV"

--- a/scripts/soak-summary.sh
+++ b/scripts/soak-summary.sh
@@ -21,24 +21,26 @@ fi
 
 final=$(tail -1 "$METRICS_CSV")
 iters=$(echo "$final" | cut -d',' -f1)
-final_ctrl_failures=$(echo "$final" | cut -d',' -f3)
-final_cache_misses=$(echo "$final" | cut -d',' -f4)
 final_resync_failures=$(echo "$final" | cut -d',' -f5)
 
-ctrl_failures_status=$([ "${final_ctrl_failures}" = "0" ] && echo "✅" || echo "❌")
+# Columns are now per-interval deltas — sum across all rows to get totals
+total_ctrl_failures=$(awk -F',' 'NR>1{sum+=$3} END{print sum+0}' "$METRICS_CSV")
+total_ctrl_failures="${total_ctrl_failures:-0}"
+
+ctrl_failures_status=$([ "${total_ctrl_failures}" = "0" ] && echo "✅" || echo "❌")
 resync_failures_status=$([ "${final_resync_failures}" = "0" ] && echo "✅" || echo "❌")
 
-# cache miss: split into startup (first iteration) and mid-run (sum of positive increments thereafter)
-# Derived from the CSV so the breakdown reflects the full run, not just the final scrape snapshot.
+# cache miss: first data row = startup window delta; rows after = mid-run deltas
 startup_misses=$(awk -F',' 'NR==2{print $4; exit}' "$METRICS_CSV")
 startup_misses="${startup_misses:-0}"
-midrun_misses=$(awk -F',' 'NR==2{prev=$4; next} NR>2{delta=$4-prev; if(delta>0) sum+=delta; prev=$4} END{print sum+0}' "$METRICS_CSV")
+midrun_misses=$(awk -F',' 'NR>2 && $4>0{sum+=$4} END{print sum+0}' "$METRICS_CSV")
 midrun_misses="${midrun_misses:-0}"
+total_cache_misses=$(( startup_misses + midrun_misses ))
 
-if [ "${final_cache_misses}" = "0" ]; then
+if [ "${total_cache_misses}" = "0" ]; then
   cache_misses_display="0"
 else
-  cache_misses_display="${final_cache_misses} total (${startup_misses} startup, ${midrun_misses} mid-run)"
+  cache_misses_display="${total_cache_misses} total (${startup_misses} startup, ${midrun_misses} mid-run)"
 fi
 cache_misses_status=$([ "${midrun_misses}" = "0" ] && echo "✅" || echo "⚠️")
 
@@ -52,7 +54,7 @@ resync_failures_display="${final_resync_failures} failures across ${resync_total
   echo ""
   echo "| Metric | Value | Status |"
   echo "|--------|-------|--------|"
-  echo "| \`watch_controller_failures_total\` | ${final_ctrl_failures} | ${ctrl_failures_status} |"
+  echo "| \`watch_controller_failures_total\` | ${total_ctrl_failures} | ${ctrl_failures_status} |"
   echo "| \`pepr_cache_miss\` | ${cache_misses_display} | ${cache_misses_status} |"
   echo "| \`pepr_resync_failure_count\` | ${resync_failures_display} | ${resync_failures_status} |"
   echo ""

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -17,7 +17,7 @@ mkdir -p "$LOGS_DIR"
 touch "$LOGS_DIR/auditor-log.txt"
 touch "$LOGS_DIR/informer-log.txt"
 touch "$LOGS_DIR/watch-logs.txt"
-echo "iteration,timestamp,watch_controller_failures_total,pepr_cache_miss,pepr_resync_failure_count" > "$LOGS_DIR/metrics.csv"
+echo "iteration,timestamp,watch_controller_failures_delta,pepr_cache_miss_delta,pepr_resync_failure_count" > "$LOGS_DIR/metrics.csv"
 
 # Initialize the map to store pod counts
 declare -A pod_map


### PR DESCRIPTION
## Description
Updated the log so it shows changes at each interval instead of cumulative.  
  - soak-record-metrics.sh: reads the previous CSV row and writes deltas for    
  watch_controller_failures and pepr_cache_miss instead of raw cumulative values
  - soak-test.sh: header columns renamed to watch_controller_failures_delta and 
  pepr_cache_miss_delta                                                         
  - soak-summary.sh: removed the manual delta computation (it was doing this    
  from cumulative values before); now just sums the delta columns directly to   
  get totals and the startup/mid-run breakdown          
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
