### PR TITLE
chore: soak test add update pod map

### DIFF
--- a/scripts/soak-test-kubectl.test.ts
+++ b/scripts/soak-test-kubectl.test.ts
@@ -81,18 +81,32 @@ describe("checkPodStability", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("does not throw when all pods are in the initial set", () => {
+  it("does not throw when each pod name is only seen once", () => {
     mockExecSync.mockReturnValue(Buffer.from("pod-a pod-b"));
-    const initialPods = new Set(["pod-a", "pod-b"]);
+    const podMap = new Map<string, number>();
 
-    expect(() => checkPodStability(initialPods, 10, tmpDir)).not.toThrow();
+    expect(() => checkPodStability(podMap, 10, tmpDir)).not.toThrow();
   });
 
-  it("throws SoakTestFailure listing recreated pods when new pods appear", () => {
-    mockExecSync.mockReturnValue(Buffer.from("pod-a pod-new-1 pod-new-2"));
-    const initialPods = new Set(["pod-a"]);
-    expect(() => checkPodStability(initialPods, 30, tmpDir)).toThrow(
-      "New pods detected (possible recreation) ~30 minutes into the run: pod-new-1, pod-new-2",
+  it("does not throw for new uniquely-named pods across checks", () => {
+    const podMap = new Map<string, number>();
+
+    mockExecSync.mockReturnValue(Buffer.from("auto-abc"));
+    checkPodStability(podMap, 10, tmpDir);
+
+    mockExecSync.mockReturnValue(Buffer.from("auto-def"));
+    expect(() => checkPodStability(podMap, 20, tmpDir)).not.toThrow();
+  });
+
+  it("throws SoakTestFailure when a pod name is seen more than once", () => {
+    const podMap = new Map<string, number>();
+
+    mockExecSync.mockReturnValue(Buffer.from("pod-a"));
+    checkPodStability(podMap, 10, tmpDir);
+
+    mockExecSync.mockReturnValue(Buffer.from("pod-a"));
+    expect(() => checkPodStability(podMap, 20, tmpDir)).toThrow(
+      "Pod recreation detected ~20 minutes into the run: pod-a (seen 2 times)",
     );
   });
 });

--- a/scripts/soak-test.ts
+++ b/scripts/soak-test.ts
@@ -145,12 +145,18 @@ export function fetchPodNames(): string[] {
   return output.split(/\s+/).filter(Boolean);
 }
 
+export function updatePodMap(podMap: Map<string, number>): void {
+  for (const pod of fetchPodNames()) {
+    podMap.set(pod, (podMap.get(pod) ?? 0) + 1);
+  }
+}
+
 export function checkPodStability(
-  initialPods: Set<string>,
+  podMap: Map<string, number>,
   elapsedMinutes: number,
   logsDir: string = LOGS_DIR,
 ): void {
-  const currentPods = fetchPodNames();
+  updatePodMap(podMap);
 
   execSync("kubectl get pods -n pepr-demo", {
     stdio: "inherit",
@@ -165,7 +171,9 @@ export function checkPodStability(
     timeout: KUBECTL_TIMEOUT_MS,
   });
 
-  const recreated = currentPods.filter(pod => !initialPods.has(pod));
+  const recreated = [...podMap.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([pod, count]) => `${pod} (seen ${count} times)`);
   if (recreated.length > 0) {
     try {
       execSync("kubectl logs deploy/pepr-soak-ci-watcher -n pepr-system", {
@@ -176,7 +184,7 @@ export function checkPodStability(
       console.error("Failed to fetch watcher logs:", e);
     }
     failWithReason(
-      `New pods detected (possible recreation) ~${elapsedMinutes} minutes into the run: ${recreated.join(", ")}`,
+      `Pod recreation detected ~${elapsedMinutes} minutes into the run: ${recreated.join(", ")}`,
       logsDir,
     );
   }
@@ -193,7 +201,11 @@ export function initLogFiles(logsDir: string = LOGS_DIR): void {
   );
 }
 
-function runIteration(iteration: number, initialPods: Set<string>, elapsedMinutes: number): void {
+function runIteration(
+  iteration: number,
+  podMap: Map<string, number>,
+  elapsedMinutes: number,
+): void {
   collectMetrics();
 
   console.log(fs.readFileSync(`${LOGS_DIR}/informer-log.txt`, "utf-8"));
@@ -209,14 +221,15 @@ function runIteration(iteration: number, initialPods: Set<string>, elapsedMinute
   assertMetrics(iteration);
 
   if (iteration % POD_CHECK_INTERVAL === 0) {
-    checkPodStability(initialPods, elapsedMinutes);
+    checkPodStability(podMap, elapsedMinutes);
   }
 }
 
 async function main(): Promise<void> {
   initLogFiles();
 
-  const initialPods = new Set(fetchPodNames());
+  const podMap = new Map<string, number>();
+  updatePodMap(podMap);
 
   const startTime = Date.now();
   const endTime = startTime + TOTAL_DURATION_MS;
@@ -226,7 +239,7 @@ async function main(): Promise<void> {
     while (Date.now() < endTime) {
       iteration++;
       const elapsedMinutes = Math.round((Date.now() - startTime) / 60_000);
-      runIteration(iteration, initialPods, elapsedMinutes);
+      runIteration(iteration, podMap, elapsedMinutes);
 
       if (Date.now() < endTime) {
         await sleep(INTERVAL_MS);

--- a/scripts/soak-test.ts
+++ b/scripts/soak-test.ts
@@ -229,7 +229,6 @@ async function main(): Promise<void> {
   initLogFiles();
 
   const podMap = new Map<string, number>();
-  updatePodMap(podMap);
 
   const startTime = Date.now();
   const endTime = startTime + TOTAL_DURATION_MS;


### PR DESCRIPTION
## Description
                                                                                
  - The shell-to-TypeScript conversion in #3062 changed the pod stability check semantics: the old shell script tracked how many times each pod name was seen across snapshots (failing only when count > 1), while the new TypeScript captured a one-time set at startup and failed if any new pod name appeared — which is expected behavior since the watch-auditor continuously creates uniquely-named ephemeral `auto-*` pods
  - Replaced the `Set<string>` initial snapshot with a `Map<string, number>` that accumulates seen-counts across checks, matching the original `declare -A pod_map` / `update_pod_map` approach
  - Removed tests that only verified `Map` get/set behavior; kept tests that verify the actual stability-check decision logic    
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #3062 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
