### PR TITLE
feat: expose all probe properties with Kubernetes defaults

### DIFF
--- a/src/lib/assets/k8sObjects.test.ts
+++ b/src/lib/assets/k8sObjects.test.ts
@@ -14,6 +14,10 @@ const expectedProbe = {
     scheme: "HTTPS",
   },
   initialDelaySeconds: 10,
+  periodSeconds: 10,
+  timeoutSeconds: 1,
+  successThreshold: 1,
+  failureThreshold: 3,
 };
 
 const assets: Assets = JSON.parse(`{

--- a/src/lib/assets/k8sObjects.ts
+++ b/src/lib/assets/k8sObjects.ts
@@ -1,12 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Pepr Authors
 
-import { KubernetesObject } from "@kubernetes/client-node";
+import { KubernetesObject, V1Probe } from "@kubernetes/client-node";
 import { kind } from "kubernetes-fluent-client";
 import { gzipSync } from "zlib";
 import { secretOverLimit } from "../helpers";
 import { Assets, isAdmission, isWatcher, norWatchOrAdmission } from "./assets";
 import { genEnv } from "./environment";
+
+function defaultProbe(): V1Probe {
+  return {
+    httpGet: {
+      path: "/healthz",
+      port: 3000,
+      scheme: "HTTPS",
+    },
+    initialDelaySeconds: 10,
+    periodSeconds: 10,
+    timeoutSeconds: 1,
+    successThreshold: 1,
+    failureThreshold: 3,
+  };
+}
 
 /** Generate the pepr-system namespace */
 export function getNamespace(namespaceLabels?: Record<string, string>): KubernetesObject {
@@ -95,30 +110,9 @@ export function getWatcher(
               image,
               imagePullPolicy: "IfNotPresent",
               args: ["/app/node_modules/pepr/dist/controller.js", hash],
-              startupProbe: {
-                httpGet: {
-                  path: "/healthz",
-                  port: 3000,
-                  scheme: "HTTPS",
-                },
-                initialDelaySeconds: 10,
-              },
-              readinessProbe: {
-                httpGet: {
-                  path: "/healthz",
-                  port: 3000,
-                  scheme: "HTTPS",
-                },
-                initialDelaySeconds: 10,
-              },
-              livenessProbe: {
-                httpGet: {
-                  path: "/healthz",
-                  port: 3000,
-                  scheme: "HTTPS",
-                },
-                initialDelaySeconds: 10,
-              },
+              startupProbe: defaultProbe(),
+              readinessProbe: defaultProbe(),
+              livenessProbe: defaultProbe(),
               ports: [
                 {
                   containerPort: 3000,
@@ -246,30 +240,9 @@ export function getDeployment(
               image,
               imagePullPolicy: "IfNotPresent",
               args: ["/app/node_modules/pepr/dist/controller.js", hash],
-              startupProbe: {
-                httpGet: {
-                  path: "/healthz",
-                  port: 3000,
-                  scheme: "HTTPS",
-                },
-                initialDelaySeconds: 10,
-              },
-              readinessProbe: {
-                httpGet: {
-                  path: "/healthz",
-                  port: 3000,
-                  scheme: "HTTPS",
-                },
-                initialDelaySeconds: 10,
-              },
-              livenessProbe: {
-                httpGet: {
-                  path: "/healthz",
-                  port: 3000,
-                  scheme: "HTTPS",
-                },
-                initialDelaySeconds: 10,
-              },
+              startupProbe: defaultProbe(),
+              readinessProbe: defaultProbe(),
+              livenessProbe: defaultProbe(),
               ports: [
                 {
                   containerPort: 3000,

--- a/src/lib/assets/yaml/overridesFile.test.ts
+++ b/src/lib/assets/yaml/overridesFile.test.ts
@@ -29,6 +29,10 @@ interface TestSchemaProperty {
 interface Probe {
   httpGet: { path: string; port: number; scheme: string };
   initialDelaySeconds: number;
+  periodSeconds: number;
+  timeoutSeconds: number;
+  successThreshold: number;
+  failureThreshold: number;
 }
 
 vi.mock("fs", async () => {
@@ -150,6 +154,10 @@ describe("overridesFile", () => {
     const expectedProbe = {
       httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
       initialDelaySeconds: 10,
+      periodSeconds: 10,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+      failureThreshold: 3,
     };
     const expectedProbes = {
       startupProbe: expectedProbe,
@@ -158,6 +166,28 @@ describe("overridesFile", () => {
     };
     expect(parsedYaml.admission).toMatchObject(expectedProbes);
     expect(parsedYaml.watcher).toMatchObject(expectedProbes);
+
+    const schemaCall = calls.find(([path]) => path === mockPath.replace(/\.yaml$/, ".schema.json"));
+    expect(schemaCall).toBeDefined();
+    const probeSchema = (JSON.parse(schemaCall![1] as string) as JSONSchema7).definitions
+      ?.Probe as JSONSchema7;
+    expect(probeSchema.properties).toMatchObject({
+      initialDelaySeconds: { type: "integer" },
+      periodSeconds: { type: "integer" },
+      timeoutSeconds: { type: "integer" },
+      successThreshold: { type: "integer" },
+      failureThreshold: { type: "integer" },
+    });
+    expect(probeSchema.required).toEqual(
+      expect.arrayContaining([
+        "initialDelaySeconds",
+        "periodSeconds",
+        "timeoutSeconds",
+        "successThreshold",
+        "failureThreshold",
+      ]),
+    );
+
     expect(parsedYaml.secrets.apiPath).toBe(Buffer.from(mockOverrides.apiPath).toString("base64"));
     expect(parsedYaml.admission.annotations["pepr.dev/description"]).toBe(
       mockOverrides.config.description,

--- a/src/lib/assets/yaml/overridesFile.ts
+++ b/src/lib/assets/yaml/overridesFile.ts
@@ -27,19 +27,18 @@ export type ChartOverrides = {
   name: string;
   image: string;
 };
+type Probe = {
+  httpGet: { path: string; port: number; scheme: "HTTPS" };
+  initialDelaySeconds: number;
+  periodSeconds: number;
+  timeoutSeconds: number;
+  successThreshold: number;
+  failureThreshold: number;
+};
 type Probes = {
-  startupProbe: {
-    httpGet: { path: string; port: number; scheme: "HTTPS" };
-    initialDelaySeconds: number;
-  };
-  readinessProbe: {
-    httpGet: { path: string; port: number; scheme: "HTTPS" };
-    initialDelaySeconds: number;
-  };
-  livenessProbe: {
-    httpGet: { path: string; port: number; scheme: "HTTPS" };
-    initialDelaySeconds: number;
-  };
+  startupProbe: Probe;
+  readinessProbe: Probe;
+  livenessProbe: Probe;
 };
 type Resources = {
   requests: { memory: string; cpu: string };
@@ -207,18 +206,20 @@ function runIdsForImage(image: string): { uid: number; gid: number; fsGroup: num
 
 function commonProbes(): Probes {
   return {
-    startupProbe: {
-      httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
-      initialDelaySeconds: 10,
-    },
-    readinessProbe: {
-      httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
-      initialDelaySeconds: 10,
-    },
-    livenessProbe: {
-      httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
-      initialDelaySeconds: 10,
-    },
+    startupProbe: defaultProbe(),
+    readinessProbe: defaultProbe(),
+    livenessProbe: defaultProbe(),
+  };
+}
+
+function defaultProbe(): Probe {
+  return {
+    httpGet: { path: "/healthz", port: 3000, scheme: "HTTPS" },
+    initialDelaySeconds: 10,
+    periodSeconds: 10,
+    timeoutSeconds: 1,
+    successThreshold: 1,
+    failureThreshold: 3,
   };
 }
 


### PR DESCRIPTION
## Description

Expands the configurable startup, readiness, and liveness probe settings for admission and watcher deployments.

The generated Helm values and schema now expose:

- `initialDelaySeconds`
- `periodSeconds`
- `timeoutSeconds`
- `successThreshold`
- `failureThreshold`

The existing 10-second initial delay is preserved, while the remaining settings use Kubernetes defaults. The `/healthz` HTTP probe configuration remains unchanged.

Tests were updated to verify the defaults in generated Kubernetes objects.

End to End Test: N/A  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed