### PR TITLE
chore: add missing `adjudicateMisboundNamespace` check to admission webhook filter

### DIFF
--- a/src/lib/filter/adjudicators/postCollection.test.ts
+++ b/src/lib/filter/adjudicators/postCollection.test.ts
@@ -226,16 +226,32 @@ describe("bindsToNamespace", () => {
 describe("misboundNamespace", () => {
   //[ Binding, result ]
   it.each([
-    [{ kind: { kind: "Kind" }, filters: { namespaces: [] } }, false],
-    [{ kind: { kind: "Kind" }, filters: { namespaces: ["namespace"] } }, false],
-    [{ kind: { kind: "Namespace" }, filters: { namespaces: [] } }, false],
-    [{ kind: { kind: "Namespace" }, filters: { namespaces: ["namespace"] } }, true],
+    [{ kind: { kind: "Kind" }, filters: { namespaces: [], regexNamespaces: [] } }, false],
+    [
+      { kind: { kind: "Kind" }, filters: { namespaces: ["namespace"], regexNamespaces: [] } },
+      false,
+    ],
+    [{ kind: { kind: "Kind" }, filters: { namespaces: [], regexNamespaces: ["^ns"] } }, false],
+    [{ kind: { kind: "Namespace" }, filters: { namespaces: [], regexNamespaces: [] } }, false],
+    [
+      { kind: { kind: "Namespace" }, filters: { namespaces: ["namespace"], regexNamespaces: [] } },
+      true,
+    ],
+    [{ kind: { kind: "Namespace" }, filters: { namespaces: [], regexNamespaces: ["^ns"] } }, true],
+    [
+      {
+        kind: { kind: "Namespace" },
+        filters: { namespaces: ["namespace"], regexNamespaces: ["^ns"] },
+      },
+      true,
+    ],
   ])("given %j, returns %s", (given, expected) => {
     const binding: Binding = {
       ...defaultBinding,
       filters: {
         ...defaultFilters,
         namespaces: given.filters.namespaces,
+        regexNamespaces: given.filters.regexNamespaces,
       },
       kind: { kind: given.kind.kind, group: defaultBinding.kind.group },
     };

--- a/src/lib/filter/adjudicators/postCollection.ts
+++ b/src/lib/filter/adjudicators/postCollection.ts
@@ -1,7 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { __, allPass, curry, difference, equals, gt, length, not, nthArg, pipe } from "ramda";
+import {
+  __,
+  allPass,
+  anyPass,
+  curry,
+  difference,
+  equals,
+  gt,
+  length,
+  not,
+  nthArg,
+  pipe,
+} from "ramda";
 import { KubernetesObject } from "kubernetes-fluent-client";
 import {
   definedKind,
@@ -9,6 +21,7 @@ import {
   definesDelete,
   definesDeletionTimestamp,
   definesNamespaces,
+  definesNamespaceRegexes,
 } from "./binding";
 import { carriedNamespace, carriesNamespace } from "./kubernetesObject";
 
@@ -26,7 +39,10 @@ export const bindsToKind = curry(
   ]),
 );
 export const bindsToNamespace = curry(pipe(bindsToKind(__, "Namespace")));
-export const misboundNamespace = allPass([bindsToNamespace, definesNamespaces]);
+export const misboundNamespace = allPass([
+  bindsToNamespace,
+  anyPass([definesNamespaces, definesNamespaceRegexes]),
+]);
 
 /*
  * If the object does not have a namespace, and it is not a namespace,

--- a/src/lib/filter/filter.test.ts
+++ b/src/lib/filter/filter.test.ts
@@ -7,7 +7,7 @@ import * as fc from "fast-check";
 import { AdmissionRequestCreatePod, AdmissionRequestDeletePod } from "../../fixtures/loader";
 import { filterNoMatchReason, shouldSkipRequest } from "./filter";
 import { Binding } from "../types";
-import { Event } from "../enums";
+import { Event, Operation } from "../enums";
 import {
   defaultBinding,
   defaultFilters,
@@ -271,6 +271,60 @@ describe("shouldSkipRequest", () => {
 
       expect(shouldSkipRequest(binding, pod, ["bleh", "bleh2"])).toMatch(
         /Ignoring Admission Callback: Object carries namespace 'helm-releasename' but namespaces allowed by Capability are '\["bleh","bleh2"\]'\./,
+      );
+    });
+
+    it("should reject when binding targets Namespace kind with a namespace filter", () => {
+      const binding = createBinding({
+        event: Event.CREATE,
+        kind: { kind: "Namespace", group: "", version: "v1" },
+        filters: { namespaces: ["ns1"] },
+        callback,
+      });
+
+      const req: AdmissionRequest = {
+        uid: "test-uid",
+        kind: { kind: "Namespace", group: "", version: "v1" },
+        resource: { group: "", version: "v1", resource: "namespaces" },
+        operation: Operation.CREATE,
+        name: "my-namespace",
+        userInfo: {},
+        object: {
+          apiVersion: "v1",
+          kind: "Namespace",
+          metadata: { name: "my-namespace" },
+        },
+      };
+
+      expect(shouldSkipRequest(binding, req, [])).toEqual(
+        "Ignoring Admission Callback: Cannot use namespace filter on a namespace object.",
+      );
+    });
+
+    it("should reject when binding targets Namespace kind with a regex namespace filter", () => {
+      const binding = createBinding({
+        event: Event.CREATE,
+        kind: { kind: "Namespace", group: "", version: "v1" },
+        filters: { regexNamespaces: ["^prod"] },
+        callback,
+      });
+
+      const req: AdmissionRequest = {
+        uid: "test-uid",
+        kind: { kind: "Namespace", group: "", version: "v1" },
+        resource: { group: "", version: "v1", resource: "namespaces" },
+        operation: Operation.CREATE,
+        name: "my-namespace",
+        userInfo: {},
+        object: {
+          apiVersion: "v1",
+          kind: "Namespace",
+          metadata: { name: "my-namespace" },
+        },
+      };
+
+      expect(shouldSkipRequest(binding, req, [])).toEqual(
+        "Ignoring Admission Callback: Cannot use namespace filter on a namespace object.",
       );
     });
   });
@@ -650,6 +704,24 @@ describe("filterNoMatchReason", () => {
       ...defaultBinding,
       kind: { kind: "Namespace", group: "some-group" },
       filters: { ...defaultFilters, namespaces: ["ns1"] },
+    };
+    const obj = {};
+    const capabilityNamespaces: string[] = [];
+    const result = filterNoMatchReason(
+      binding,
+      obj as unknown as Partial<KubernetesObject>,
+      capabilityNamespaces,
+    );
+    expect(result).toEqual(
+      "Ignoring Watch Callback: Cannot use namespace filter on a namespace object.",
+    );
+  });
+
+  it("returns namespace filter error for namespace objects with regex namespace filters", () => {
+    const binding: Binding = {
+      ...defaultBinding,
+      kind: { kind: "Namespace", group: "some-group" },
+      filters: { ...defaultFilters, namespaces: [], regexNamespaces: ["^prod"] },
     };
     const obj = {};
     const capabilityNamespaces: string[] = [];

--- a/src/lib/filter/filter.ts
+++ b/src/lib/filter/filter.ts
@@ -53,6 +53,7 @@ export function shouldSkipRequest(
     (): AdjudicationResult => adjudicateMismatchedGroup(binding, req),
     (): AdjudicationResult => adjudicateMismatchedVersion(binding, req),
     (): AdjudicationResult => adjudicateMismatchedKind(binding, req),
+    (): AdjudicationResult => adjudicateMisboundNamespace(binding),
     (): AdjudicationResult => adjudicateUnbindableNamespaces(capabilityNamespaces, binding),
     (): AdjudicationResult => adjudicateUncarryableNamespace(capabilityNamespaces, obj),
     (): AdjudicationResult => adjudicateMismatchedNamespace(binding, obj),


### PR DESCRIPTION
   - Cherry-picked from #2978 (fork PR by @joonas) to enable CI secrets access

shouldSkipRequest omitted the adjudicateMisboundNamespace adjudicator that filterNoMatchReason (the watch path) already included. This meant bindings targeting kind: Namespace with a namespace filter (a configuration error since namespaces don't live inside namespaces) were not rejected on the admission side. Instead, the request fell through to
adjudicateMismatchedNamespace, which produced a misleading error:

"Binding defines namespaces ... but Object carries ''"
rather than the correct "Cannot use namespace filter on a namespace object" rejection.

Additionally, misboundNamespace only checked
definesNamespaces (literal namespace list) but not definesNamespaceRegexes. A kind: Namespace binding with regexNamespaces would slip through in both the admission and watch paths with the same misleading mismatch message.

Two fixes:

Add adjudicateMisboundNamespace(binding) to the shouldSkipRequest adjudicator list in filter.ts, placed before the namespace mismatch checks so the configuration error is caught early.

Broaden misboundNamespace in postCollection.ts from allPass([bindsToNamespace, definesNamespaces]) to allPass([bindsToNamespace, anyPass([definesNamespaces, definesNamespaceRegexes])]), covering both filter variants.

Tests added for both admission and watch paths with literal and regex namespace filters, plus unit tests for the broadened predicate.

...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
