### PR TITLE
chore: major bumps excluded from group prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,14 @@ updates:
     groups:
       production-dependencies:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       development-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "pino"
         versions: ["9.8.0"]


### PR DESCRIPTION
## Description
Major version bumps often bring breaking changes.  Currently the major, minor and patch bumps are all grouped in the same Dependabot PR.  This change will keep the minor/patch changes in group PRs but force[ major updates into standalone PRs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#:~:text=Any%20outdated%20dependencies%20that%20do%20not%20match%20a%20rule%20are%20updated%20in%20individual%20pull%20requests).  
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
