### PR TITLE
chore: restore public base images as default Dockerfile ARGs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 # In this file, we delete the *.ts intentionally
 # Any other changes to Dockerfile should be reflected in Publish
 ARG REQUIRE_CHOWN="true"
-ARG BUILD_IMAGE=cgr.dev/defenseunicorns.com/node:26-dev@sha256:157c6017890d666a24a6c8eb69458ff53c22e6e2e3209abb19f2c0769ee19bc4
-ARG BASE_IMAGE=cgr.dev/defenseunicorns.com/node:26@sha256:b79a4c8ef338375c198b1c7df7e833648d3fa0584922e399ce7e7e15c64fc793
+ARG BUILD_IMAGE=docker.io/library/node:26@sha256:b46a10d964ad15136ebdf9012142131481caa0697d7a4d4eafe4bbabd818f876
+ARG BASE_IMAGE=docker.io/library/node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9
 
 FROM ${BUILD_IMAGE} AS build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Any other changes to Dockerfile should be reflected in Publish
 ARG REQUIRE_CHOWN="true"
 ARG BUILD_IMAGE=docker.io/library/node:26@sha256:b46a10d964ad15136ebdf9012142131481caa0697d7a4d4eafe4bbabd818f876
-ARG BASE_IMAGE=docker.io/library/node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9
+ARG BASE_IMAGE=docker.io/library/node:26-slim@sha256:a1d9d671994fc2d26e297ac56b4b1522a8bc7fa71c43b14cd1b1fe6c5116f7dc
 
 FROM ${BUILD_IMAGE} AS build
 


### PR DESCRIPTION
## Description
  PR #3166 changed the root Dockerfile's default `BUILD_IMAGE` and `BASE_IMAGE` ARGs from public Docker Hub images to private Chainguard images (`cgr.dev/defenseunicorns.com/node`). This broke `npm run build:image` for anyone without access to the Chainguard registry, including open-source contributors. 

  ## What changed

  - `BUILD_IMAGE` default: `cgr.dev/defenseunicorns.com/node:26-dev@sha256:...`
  → `docker.io/library/node:26`
  - `BASE_IMAGE` default: `cgr.dev/defenseunicorns.com/node:26@sha256:...` →
  `docker.io/library/node:26-slim`

  ## Why this is safe

  - `config/Dockerfile` (used by `build:image:unicorn`) is unchanged — still uses private Chainguard images for production builds
  - CI workflows authenticate via `chainguard-dev/setup-chainctl` and can override defaults with `--build-arg`
  - This matches the pattern used during RapidFort: public defaults in the root Dockerfile, private images only in `config/Dockerfile`

...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
