### PR TITLE
chore: add deprecation warning for pepr format

### DIFF
--- a/src/cli/format/index.ts
+++ b/src/cli/format/index.ts
@@ -13,6 +13,12 @@ export default function (program: Command): void {
     .description("Lint and format this Pepr module")
     .option("-v, --validate-only", "Do not modify files, only validate formatting.")
     .action(async opts => {
+      Log.warn(
+        "DEPRECATION NOTICE: Pepr v1.1.6 is the last release that supports ESLint v9. " +
+          "The next release will upgrade to ESLint v10, which includes breaking changes. " +
+          "Review the ESLint v10 migration guide before upgrading Pepr: <ADD_URL_HERE>",
+      );
+
       const success = await peprFormat(opts.validateOnly);
 
       if (success) {

--- a/src/cli/format/index.ts
+++ b/src/cli/format/index.ts
@@ -14,8 +14,8 @@ export default function (program: Command): void {
     .option("-v, --validate-only", "Do not modify files, only validate formatting.")
     .action(async opts => {
       Log.warn(
-        "DEPRECATION NOTICE: `pepr format` will be deprecated removed in summer 2026. " +
-          "Please configure linting and formatting directly in your project instead.",
+        "DEPRECATION NOTICE: The pepr format command will be removed in summer 2026. " +
+          "Once removed, module authors must run a linter separately from the pepr CLI.",
       );
 
       const success = await peprFormat(opts.validateOnly);

--- a/src/cli/format/index.ts
+++ b/src/cli/format/index.ts
@@ -14,9 +14,8 @@ export default function (program: Command): void {
     .option("-v, --validate-only", "Do not modify files, only validate formatting.")
     .action(async opts => {
       Log.warn(
-        "DEPRECATION NOTICE: Pepr v1.1.6 is the last release that supports ESLint v9. " +
-          "The next release will upgrade to ESLint v10, which includes breaking changes. " +
-          "Review the ESLint v10 migration guide before upgrading Pepr: <ADD_URL_HERE>",
+        "DEPRECATION NOTICE: `pepr format` will be deprecated removed in summer 2026. " +
+          "Please configure linting and formatting directly in your project instead.",
       );
 
       const success = await peprFormat(opts.validateOnly);


### PR DESCRIPTION
## Description
Added a warning to `pepr format` to alert users to upcoming breaking changes with Pepr `2.0.0` when `pepr format` will be deprecated.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
