### PR TITLE
feat: support annotations and labels on webhooks

### DIFF
--- a/src/lib/assets/index.test.ts
+++ b/src/lib/assets/index.test.ts
@@ -58,5 +58,9 @@ describe("createWebhookYaml", () => {
     expect(result).toContain("{{- range .Values.additionalIgnoredNamespaces }}");
     expect(result).toContain("{{ . }}");
     expect(result).toContain("{{- end }}");
+    expect(result).toContain("{{- if .Values.admission.webhookAnnotations }}");
+    expect(result).toContain("{{- toYaml .Values.admission.webhookAnnotations | nindent 4 }}");
+    expect(result).toContain("{{- if .Values.admission.webhookLabels }}");
+    expect(result).toContain("{{- toYaml .Values.admission.webhookLabels | nindent 4 }}");
   });
 });

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -29,6 +29,10 @@ export function createWebhookYaml(
       replace: "{{ .Values.admission.webhookTimeout }}",
     },
     {
+      search: "metadata:\n  name: {{ .Values.uuid }}",
+      replace: `metadata:\n  name: {{ .Values.uuid }}\n  {{- if .Values.admission.webhookAnnotations }}\n  annotations:\n    {{- toYaml .Values.admission.webhookAnnotations | nindent 4 }}\n  {{- end }}\n  {{- if .Values.admission.webhookLabels }}\n  labels:\n    {{- toYaml .Values.admission.webhookLabels | nindent 4 }}\n  {{- end }}`,
+    },
+    {
       search: `
         - key: kubernetes.io/metadata.name
           operator: NotIn

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -87,6 +87,8 @@ export async function overridesFile(
       ...commonProbes(),
       resources: commonResources(),
       containerSecurityContext: containerSecurityContext(image),
+      webhookAnnotations: {},
+      webhookLabels: {},
       podAnnotations: {},
       podLabels: {},
       nodeSelector: {},


### PR DESCRIPTION
## Description

Adds support for webhook annotations and labels through the generated helm chart.

## Related Issue

Fixes https://github.com/defenseunicorns/pepr/issues/3105

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
