### PR TITLE
chore(deps): group codeql dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,11 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action"
+          - "github/codeql-action/*"
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
## Description


This PR reduces maintenance burden by grouping updates that are often related to each other.

Adds a Dependabot github-actions group for the github/codeql-action family so updates for init, analyze, and upload-sarif are raised together instead of as separate noisy PRs.

This follows GitHub's Dependabot groups configuration for matching dependencies by patterns.

Validation:

ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml YAML OK"'
Commit hook ran prettier --write for .github/dependabot.yml during commit and reported the file unchanged.

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

See also https://github.com/defenseunicorns/kubernetes-fluent-client/pull/1244


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [ ] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
