### PR TITLE
fix(ci): use app-token auth in peer-deps-update workflow

### DIFF
--- a/.github/workflows/peer-deps-update.yml
+++ b/.github/workflows/peer-deps-update.yml
@@ -58,24 +58,26 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      # `token` is set so subsequent `git push` and `gh pr create` calls use
-      # PEER_DEPS_PR_TOKEN if available. Without that PAT the default
-      # GITHUB_TOKEN works, but PRs created with it do not trigger
-      # pull_request-event workflows (a documented GitHub limitation), which
-      # would leave node.js.yml ungated on these PRs.
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_SECRET }}
+      # `token` is the GitHub App installation token created above. App-token
+      # PRs (unlike PRs opened with GITHUB_TOKEN) trigger pull_request-event
+      # workflows on the bot's PRs — specifically node.js.yml, which is the
+      # gate the team relies on for format / unit / integration coverage.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
-          token: ${{ secrets.PEER_DEPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: npm
-      - name: Warn if PEER_DEPS_PR_TOKEN is absent
-        if: ${{ secrets.PEER_DEPS_PR_TOKEN == '' }}
-        run: echo "::warning::PEER_DEPS_PR_TOKEN is not set; PRs will be created with GITHUB_TOKEN and will not trigger pull_request workflows."
       - name: Install dependencies
         run: npm ci
       - name: Apply bump
@@ -93,7 +95,7 @@ jobs:
         run: npm run test:unit
       - name: Open PR
         env:
-          GH_TOKEN: ${{ secrets.PEER_DEPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           KIND: ${{ matrix.kind }}
           PKG: ${{ matrix.pkg }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Description

Builds on #3094. The scheduled run ([26757597837](https://github.com/defenseunicorns/pepr/actions/runs/26757597837)) failed at workflow load with:

```
Invalid workflow file: .github/workflows/peer-deps-update.yml#L1
(Line: 77, Col: 13): Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.PEER_DEPS_PR_TOKEN == ''
```

**Root cause.** GitHub Actions does not permit the `secrets` context inside `if:` expressions — the parser rejects the entire workflow file before secrets are wired in. The offending line was the "Warn if PEER_DEPS_PR_TOKEN is absent" step that #3094 added to flag the (never-provisioned) PAT-fallback path.

**Approach.** Rather than papering over the parse error by hoisting the secret through `env:` and keeping a PAT-fallback story for a PAT nobody provisioned, this PR drops the `PEER_DEPS_PR_TOKEN` plumbing entirely and adopts the **GitHub App installation-token pattern** already used by [`grype-suppression-audit.yaml`](.github/workflows/grype-suppression-audit.yaml) (lines 31-41). App-token PRs (unlike PRs opened with `GITHUB_TOKEN`) trigger `pull_request`-event workflows on the recipient repo — which means `node.js.yml`'s format / unit / integration fanout now runs automatically on bot peer-dep PRs, the exact unlock that motivated the original PAT plan.

**No new secret.** Reuses the existing `GRYPE_AUDIT_GITHUB_APP_ID` / `GRYPE_AUDIT_GITHUB_APP_SECRET` App pair, which is already installed on this repo with `contents: write` + `pull-requests: write` (same scopes peer-deps needs).

## Changes

- Insert `Create GitHub App Token` step in `propose` job (mirrors `grype-suppression-audit.yaml` byte-for-byte: same `actions/create-github-app-token@1b10c78c…` SHA, same `id: app-token`).
- `Checkout`'s `token:` and `Open PR`'s `GH_TOKEN:` now read `${{ steps.app-token.outputs.token }}`.
- Remove the `Warn if PEER_DEPS_PR_TOKEN is absent` step (source of the parse error; no longer applicable).
- Replace the PAT-fallback comment block with a shorter note documenting the App-token rationale.

`discover` job, `concurrency`, `strategy.matrix`, and the pre-PR gates (`format:check`, `build`, `test:unit`) are unchanged.

## Verification

Local (parser-level):

- ``node -e \"require('js-yaml').load(require('fs').readFileSync('.github/workflows/peer-deps-update.yml','utf8'))\"`` — parses cleanly.
- ``grep -n PEER_DEPS_PR_TOKEN .github/workflows/peer-deps-update.yml`` — zero matches.
- ``grep -n 'secrets\\.' .github/workflows/peer-deps-update.yml`` — only `GRYPE_AUDIT_GITHUB_APP_ID` and `GRYPE_AUDIT_GITHUB_APP_SECRET` references remain.
- Side-by-side diff vs. `grype-suppression-audit.yaml` lines 31-41 — App-token block matches.

End-to-end on GitHub (post-merge):

- [ ] Trigger via `workflow_dispatch`; confirm the `Invalid workflow file` banner is gone.
- [ ] On the resulting bot PR, confirm the author is the App identity (not `github-actions[bot]`).
- [ ] On the resulting bot PR, confirm `node.js.yml` auto-triggers (no manual nudge needed).

## Follow-up (out of scope)

Reusing the Grype App for peer-deps work is functional but semantically awkward. A future PR could provision a dedicated `PEPR_BOT_GITHUB_APP_*` and migrate both `peer-deps-update.yml` and `grype-suppression-audit.yaml` onto it.

## Related Issue

Builds on #3094.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed