### PR TITLE
fix(ci): exclude generated CHANGELOG.md from markdownlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format:check": "npm run format:src && npm run format:tests && npm run format:markdown && npm run format:integration && npm run format:prettier -- --check",
     "format:fix": "npm run format:src -- --fix && npm run format:markdown -- --fix && npm run format:integration -- --fix && npm run format:prettier -- --write",
     "format:integration": "eslint --config config/eslint.integration.config.mjs integration/cli integration/helpers",
-    "format:markdown": "npx -y markdownlint-cli --config config/.markdownlint.json --ignore adr --ignore integration/testroot --ignore pepr-test-module --ignore node_modules --rules config/markdownlint-step-format-rule.js \"**/*.md\"",
+    "format:markdown": "npx -y markdownlint-cli --config config/.markdownlint.json --ignore adr --ignore integration/testroot --ignore pepr-test-module --ignore node_modules --ignore CHANGELOG.md --rules config/markdownlint-step-format-rule.js \"**/*.md\"",
     "format:prettier": "prettier --config config/.prettierrc src integration/cli/**/*.ts integration/helpers/**/*.ts",
     "format:src": "eslint --config config/eslint.root.config.mjs 'src/**/*.ts' '.github/workflows/scripts/**/*.ts' --ignore-pattern '**/*.test.ts' --ignore-pattern 'src/templates/**'",
     "format:tests": "eslint --config config/eslint.test.config.mjs 'src/**/*.test.ts'",


### PR DESCRIPTION
## Problem

Release PRs fail the `format` check in CI. Example: [run on #3182](https://github.com/defenseunicorns/pepr/actions/runs/29948353595/job/89020054775).

The failing step is `format:markdown` (markdownlint), not prettier:

```
CHANGELOG.md:5  error MD012/no-multiple-blanks  Multiple consecutive blank lines [Expected: 1; Actual: 2]
```

## Root cause

[Release Please](https://github.com/googleapis/release-please) regenerates `CHANGELOG.md` with **two blank lines** between version blocks and section headings. Our `config/.markdownlint.json` sets `"default": true`, which enables `MD012/no-multiple-blanks` (max one consecutive blank).

Because the changelog is fully machine-generated, this is a permanent generator-vs-linter conflict: **every Release Please PR is guaranteed to fail the format check**, and the file cannot be hand-fixed since the next release rewrites it.

## Fix

Add `--ignore CHANGELOG.md` to the `format:markdown` script, following the repo's existing convention of ignoring generated/vendored paths (`adr`, `pepr-test-module`, `node_modules`).

## Verification

- Reproduced the exact `MD012` errors locally with a double-blank changelog.
- Confirmed `npm run format:markdown` exits `0` with the fix while the double-blank changelog is present.
- Working tree contains only the one-line `package.json` change.