### PR TITLE
chore: add deps as a prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "deps"
+      include-scope: true
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -67,6 +70,8 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "deps"
 
   - package-ecosystem: docker
     directory: /
@@ -74,11 +79,15 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "deps"
 
   - package-ecosystem: docker
     directory: /config
     schedule:
       interval: daily
+    commit-message:
+      prefix: "deps"
     registries:
       - chainguard
 

--- a/config/commitlint.config.js
+++ b/config/commitlint.config.js
@@ -23,6 +23,6 @@ module.exports = {
   ignores: [
     // prevent header-max-length error on long, dependabot-gen'd commits titles
     //  https://github.com/dependabot/dependabot-core/issues/2445
-    (message) => /^chore: bump .+ from .+ to .+$/m.test(message)
+    (message) => /^(chore|deps)(\(.+\))?: bump .+ from .+ to .+$/m.test(message)
   ],
 };

--- a/config/commitlint.config.js
+++ b/config/commitlint.config.js
@@ -1,5 +1,25 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "deps",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
   ignores: [
     // prevent header-max-length error on long, dependabot-gen'd commits titles
     //  https://github.com/dependabot/dependabot-core/issues/2445

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
         { "type": "build", "section": "Build System", "hidden": true },
         { "type": "ci", "section": "Continuous Integration", "hidden": true },
         { "type": "chore", "section": "Chores", "hidden": true },
+        { "type": "deps", "section": "Dependencies" },
         { "type": "*", "section": "Miscellaneous" }
       ]
     }


### PR DESCRIPTION
## Description
Currently, `release-please` will only open a PR if the prefix is `fix` or `feat`.  Many releases are stictly dependency updates.  Adding `deps` prefix to `commitlint` and `release-please` will allow the release PR to be opened when a dependabot PR is merged.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
