### PR TITLE
chore: clone `config.env` in `genEnv` to prevent shared-object mutation

### DIFF
--- a/src/lib/assets/environment.test.ts
+++ b/src/lib/assets/environment.test.ts
@@ -143,6 +143,57 @@ describe("genEnv", () => {
     expect(result).toEqual(expectedEnv);
   });
 
+  it("does not mutate config.env when PEPR_WATCH_MODE is present", () => {
+    const config: ModuleConfig = {
+      uuid: "12345",
+      logLevel: "info",
+      env: {
+        PEPR_WATCH_MODE: "false",
+        CUSTOM_VAR: "keep_me",
+      },
+      alwaysIgnore: { namespaces: [] },
+    };
+
+    // Snapshot the original env object to verify it's not mutated.
+    const envBefore = { ...config.env };
+
+    genEnv(config, false);
+
+    expect(config.env).toEqual(envBefore);
+  });
+
+  it("does not mutate config.env across consecutive calls with the same config", () => {
+    // This simulates the real usage pattern: genEnv is called once for the
+    // admission deployment and once for the watcher deployment, both sharing
+    // the same ModuleConfig reference.
+    const config: ModuleConfig = {
+      uuid: "12345",
+      logLevel: "info",
+      env: {
+        PEPR_WATCH_MODE: "false",
+        CUSTOM_VAR: "value",
+      },
+      alwaysIgnore: { namespaces: [] },
+    };
+
+    const envSnapshot = { ...config.env };
+
+    // First call — admission (watchMode=false).
+    genEnv(config, false);
+
+    // config.env must be unchanged after the first call. The pre-fix code
+    // deleted PEPR_WATCH_MODE here, which is the actual mutation bug — the
+    // output values alone don't catch it because `def` always supplies
+    // PEPR_WATCH_MODE from the watchMode parameter.
+    expect(config.env).toEqual(envSnapshot);
+
+    // Second call — watcher (watchMode=true).
+    genEnv(config, true);
+
+    // Still unchanged after the second call.
+    expect(config.env).toEqual(envSnapshot);
+  });
+
   it("handles ignoreWatchMode for helm chart", () => {
     const config: ModuleConfig = {
       uuid: "12345",

--- a/src/lib/assets/environment.ts
+++ b/src/lib/assets/environment.ts
@@ -23,10 +23,11 @@ export function genEnv(
     ...noWatchDef,
   };
 
-  if (config.env && config.env["PEPR_WATCH_MODE"]) {
-    delete config.env["PEPR_WATCH_MODE"];
-  }
-  const cfg = config.env || {};
+  // Clone config.env so we don't mutate the caller's object. The delete
+  // prevents a user-supplied PEPR_WATCH_MODE from overriding the programmatic
+  // value set via the watchMode parameter.
+  const cfg = { ...(config.env || {}) };
+  delete cfg["PEPR_WATCH_MODE"];
   return ignoreWatchMode
     ? Object.entries({ ...noWatchDef, ...cfg }).map(([name, value]) => ({ name, value }))
     : Object.entries({ ...def, ...cfg }).map(([name, value]) => ({ name, value }));


### PR DESCRIPTION
  - Clones `config.env` in `genEnv` to prevent shared-object mutation across
    controller instances
   - Cherry-picked from #2981 (fork PR by @joonas) to enable CI secrets access

   ## Context
   PR #2981  from `joonas/pepr` could not run secret-dependent CI jobs
   (`controller image`, `upgrade-unicorn`) because GitHub does not expose
   secrets to fork PRs. This PR re-creates the same change from an upstream
   branch.

   Original author: @joonas
 
`genEnv` deleted `config.env["PEPR_WATCH_MODE"]` directly from the caller's `ModuleConfig` reference. Since the same config object is passed twice (once for the admission deployment and once for the watcher deployment) the first call permanently removed the key. Any code reading `config.env` after the first `genEnv` call would no longer see `PEPR_WATCH_MODE`.

Shallow-clone `config.env` into a local `cfg` object and delete the key from the clone instead. This preserves the original config while still preventing a user-supplied `PEPR_WATCH_MODE` from overriding the programmatic value controlled by the `watchMode` parameter.

Both regression tests assert `config.env` identity via snapshot comparison rather than checking `genEnv` return values. The `def` object always supplies `PEPR_WATCH_MODE` from the `watchMode` parameter, so output-based assertions pass even with the mutation bug present. Existing tests already cover output correctness for each mode.


...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
