### PR TITLE
validate registry-info format in pepr build

### DIFF
--- a/src/cli/build/build.helpers.ts
+++ b/src/cli/build/build.helpers.ts
@@ -78,6 +78,14 @@ interface ImageOptions {
  * @param imageOptions CLI options for image
  * @returns image string
  */
+export function validateRegistryInfo(registryInfo: string): void {
+  if (!registryInfo.includes("/")) {
+    throw new Error(
+      `Invalid registry-info "${registryInfo}". Expected format: <registry/username> (e.g. docker.io/myuser).`,
+    );
+  }
+}
+
 export function assignImage(imageOptions: ImageOptions): string {
   const { customImage, registryInfo, peprVersion, registry } = imageOptions;
   if (customImage) {
@@ -85,6 +93,7 @@ export function assignImage(imageOptions: ImageOptions): string {
   }
 
   if (registryInfo) {
+    validateRegistryInfo(registryInfo);
     return `${registryInfo}/custom-pepr-controller:${peprVersion}`;
   }
 

--- a/src/cli/build/build.test.ts
+++ b/src/cli/build/build.test.ts
@@ -145,6 +145,17 @@ describe("assignImage", () => {
     });
     expect(result).toBe("");
   });
+
+  it("should throw an error if registryInfo does not contain a slash", () => {
+    expect(() =>
+      assignImage({
+        customImage: "",
+        registryInfo: "any-randomstring",
+        peprVersion: mockPeprVersion,
+        registry: "",
+      }),
+    ).toThrow(/Invalid registry-info/);
+  });
 });
 
 describe("determineRbacMode", () => {


### PR DESCRIPTION
The --registry-info flag accepts any string without validation, then silently produces an invalid image reference. Adds a check that the value contains a / separator (expected: registry/username) before using it in the controller image path.