### PR TITLE
fix: address container scan CVEs with dependency overrides and base image update

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -15,3 +15,40 @@ ignore:
   # detects it via the package.json copied into node_modules/pepr/ which lists
   # esbuild as a peerDependency, but the binary is not present in the image.
   - vulnerability: GHSA-g7r4-m6w7-qqqr
+
+  # decompress (GHSA-mp2f-45pm-3cg9) and file-type (GHSA-5v7r-6r5c-r473,
+  # GHSA-j47w-4g3g-c36v) are transitive dependencies of shellcheck, which is a
+  # devDependency. The Dockerfile runs `npm ci --omit=dev` in the production
+  # stage, so these packages are not present in the final container image.
+  - vulnerability: GHSA-mp2f-45pm-3cg9
+  - vulnerability: GHSA-5v7r-6r5c-r473
+  - vulnerability: GHSA-j47w-4g3g-c36v
+
+  # nodejs-26 CVEs with no fix version available in the Chainguard base image.
+  # These are upstream Node.js issues awaiting patches from Chainguard.
+  - vulnerability: CVE-2026-48933
+  - vulnerability: CVE-2026-48618
+  - vulnerability: CVE-2026-48619
+  - vulnerability: CVE-2026-48930
+  - vulnerability: CVE-2026-48615
+  - vulnerability: CVE-2026-48928
+  - vulnerability: CVE-2026-48931
+  - vulnerability: CVE-2026-48934
+  - vulnerability: CVE-2026-48617
+  - vulnerability: CVE-2026-48935
+  - vulnerability: CVE-2026-48936
+
+  # libnghttp2-14/nghttp2 CVE with no fix version available in the Chainguard
+  # base image. Awaiting upstream patch.
+  - vulnerability: CVE-2026-58055
+
+  # undici GHSAs — the npm-level instance (7.24.6) is fixed by the
+  # kubernetes-fluent-client override to 7.28.0. The Node.js 26 runtime still
+  # bundles undici 6.26.0 with no upstream fix available.
+  - vulnerability: GHSA-vxpw-j846-p89q
+  - vulnerability: GHSA-vmh5-mc38-953g
+  - vulnerability: GHSA-hm92-r4w5-c3mj
+  - vulnerability: GHSA-pr7r-676h-xcf6
+  - vulnerability: GHSA-p88m-4jfj-68fv
+  - vulnerability: GHSA-g8m3-5g58-fq7m
+  - vulnerability: GHSA-35p6-xmwp-9g52

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Any other changes to Dockerfile should be reflected in Publish
 ARG REQUIRE_CHOWN="true"
 ARG BUILD_IMAGE=cgr.dev/defenseunicorns.com/node:26-dev@sha256:157c6017890d666a24a6c8eb69458ff53c22e6e2e3209abb19f2c0769ee19bc4
-ARG BASE_IMAGE=cgr.dev/defenseunicorns.com/node:26@sha256:b79a4c8ef338375c198b1c7df7e833648d3fa0584922e399ce7e7e15c64fc793
+ARG BASE_IMAGE=cgr.dev/defenseunicorns.com/node:26-slim@sha256:4cb99318578b84de496a61a0ec21b98655e85931f6c411d312122ba6de46a794
 
 FROM ${BUILD_IMAGE} AS build
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -40,7 +40,7 @@ RUN npm run build && \
 
 
 ##### DELIVER #####
-FROM cgr.dev/defenseunicorns.com/node:26@sha256:b79a4c8ef338375c198b1c7df7e833648d3fa0584922e399ce7e7e15c64fc793
+FROM cgr.dev/defenseunicorns.com/node:26-slim@sha256:4cb99318578b84de496a61a0ec21b98655e85931f6c411d312122ba6de46a794
 
 
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -5142,18 +5142,6 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
-    "node_modules/kubernetes-fluent-client/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/kubernetes-fluent-client/node_modules/quicktype-core": {
       "version": "23.2.6",
       "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.2.6.tgz",
@@ -5221,7 +5209,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client/node_modules/undici": {
-      "version": "7.24.6",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,11 @@
     "rollup": "4.59.0",
     "brace-expansion": "^5.0.6",
     "ip-address": "^10.1.1",
-    "tar": "^7.5.16"
+    "tar": "^7.5.16",
+    "kubernetes-fluent-client": {
+      "undici": "7.28.0",
+      "js-yaml": "4.2.0"
+    }
   },
   "peerDependencies": {
     "@types/prompts": "^2.4.9",


### PR DESCRIPTION
## Summary

- **npm overrides**: Override `kubernetes-fluent-client` transitive deps to patch vulnerable versions:
  - `undici` 7.24.6 → 7.28.0 (GHSA-vxpw-j846-p89q, GHSA-vmh5-mc38-953g, GHSA-hm92-r4w5-c3mj, GHSA-pr7r-676h-xcf6, GHSA-p88m-4jfj-68fv, GHSA-g8m3-5g58-fq7m, GHSA-35p6-xmwp-9g52)
  - `js-yaml` 4.1.1 → 4.2.0 (GHSA-h67p-54hq-rp68)
- **Base image update**: Switch runtime image from `node:26` to `node:26-slim` to pick up APK-level fixes for `node-gyp`, `npm`, `glibc`, and reduce attack surface by removing build tools from the runtime container
- **Grype suppressions** for unfixable/false-positive findings:
  - 11 nodejs-26 CVEs with no upstream fix available
  - `libnghttp2`/`nghttp2` CVE-2026-58055 (no fix available)
  - 7 undici GHSAs from Node.js 26 runtime bundled undici 6.26.0 (no fix available)
  - `decompress`/`file-type` GHSAs (dev-only deps not in container image)

## Test plan

- [x] `npm install` succeeds with new overrides
- [x] `npm run build` passes
- [x] `npm run test:unit` passes
- [ ] Container builds successfully with new slim base image
- [ ] Container scans pass with updated grype suppressions