### PR TITLE
chore: bump workflows to node 24

### DIFF
--- a/.github/actions/ironbank-setup/action.yaml
+++ b/.github/actions/ironbank-setup/action.yaml
@@ -14,10 +14,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 22
+    - name: Use Node.js 24
       uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
-        node-version: 22
+        node-version: 24
 
     - name: Install k3d
       shell: bash

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js latest
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
       - name: Install Pepr Dependencies
         run: npm ci

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -31,7 +31,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache-dependency-path: pepr
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -41,7 +41,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -27,10 +27,10 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 

--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -74,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - run: npm ci
       - run: npm install ts-node
@@ -89,10 +89,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: "Install K3d"
         run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -41,7 +41,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 
@@ -120,7 +120,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 
@@ -175,7 +175,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr-excellent-examples
 

--- a/.github/workflows/pepr-excellent-examples-upstream.yml
+++ b/.github/workflows/pepr-excellent-examples-upstream.yml
@@ -37,7 +37,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 
@@ -103,7 +103,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 
@@ -158,7 +158,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr-excellent-examples
 

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr
 


### PR DESCRIPTION
## Description
  - Bump all CI workflow Node.js versions from 20/22 to 24, dropping the EOL  
  Node 20                                                                       
  - Update the on-demand test matrix from [20, 22, 24] to [22, 24]
  - Update step names to reflect the new version                                
                                                                              
  **Motivation**                                                                    
                                                                              
  Node 20 reached EOL in April 2026. Several CI workflows were still pinned to  
  Node 20 while the release workflows had already moved to 24, creating an    
  inconsistency where we were testing on a different (and EOL) version than we  
  were releasing with. This aligns all CI on Node 24 and keeps 22 in the test 
  matrix since it's still LTS.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
