### PR TITLE
ci: align CodeQL analyze action and bump peer-deps workflow to Node 22

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
         uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/peer-deps-update.yml
+++ b/.github/workflows/peer-deps-update.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Description
Splits two unrelated CI/workflow changes out of #3192 (custom startup probes) into their own atomic PR.

### Changes
- **`codeql.yml`** — pin `github/codeql-action/analyze` to `v4.37.0` (`99df26d…`). It lagged at `v4.35.5` while `init` and `autobuild` were already on `v4.37.0`; keeping the three in lockstep avoids CodeQL bundle/DB-format drift between the DB-building and result-uploading steps.
- **`peer-deps-update.yml`** — bump `node-version` `20 → 22` in both jobs so the workflow matches the project's declared `engines.node` (`>=22.19.0`). Node 20 was below the supported floor.

### Validation
- Workflow-only change; no source or dependency impact.
- `analyze` now shares the identical SHA with `init`/`autobuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)