### PR TITLE
fix(ci): point peer-deps-update at the App secrets that actually exist

### DIFF
--- a/.github/workflows/peer-deps-update.yml
+++ b/.github/workflows/peer-deps-update.yml
@@ -47,6 +47,9 @@ jobs:
     if: needs.discover.outputs.empty == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # `prod` is where the GitHub App credentials live as environment secrets;
+    # without this block they resolve to empty strings and the token step fails.
+    environment: prod
     permissions:
       contents: write
       pull-requests: write
@@ -62,8 +65,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_ID }}
-          private-key: ${{ secrets.GRYPE_AUDIT_GITHUB_APP_SECRET }}
+          app-id: ${{ secrets.DOCS_WORKFLOW_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DOCS_WORKFLOW_GITHUB_APP_SECRET }}
       # `token` is the GitHub App installation token created above. App-token
       # PRs (unlike PRs opened with GITHUB_TOKEN) trigger pull_request-event
       # workflows on the bot's PRs — specifically node.js.yml, which is the


### PR DESCRIPTION
## Summary

The `propose` job in `peer-deps-update.yml` has been failing every run with:

> Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.

Failure: https://github.com/defenseunicorns/pepr/actions/runs/26768929000/job/78902935290

### Root cause

The workflow references `secrets.GRYPE_AUDIT_GITHUB_APP_ID` and `secrets.GRYPE_AUDIT_GITHUB_APP_SECRET`, but those secrets don't exist — not at the repo level, and not in the `prod` environment. They evaluate to empty strings, so `actions/create-github-app-token` fails immediately.

The only App-token credentials that actually exist in this repo are `DOCS_WORKFLOW_GITHUB_APP_ID` / `DOCS_WORKFLOW_GITHUB_APP_SECRET`, and they live in the `prod` environment.

### Fix

- Switch the two secret references to `DOCS_WORKFLOW_GITHUB_APP_ID` / `DOCS_WORKFLOW_GITHUB_APP_SECRET`.
- Add `environment: prod` to the `propose` job so environment-scoped secrets are actually exposed to the workflow context.

### Out of scope (but related)

`.github/workflows/grype-suppression-audit.yaml` has the **same bug** with the same nonexistent secret names — it has been failing every Monday since 2026-05-04 for the identical reason. I left it alone here to keep this PR tightly scoped, but it should get the same treatment in a follow-up.

## Test plan

- [ ] Merge, then trigger `Peer Dependencies Update` via `workflow_dispatch` and confirm the `Create GitHub App Token` step succeeds.
- [ ] Confirm the GitHub App associated with `DOCS_WORKFLOW_*` has `contents: write` and `pull_requests: write` on this repo (it should, since it was provisioned for a docs PR-opening workflow).
- [ ] Confirm a peer-dep PR opens, has the expected branch/labels/body, and triggers `node.js.yml` (App-token PRs do, unlike `GITHUB_TOKEN` PRs).