### PR TITLE
chore: use GitHub Contents API for verified commits in grype audit

### DIFF
--- a/.github/workflows/grype-suppression-audit.yaml
+++ b/.github/workflows/grype-suppression-audit.yaml
@@ -32,7 +32,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_ID }}
+          app-id: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_ID }}
           private-key: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_SECRET }}
 
       - name: Checkout repository

--- a/.github/workflows/grype-suppression-audit.yaml
+++ b/.github/workflows/grype-suppression-audit.yaml
@@ -28,8 +28,17 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_SECRET }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Use Node.js latest
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -50,6 +59,6 @@ jobs:
       - name: Audit suppression list
         env:
           GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: npx tsx .github/workflows/scripts/audit-grype-suppressions.ts

--- a/.github/workflows/scripts/audit-grype-suppressions.ts
+++ b/.github/workflows/scripts/audit-grype-suppressions.ts
@@ -125,22 +125,28 @@ function ensureBranch(branch: string): void {
   // Create the branch from HEAD if it doesn't already exist on the remote.
   try {
     exec("gh", ["api", `repos/{owner}/{repo}/git/ref/heads/${branch}`]);
-  } catch {
-    const headSha = exec("gh", [
-      "api",
-      "repos/{owner}/{repo}/git/ref/heads/main",
-      "--jq",
-      ".object.sha",
-    ]);
-    exec("gh", [
-      "api",
-      "repos/{owner}/{repo}/git/refs",
-      "-f",
-      `ref=refs/heads/${branch}`,
-      "-f",
-      `sha=${headSha}`,
-    ]);
+    return;
+  } catch (err) {
+    const stderr = String((err as { stderr?: unknown }).stderr ?? "");
+    if (!stderr.includes("Not Found")) {
+      throw err;
+    }
   }
+
+  const headSha = exec("gh", [
+    "api",
+    "repos/{owner}/{repo}/git/ref/heads/main",
+    "--jq",
+    ".object.sha",
+  ]);
+  exec("gh", [
+    "api",
+    "repos/{owner}/{repo}/git/refs",
+    "-f",
+    `ref=refs/heads/${branch}`,
+    "-f",
+    `sha=${headSha}`,
+  ]);
 }
 
 function pushBranch(branch: string, staleCount: number): void {

--- a/.github/workflows/scripts/audit-grype-suppressions.ts
+++ b/.github/workflows/scripts/audit-grype-suppressions.ts
@@ -133,9 +133,17 @@ function ensureBranch(branch: string): void {
     }
   }
 
+  const defaultBranch = exec("gh", [
+    "repo",
+    "view",
+    "--json",
+    "defaultBranchRef",
+    "--jq",
+    ".defaultBranchRef.name",
+  ]);
   const headSha = exec("gh", [
     "api",
-    "repos/{owner}/{repo}/git/ref/heads/main",
+    `repos/{owner}/{repo}/git/ref/heads/${defaultBranch}`,
     "--jq",
     ".object.sha",
   ]);
@@ -223,8 +231,6 @@ function openOrUpdatePR(branch: string, title: string, body: string): string {
         bodyFile,
         "--head",
         branch,
-        "--base",
-        "main",
       ]);
     }
   } finally {

--- a/.github/workflows/scripts/audit-grype-suppressions.ts
+++ b/.github/workflows/scripts/audit-grype-suppressions.ts
@@ -121,15 +121,59 @@ function buildPRContent(staleIds: string[], matchCount: number): { title: string
   return { title, body };
 }
 
+function ensureBranch(branch: string): void {
+  // Create the branch from HEAD if it doesn't already exist on the remote.
+  try {
+    exec("gh", ["api", `repos/{owner}/{repo}/git/ref/heads/${branch}`]);
+  } catch {
+    const headSha = exec("gh", [
+      "api",
+      "repos/{owner}/{repo}/git/ref/heads/main",
+      "--jq",
+      ".object.sha",
+    ]);
+    exec("gh", [
+      "api",
+      "repos/{owner}/{repo}/git/refs",
+      "-f",
+      `ref=refs/heads/${branch}`,
+      "-f",
+      `sha=${headSha}`,
+    ]);
+  }
+}
+
 function pushBranch(branch: string, staleCount: number): void {
   const commitMsg = `chore: remove ${staleCount} stale CVE suppression(s) from .grype.yaml`;
 
-  exec("git", ["config", "user.name", "github-actions[bot]"]);
-  exec("git", ["config", "user.email", "github-actions[bot]@users.noreply.github.com"]);
-  exec("git", ["checkout", "-B", branch]);
-  exec("git", ["add", ".grype.yaml"]);
-  exec("git", ["commit", "-m", commitMsg]);
-  exec("git", ["push", "origin", branch, "--force-with-lease"]);
+  ensureBranch(branch);
+
+  // Get the current file's blob SHA on the branch (required by the Contents API).
+  const blobSha = exec("gh", [
+    "api",
+    `repos/{owner}/{repo}/contents/${GRYPE_YAML}?ref=${branch}`,
+    "-q",
+    ".sha",
+  ]);
+
+  // Read the locally-modified file and base64-encode it.
+  const content = readFileSync(GRYPE_YAML).toString("base64");
+
+  // Update the file via the Contents API — GitHub auto-verifies the commit.
+  exec("gh", [
+    "api",
+    "-X",
+    "PUT",
+    `repos/{owner}/{repo}/contents/${GRYPE_YAML}`,
+    "-f",
+    `message=${commitMsg}`,
+    "-f",
+    `content=${content}`,
+    "-f",
+    `sha=${blobSha}`,
+    "-f",
+    `branch=${branch}`,
+  ]);
 }
 
 function openOrUpdatePR(branch: string, title: string, body: string): string {


### PR DESCRIPTION
## Description
U0pdate workflow to use Github API to verify commits for the Grype Audit Workflow to fix [error](https://github.com/defenseunicorns/pepr/actions/runs/25327380086/job/74251635502#step:9:1).
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
