### PR TITLE
chore: filter paths instead of ignore

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,27 +2,36 @@ name: Node.js CI
 
 on:
   push:
-    paths-ignore:
-    - "**.md"
-    - "LICENSE"
-    - "CODEOWNERS"
   pull_request:
-    paths-ignore:
-    - "**.md"
-    - "LICENSE"
-    - "CODEOWNERS"
-    
+
 permissions:
   id-token: write # This is needed for OIDC federation.
   contents: read
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      code-changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**.md'
+              - '!LICENSE'
+              - '!CODEOWNERS'
+
   on-demand-workflows:
+    needs: check-paths
     uses: ./.github/workflows/on-demand-workflows.yaml
     secrets:
       CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
     with:
-      run-format: true
-      run-units: true
-      run-integration: true
+      run-format: ${{ needs.check-paths.outputs.code-changed == 'true' }}
+      run-units: ${{ needs.check-paths.outputs.code-changed == 'true' }}
+      run-integration: ${{ needs.check-paths.outputs.code-changed == 'true' }}
 


### PR DESCRIPTION
## Description
`paths-ignore:` in `nodes.js.yml` stopped the entire on-demand workflow when a `.md` only PR was run.  This required manual bypass and merging.  Changing from `paths-ignore` to ` paths-filter` will allow the workflow to be skipped instead of stopped for doc only PRs. Github treas skipped jobs as passing.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
