### PR TITLE
chore: remove no-op npm overrides (tar, rollup, glob)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,8 @@
     "vitest": "^4.0.4"
   },
   "overrides": {
-    "glob": "^9.0.0",
-    "rollup": "4.59.0",
     "brace-expansion": "^5.0.7",
-    "ip-address": "^10.1.1",
-    "tar": "^7.5.16"
+    "ip-address": "^10.1.1"
   },
   "peerDependencies": {
     "@types/prompts": "^2.4.9",


### PR DESCRIPTION
## Description
Cleanup surfaced while auditing dependency changes on #3192 (custom startup probes). Three npm `overrides` target packages that are not in the resolved dependency tree, so they never take effect.

### Findings
| Override | In resolved tree? | Effect |
|---|---|---|
| `tar` | ❌ (only `tar-fs`/`tar-stream`) | none |
| `rollup` | ❌ | none |
| `glob` | ❌ (only `is-glob`/`is-extglob`) | none |
| `brace-expansion` | ✅ via eslint/ts-eslint | kept |
| `ip-address` | ✅ via socks ← KFC | kept |

### Changes
- Remove `tar`, `rollup`, and `glob` from `overrides`.
- Keep `brace-expansion` and `ip-address`, which are present and effective.

### Validation
- `npm install --package-lock-only` after removal produces **zero** `package-lock.json` changes, confirming the removed overrides were inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)