### PR TITLE
chore: exclude LLM-assistant config directories from project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ coverage/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# LLM-assistant configs
+.claude/
+.omc/
+.omx/
+
 # Kubernetes Generated files - skip generated files, except for vendored files
 
 !vendor/**/zz_generated.*


### PR DESCRIPTION
## Description

This PR excludes some LLM-assistant directories from the project git config.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
