### PR TITLE
chore: update broken doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ See the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/typescrip
 
 ## Community
 
-To join our channel go to [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community) and join the `#pepr` channel.
+To join our channel go to [Kubernetes Slack](https://inviter.co/kubernetes) and join the `#pepr` channel.
 
 [contributors]: https://contrib.rocks/image?repo=defenseunicorns/pepr
 [![Contributor Chart][contributors]](https://github.com/defenseunicorns/pepr/graphs/contributors)

--- a/docs/contribute/contributor-guide.md
+++ b/docs/contribute/contributor-guide.md
@@ -87,14 +87,14 @@ Please follow the coding conventions and style used in the project. Use ESLint a
 
 ### Grype Suppression Audit
 
-A weekly GitHub Actions workflow ([`grype-suppression-audit.yaml`](../../.github/workflows/grype-suppression-audit.yaml)) scans the Pepr controller image for stale CVE suppressions in `.grype.yaml`. When stale entries are found, the workflow removes them and opens (or updates) a PR on the bot-owned branch `grype/suppression-audit`.
+A weekly GitHub Actions workflow ([`grype-suppression-audit.yaml`](https://github.com/defenseunicorns/pepr/blob/main/.github/workflows/grype-suppression-audit.yaml)) scans the Pepr controller image for stale CVE suppressions in `.grype.yaml`. When stale entries are found, the workflow removes them and opens (or updates) a PR on the bot-owned branch `grype/suppression-audit`.
 
 - **Do not push manual commits to `grype/suppression-audit`** — the workflow force-pushes to this branch weekly and any manual changes will be overwritten.
 - To add context to a suppression entry (e.g. `reason:`), add it directly to `.grype.yaml` on `main`. The audit script skips multi-key entries and will not remove them automatically.
 
 ### Peer-Dependency Updates
 
-The `peerDependencies` block in `package.json` is maintained by the [`peer-deps-update`](../../.github/workflows/peer-deps-update.yml) GitHub Actions workflow. The workflow runs every Monday and opens PRs grouped by SemVer risk: a single PR for all minor/patch bumps and a separate PR per major-version bump (so that majors get isolated review and revert paths).
+The `peerDependencies` block in `package.json` is maintained by the [`peer-deps-update`](https://github.com/defenseunicorns/pepr/blob/main/.github/workflows/peer-deps-update.yml) GitHub Actions workflow. The workflow runs every Monday and opens PRs grouped by SemVer risk: a single PR for all minor/patch bumps and a separate PR per major-version bump (so that majors get isolated review and revert paths).
 
 - To trigger an off-cycle run, dispatch the workflow manually from the Actions tab.
 - To inspect the latest peer-dep candidates locally without opening a PR, run `node scripts/update-peer-deps.mjs report`.


### PR DESCRIPTION
## Description
Update Inviter link for K8s slack channel and GH workflow links.  Broken link for inviter redirects however, it is failing the link check tests in pepr-docs repo.
...

End to End Test:  <!-- if applicable -->  
(See [Pepr Excellent Examples](https://github.com/defenseunicorns/pepr-excellent-examples))

## Related Issue

Fixes Pepr-Docs CI ([example #305](https://github.com/defenseunicorns/pepr-docs/actions/runs/30683479664/attempts/1#summary-91324837841))
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging
- [x] Unit, Integration, [docs](https://github.com/defenseunicorns/pepr/tree/main/docs), [adr](https://github.com/defenseunicorns/pepr/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
