### PR TITLE
chore: skip workflows for forks

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -13,6 +13,7 @@ on:
   
 jobs:
   container-scans:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   deploy:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: deploy test (${{ matrix.deployer }})
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   pepr-build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: controller image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pepr-excellent-examples-upstream.yml
+++ b/.github/workflows/pepr-excellent-examples-upstream.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   pepr-build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: controller image
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   pepr-build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: pepr build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/upgrade-unicorn.yml
+++ b/.github/workflows/upgrade-unicorn.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   upgrade-unicorn:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/upgrade-upstream.yml
+++ b/.github/workflows/upgrade-upstream.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   upgrade-upstream:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Description
Fork PRs can't access repo secrets, so the Chainguard login fails and jobs show as failed. With "Only merge non-failing pull requests" enabled on the merge queue, those failures block the PR from ever entering the queue. The `merge_group` event never fires and the jobs never get a chance to run with secrets.

Workflows that require the `CHAINGUARD_IDENTITY` secret now skip on fork PRs instead of failing with `401 Unauthorized`. Affected workflows: container-scan, deploy, e2e-unicorn, e2e-upstream, uds, upgrade-unicorn, upgrade-upstream.  This has no affect on PRs from the main repo.   
                                                            
How it works
                                                                                
  Fork PR:                                                                      
  1. PR opened — 7 secrets-dependent jobs skip, remaining jobs run normally   
  2. PR added to merge queue — GitHub creates a temporary branch in the base repo, triggering merge_group. All 7 jobs run with secrets                 
  3. If CI passes — merged to main                                              
  4. If CI fails — PR is rejected from the queue and not merged
                                                                                
  No code reaches main without passing every job.   
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #3175 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
