### PR TITLE
chore: added deprecation warning to docs

### DIFF
--- a/docs/reference/best-practices.md
+++ b/docs/reference/best-practices.md
@@ -240,7 +240,7 @@ Recommendations for keeping modules small are:
 It is suggested to lint and format your modules using `npx pepr format`.
 
 > [!WARNING]
-> `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. Once removed, module authors must run a linter separately from the pepr CLI.
+> `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. Once removed, module authors must run a linter separately from the Pepr CLI. Please configure linting and formatting directly in your project instead.
 
 ## Monitoring
 

--- a/docs/reference/best-practices.md
+++ b/docs/reference/best-practices.md
@@ -237,7 +237,7 @@ Recommendations for keeping modules small are:
 - Don't repeat yourself
 - Only import the part of the library modules that you need
 
-It is suggested to lint and format your modules  using `npx pepr format`. Configure linting and formatting tools directly in your project.
+It is suggested to lint and format your modules  using `npx pepr format`.
 
 > [!WARNING]
 > `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. "Once removed, module authors must run a linter separately from the pepr CLI."

--- a/docs/reference/best-practices.md
+++ b/docs/reference/best-practices.md
@@ -237,10 +237,10 @@ Recommendations for keeping modules small are:
 - Don't repeat yourself
 - Only import the part of the library modules that you need
 
-It is suggested to lint and format your modules  using `npx pepr format`.
+It is suggested to lint and format your modules using `npx pepr format`.
 
 > [!WARNING]
-> `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. "Once removed, module authors must run a linter separately from the pepr CLI."
+> `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. Once removed, module authors must run a linter separately from the pepr CLI.
 
 ## Monitoring
 

--- a/docs/reference/best-practices.md
+++ b/docs/reference/best-practices.md
@@ -237,7 +237,10 @@ Recommendations for keeping modules small are:
 - Don't repeat yourself
 - Only import the part of the library modules that you need
 
-It is suggested to lint and format your modules using `npx pepr format`.
+It is suggested to lint and format your modules  using `npx pepr format`. Configure linting and formatting tools directly in your project.
+
+> [!WARNING]
+> `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. "Once removed, module authors must run a linter separately from the pepr CLI."
 
 ## Monitoring
 

--- a/docs/user-guide/pepr-cli.md
+++ b/docs/user-guide/pepr-cli.md
@@ -121,6 +121,9 @@ These can't be auto-removed because they're global in scope & doing so would ris
 
 ## `npx pepr format`
 
+> [!WARNING]
+> `pepr format` will deprecated and removed in Pepr v2.0.0 expected in summer 2026. "Once removed, module authors must run a linter separately from the pepr CLI."Please configure linting and formatting directly in your project instead.
+
 Lint and format this Pepr module.
 
 **Options:**

--- a/docs/user-guide/pepr-cli.md
+++ b/docs/user-guide/pepr-cli.md
@@ -122,7 +122,7 @@ These can't be auto-removed because they're global in scope & doing so would ris
 ## `npx pepr format`
 
 > [!WARNING]
-> `pepr format` will be deprecated and removed in Pepr v2.0.0 expected in summer 2026. Once removed, module authors must run a linter separately from the pepr CLI. Please configure linting and formatting directly in your project instead.
+> `npx pepr format` will be deprecated and removed in summer 2026 with the release of Pepr v2.0.0. Once removed, module authors must run a linter separately from the Pepr CLI. Please configure linting and formatting directly in your project instead.
 
 Lint and format this Pepr module.
 

--- a/docs/user-guide/pepr-cli.md
+++ b/docs/user-guide/pepr-cli.md
@@ -122,7 +122,7 @@ These can't be auto-removed because they're global in scope & doing so would ris
 ## `npx pepr format`
 
 > [!WARNING]
-> `pepr format` will deprecated and removed in Pepr v2.0.0 expected in summer 2026. "Once removed, module authors must run a linter separately from the pepr CLI."Please configure linting and formatting directly in your project instead.
+> `pepr format` will be deprecated and removed in Pepr v2.0.0 expected in summer 2026. Once removed, module authors must run a linter separately from the pepr CLI. Please configure linting and formatting directly in your project instead.
 
 Lint and format this Pepr module.
 


### PR DESCRIPTION
## Description
Added deprecation warning for pepr format cli to `best-practices.md` and `pepr-cli.md`
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
