### PR TITLE
fix: align webhook timeout parsing with codebase conventions

### DIFF
--- a/src/lib/controller/index.ts
+++ b/src/lib/controller/index.ts
@@ -14,7 +14,12 @@ import { ModuleConfig } from "../types";
 import { mutateProcessor } from "../processors/mutate-processor";
 import { validateProcessor } from "../processors/validate-processor";
 import { StoreController } from "./store";
-import { karForMutate, karForValidate, KubeAdmissionReview } from "./index.util";
+import {
+  karForMutate,
+  karForValidate,
+  KubeAdmissionReview,
+  parseWebhookTimeouts,
+} from "./index.util";
 import { AdmissionRequest } from "../common-types";
 import { featureFlagStore } from "../features/store";
 import { GroupVersionKind } from "kubernetes-fluent-client";
@@ -280,24 +285,27 @@ export class Controller {
   };
 
   /**
+   * Parse and apply HTTP timeout settings to the server.
+   *
+   * @param server the HTTPS server to configure
+   */
+  static #applyTimeouts(server: https.Server): {
+    keepAliveTimeoutMs: number;
+    headersTimeoutMs: number;
+  } {
+    const { keepAliveTimeoutMs, headersTimeoutMs } = parseWebhookTimeouts();
+    server.keepAliveTimeout = keepAliveTimeoutMs;
+    server.headersTimeout = headersTimeoutMs;
+    return { keepAliveTimeoutMs, headersTimeoutMs };
+  }
+
+  /**
    * Middleware for logging requests
    *
    * @param req the incoming request
    * @param res the outgoing response
    * @param next the next middleware function
    */
-  static #applyTimeouts(server: https.Server): {
-    keepAliveTimeoutMs: number;
-    headersTimeoutMs: number;
-  } {
-    const keepAliveTimeoutMs =
-      parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS ?? "90000", 10) || 90000;
-    const headersTimeoutMs = parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS ?? "32000", 10) || 32000;
-    server.keepAliveTimeout = keepAliveTimeoutMs;
-    server.headersTimeout = headersTimeoutMs;
-    return { keepAliveTimeoutMs, headersTimeoutMs };
-  }
-
   static #logger(req: express.Request, res: express.Response, next: express.NextFunction): void {
     const startTime = Date.now();
 

--- a/src/lib/controller/index.util.test.ts
+++ b/src/lib/controller/index.util.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { MutateResponse, ValidateResponse } from "../k8s";
 import * as sut from "./index.util";
 import { AdmissionRequest } from "../common-types";
@@ -208,57 +208,43 @@ describe("parseWebhookTimeouts()", () => {
     }
   });
 
-  it("returns default values when env vars are not set", () => {
-    delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
-    delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+  it.each([
+    {
+      name: "returns defaults when env vars are not set",
+      keepAliveEnv: undefined,
+      headersEnv: undefined,
+      expected: { keepAliveTimeoutMs: 90000, headersTimeoutMs: 32000 },
+    },
+    {
+      name: "uses both env vars when set",
+      keepAliveEnv: "120000",
+      headersEnv: "60000",
+      expected: { keepAliveTimeoutMs: 120000, headersTimeoutMs: 60000 },
+    },
+    {
+      name: "defaults keepAlive when only headers env is set",
+      keepAliveEnv: undefined,
+      headersEnv: "45000",
+      expected: { keepAliveTimeoutMs: 90000, headersTimeoutMs: 45000 },
+    },
+    {
+      name: "defaults headers when only keepAlive env is set",
+      keepAliveEnv: "120000",
+      headersEnv: undefined,
+      expected: { keepAliveTimeoutMs: 120000, headersTimeoutMs: 32000 },
+    },
+  ])("$name", ({ keepAliveEnv, headersEnv, expected }) => {
+    if (keepAliveEnv !== undefined) {
+      process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = keepAliveEnv;
+    } else {
+      delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+    }
+    if (headersEnv !== undefined) {
+      process.env.PEPR_HEADERS_TIMEOUT_MS = headersEnv;
+    } else {
+      delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+    }
 
-    const result = sut.parseWebhookTimeouts();
-
-    expect(result).toEqual({
-      keepAliveTimeoutMs: 90000,
-      headersTimeoutMs: 32000,
-    });
-  });
-
-  it("uses environment variables to configure timeouts", () => {
-    const parseIntSpy = vi.spyOn(global, "parseInt");
-
-    process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = "120000";
-    process.env.PEPR_HEADERS_TIMEOUT_MS = "60000";
-
-    const result = sut.parseWebhookTimeouts();
-
-    expect(parseIntSpy).toHaveBeenCalledWith("120000", 10);
-    expect(parseIntSpy).toHaveBeenCalledWith("60000", 10);
-    expect(result).toEqual({
-      keepAliveTimeoutMs: 120000,
-      headersTimeoutMs: 60000,
-    });
-
-    parseIntSpy.mockRestore();
-  });
-
-  it("uses default keepAliveTimeoutMs when only PEPR_HEADERS_TIMEOUT_MS is set", () => {
-    delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
-    process.env.PEPR_HEADERS_TIMEOUT_MS = "45000";
-
-    const result = sut.parseWebhookTimeouts();
-
-    expect(result).toEqual({
-      keepAliveTimeoutMs: 90000,
-      headersTimeoutMs: 45000,
-    });
-  });
-
-  it("uses default headersTimeoutMs when only PEPR_KEEP_ALIVE_TIMEOUT_MS is set", () => {
-    process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = "120000";
-    delete process.env.PEPR_HEADERS_TIMEOUT_MS;
-
-    const result = sut.parseWebhookTimeouts();
-
-    expect(result).toEqual({
-      keepAliveTimeoutMs: 120000,
-      headersTimeoutMs: 32000,
-    });
+    expect(sut.parseWebhookTimeouts()).toEqual(expected);
   });
 });

--- a/src/lib/controller/index.util.test.ts
+++ b/src/lib/controller/index.util.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MutateResponse, ValidateResponse } from "../k8s";
 import * as sut from "./index.util";
 import { AdmissionRequest } from "../common-types";
@@ -187,6 +187,78 @@ describe("karForValidate()", () => {
       };
       const result = sut.karForValidate(ar, vrs);
       expect(result).toEqual(kar);
+    });
+  });
+});
+
+describe("parseWebhookTimeouts()", () => {
+  const originalKeepAlive = process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+  const originalHeaders = process.env.PEPR_HEADERS_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalKeepAlive === undefined) {
+      delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+    } else {
+      process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = originalKeepAlive;
+    }
+    if (originalHeaders === undefined) {
+      delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+    } else {
+      process.env.PEPR_HEADERS_TIMEOUT_MS = originalHeaders;
+    }
+  });
+
+  it("returns default values when env vars are not set", () => {
+    delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+    delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+
+    const result = sut.parseWebhookTimeouts();
+
+    expect(result).toEqual({
+      keepAliveTimeoutMs: 90000,
+      headersTimeoutMs: 32000,
+    });
+  });
+
+  it("uses environment variables to configure timeouts", () => {
+    const parseIntSpy = vi.spyOn(global, "parseInt");
+
+    process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = "120000";
+    process.env.PEPR_HEADERS_TIMEOUT_MS = "60000";
+
+    const result = sut.parseWebhookTimeouts();
+
+    expect(parseIntSpy).toHaveBeenCalledWith("120000", 10);
+    expect(parseIntSpy).toHaveBeenCalledWith("60000", 10);
+    expect(result).toEqual({
+      keepAliveTimeoutMs: 120000,
+      headersTimeoutMs: 60000,
+    });
+
+    parseIntSpy.mockRestore();
+  });
+
+  it("uses default keepAliveTimeoutMs when only PEPR_HEADERS_TIMEOUT_MS is set", () => {
+    delete process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS;
+    process.env.PEPR_HEADERS_TIMEOUT_MS = "45000";
+
+    const result = sut.parseWebhookTimeouts();
+
+    expect(result).toEqual({
+      keepAliveTimeoutMs: 90000,
+      headersTimeoutMs: 45000,
+    });
+  });
+
+  it("uses default headersTimeoutMs when only PEPR_KEEP_ALIVE_TIMEOUT_MS is set", () => {
+    process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS = "120000";
+    delete process.env.PEPR_HEADERS_TIMEOUT_MS;
+
+    const result = sut.parseWebhookTimeouts();
+
+    expect(result).toEqual({
+      keepAliveTimeoutMs: 120000,
+      headersTimeoutMs: 32000,
     });
   });
 });

--- a/src/lib/controller/index.util.ts
+++ b/src/lib/controller/index.util.ts
@@ -19,6 +19,16 @@ export function karForMutate(mr: MutateResponse): KubeAdmissionReview {
   };
 }
 
+export function parseWebhookTimeouts(): { keepAliveTimeoutMs: number; headersTimeoutMs: number } {
+  const keepAliveTimeoutMs = process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS
+    ? parseInt(process.env.PEPR_KEEP_ALIVE_TIMEOUT_MS, 10)
+    : 90000;
+  const headersTimeoutMs = process.env.PEPR_HEADERS_TIMEOUT_MS
+    ? parseInt(process.env.PEPR_HEADERS_TIMEOUT_MS, 10)
+    : 32000;
+  return { keepAliveTimeoutMs, headersTimeoutMs };
+}
+
 export function karForValidate(ar: AdmissionRequest, vr: ValidateResponse[]): KubeAdmissionReview {
   const isAllowed = vr.filter(r => !r.allowed).length === 0;
 


### PR DESCRIPTION
## Summary
- Aligns `PEPR_KEEP_ALIVE_TIMEOUT_MS` / `PEPR_HEADERS_TIMEOUT_MS` parsing with the ternary-guard pattern used by all other `PEPR_*` numeric env vars in `watch-processor.ts`
- Extracts parsing into a testable `parseWebhookTimeouts()` helper in `index.util.ts`
- Fixes misplaced JSDoc comment that described `#logger` but sat above `#applyTimeouts`

## Test plan
- [x] `npx vitest run src/lib/controller/` — all 106 tests pass (4 new + 102 existing)
- [x] Lint clean on both `eslint.root.config` and `eslint.test.config`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)