### PR TITLE
ci: add resilient setup-k3d composite and harden transient CI flakes

### DIFF
--- a/.github/actions/setup-k3d/action.yaml
+++ b/.github/actions/setup-k3d/action.yaml
@@ -12,19 +12,15 @@ runs:
   using: composite
   steps:
     - name: install k3d
-      shell: bash
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       env:
         TAG: ${{ inputs.version }}
-      run: |
-        set -euo pipefail
-        for attempt in 1 2 3 4 5; do
-          if curl -sfL --retry 5 --retry-all-errors --retry-delay 5 \
-               https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash; then
-            k3d version
-            exit 0
-          fi
-          echo "::warning::k3d install attempt ${attempt} failed; backing off"
-          sleep $(( attempt * 10 ))
-        done
-        echo "::error::k3d install failed after 5 attempts"
-        exit 1
+      with:
+        max_attempts: 5
+        timeout_minutes: 3
+        retry_wait_seconds: 10
+        retry_on: any
+        command: |
+          set -eo pipefail
+          curl -sfL --retry 5 --retry-all-errors --retry-delay 5 https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+          k3d version

--- a/.github/actions/setup-k3d/action.yaml
+++ b/.github/actions/setup-k3d/action.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+name: setup-k3d
+description: "Install k3d with retry/backoff to tolerate transient network failures"
+inputs:
+  version:
+    description: "k3d version to install, e.g. v5.7.4. Empty installs latest."
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: install k3d
+      shell: bash
+      env:
+        TAG: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3 4 5; do
+          if curl -sfL --retry 5 --retry-all-errors --retry-delay 5 \
+               https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash; then
+            k3d version
+            exit 0
+          fi
+          echo "::warning::k3d install attempt ${attempt} failed; backing off"
+          sleep $(( attempt * 10 ))
+        done
+        echo "::error::k3d install failed after 5 attempts"
+        exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,6 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Install k3d
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
-
       - name: Install The Latest Release Version of Zarf
         if: matrix.deployer == 'zarf'
         uses: zarf-dev/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
@@ -50,6 +46,9 @@ jobs:
         with:
           repository: defenseunicorns/pepr
           path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -16,15 +16,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
-
       - name: clone pepr
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: defenseunicorns/pepr
           path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: "set env: PEPR"
         run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"

--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -94,9 +94,8 @@ jobs:
         with:
           node-version: 26
           cache: "npm"
-      - name: "Install K3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: install k3d
+        uses: ./.github/actions/setup-k3d
       - name: Setup Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:

--- a/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
+++ b/.github/workflows/pepr-excellent-examples-ironbank-amd.yml
@@ -62,9 +62,13 @@ jobs:
       matrix: ${{ fromJSON(needs.ironbank-setup.outputs.matrix) }}
     steps:
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: checkout pepr (for setup-k3d action)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: Clone Pepr Excellent Examples
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -92,7 +96,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 8
+          timeout_minutes: 12
           command: |
             cd $PEPR_EXCELLENT_EXAMPLES_PATH
 

--- a/.github/workflows/pepr-excellent-examples-unicorn.yml
+++ b/.github/workflows/pepr-excellent-examples-unicorn.yml
@@ -146,9 +146,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: checkout pepr (for setup-k3d action)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pepr-excellent-examples-upstream.yml
+++ b/.github/workflows/pepr-excellent-examples-upstream.yml
@@ -141,9 +141,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: checkout pepr (for setup-k3d action)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/soak.yaml
+++ b/.github/workflows/soak.yaml
@@ -77,9 +77,8 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: install k3d
+        uses: ./.github/actions/setup-k3d
 
       - name: dowload image tar artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/tutorials-test.yml
+++ b/.github/workflows/tutorials-test.yml
@@ -23,15 +23,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
-
       - name: clone pepr
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: defenseunicorns/pepr
           path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -98,9 +98,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "install k3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: checkout pepr (for setup-k3d action)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: pepr
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/uds.yml
+++ b/.github/workflows/uds.yml
@@ -98,14 +98,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: checkout pepr (for setup-k3d action)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          path: pepr
-
-      - name: install k3d
-        uses: ./pepr/.github/actions/setup-k3d
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: defenseunicorns/uds-core
@@ -165,6 +157,9 @@ jobs:
 
       - name: "set env: PEPR"
         run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
+
+      - name: install k3d
+        uses: ./pepr/.github/actions/setup-k3d
 
       - name: import docker image from pepr tar
         run: |

--- a/.github/workflows/upgrade-unicorn.yml
+++ b/.github/workflows/upgrade-unicorn.yml
@@ -38,9 +38,8 @@ jobs:
           node-version: 26
           cache: "npm"
 
-      - name: "Install K3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: install k3d
+        uses: ./.github/actions/setup-k3d
 
       - name: Login to Chainguard
         uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1

--- a/.github/workflows/upgrade-upstream.yml
+++ b/.github/workflows/upgrade-upstream.yml
@@ -43,9 +43,8 @@ jobs:
           node-version: 26
           cache: "npm"
 
-      - name: "Install K3d"
-        run: "curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      - name: install k3d
+        uses: ./.github/actions/setup-k3d
 
       - run: npm ci
       - run: |


### PR DESCRIPTION
## Description

Addresses network flakes from a triage of failing CI on `main`. These are non-deterministic network/runner failures that surfaced in scheduled runs.

### Root cause

k3d was installed via an inline one-liner duplicated across 11 workflows:

```
curl -s --retry 5 --retry-all-errors --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
```

`curl --retry` only covers the transport for the script download. Transient failures inside `install.sh` are not retried, and `pipefail` fails the step.

### Changes

- **New composite action** `.github/actions/setup-k3d` — wraps the install in a **5-attempt outer retry loop** with linear backoff, verifies the binary with `k3d version`, and supports an optional pinned `version` (via k3d's `TAG`).
- **All 11 workflows** converted to the composite. The workspace-relative reference differs by each job's checkout topology:
  - pepr at workspace **root** before k3d → `./.github/actions/setup-k3d` (soak, on-demand-workflows, upgrade-upstream, upgrade-unicorn)
  - pepr checked out to `./pepr` → k3d **moved after** that checkout → `./pepr/.github/actions/setup-k3d` (deploy, load, tutorials-test)
  - pepr **not** checked out in the job → **added** a `path: pepr` checkout before k3d → `./pepr/.github/actions/setup-k3d` (uds, pepr-excellent-examples-upstream/unicorn/ironbank-amd)
- **IronBank e2e** — bumped the `Run e2e tests` retry `timeout_minutes` from `8` → `12` so a slow image-load/deploy doesn't fail the matrix leg.