### PR TITLE
chore: add maxbuffer and async wrapper

### DIFF
--- a/scripts/soak-summary.ts
+++ b/scripts/soak-summary.ts
@@ -126,26 +126,31 @@ export function writeSummary({
 
 // CLI entry point — only runs when executed directly (not when imported).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const { Command } = await import("commander");
-  const program = new Command()
-    .description("Reads soak test metrics and writes a Markdown summary to $GITHUB_STEP_SUMMARY.")
-    .argument("<metrics-csv>", "path to metrics CSV file")
-    .argument("<informer-log>", "path to informer log file")
-    .argument("<failure-reason>", "path to failure reason file")
-    .parse();
+  (async (): Promise<void> => {
+    const { Command } = await import("commander");
+    const program = new Command()
+      .description("Reads soak test metrics and writes a Markdown summary to $GITHUB_STEP_SUMMARY.")
+      .argument("<metrics-csv>", "path to metrics CSV file")
+      .argument("<informer-log>", "path to informer log file")
+      .argument("<failure-reason>", "path to failure reason file")
+      .parse();
 
-  const [metricsCSV, informerLog, failureReason] = program.args;
+    const [metricsCSV, informerLog, failureReason] = program.args;
 
-  const summary = process.env.GITHUB_STEP_SUMMARY;
-  if (!summary) {
-    console.error("GITHUB_STEP_SUMMARY environment variable is not set");
+    const summary = process.env.GITHUB_STEP_SUMMARY;
+    if (!summary) {
+      console.error("GITHUB_STEP_SUMMARY environment variable is not set");
+      process.exitCode = 1;
+    } else {
+      writeSummary({
+        metricsCsvPath: metricsCSV,
+        informerLogPath: informerLog,
+        failureReasonPath: failureReason,
+        summaryPath: summary,
+      });
+    }
+  })().catch(err => {
+    console.error("Unexpected error:", err);
     process.exitCode = 1;
-  } else {
-    writeSummary({
-      metricsCsvPath: metricsCSV,
-      informerLogPath: informerLog,
-      failureReasonPath: failureReason,
-      summaryPath: summary,
-    });
-  }
+  });
 }

--- a/scripts/soak-test.ts
+++ b/scripts/soak-test.ts
@@ -55,6 +55,7 @@ export function collectMetrics(logsDir: string = LOGS_DIR): void {
 
   const watchOutput = execSync("kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system", {
     timeout: KUBECTL_TIMEOUT_MS,
+    maxBuffer: 10 * 1024 * 1024,
   }).toString();
   fs.writeFileSync(`${logsDir}/watch-logs.txt`, watchOutput);
 }


### PR DESCRIPTION
## Description

  - Fix [ `ENOBUFS` crash ](https://github.com/defenseunicorns/pepr/actions/runs/26142979040/job/76892393417#step:17:38) in `soak-test.ts` by increasing the `execSync maxBuffer` for `kubectl logs` from the default 1MB to 10MB, since watcher pod logs exceed the default buffer size during long soak runs                                     

  - Fix `soak-summary.ts` [top-level `await` error](https://github.com/defenseunicorns/pepr/actions/runs/26142979040/job/76892393417#step:18:14) by wrapping the CLI entry point in an async function, since tsx/esbuild does not support top-level await in CJS output format. Added a `.catch()` handler to match the error handling pattern in `soak-test.ts`.       
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
