### PR TITLE
chore(deps): upgrade KFC to 3.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "globals": "17.11.0",
         "http-status-codes": "^2.3.0",
         "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "3.12.1",
+        "kubernetes-fluent-client": "3.12.2",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
         "prom-client": "15.1.3",
@@ -4816,9 +4816,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.12.1.tgz",
-      "integrity": "sha512-MgvaRlFoL3merE50NjRNuAN4CWMEZN3AFdZ1NHwbq52maccjNHeweCJyufjX4hYrVfli21oQ0S7tWK+DpASqog==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.12.2.tgz",
+      "integrity": "sha512-Yw2TljXbjgngsPgAX0bJwpCbROsKnkkMCsv1fufgbgSw83EO9pxDsYB8xT0TMWzSBJ9Ffz/Sb9AZnAZS98YLqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "globals": "17.11.0",
     "http-status-codes": "^2.3.0",
     "json-pointer": "^0.6.2",
-    "kubernetes-fluent-client": "3.12.1",
+    "kubernetes-fluent-client": "3.12.2",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",


### PR DESCRIPTION
## Summary

- upgrade `kubernetes-fluent-client` from 3.12.1 to 3.12.2
- refresh the npm lockfile resolution and integrity metadata

## Validation
- `npm ls kubernetes-fluent-client --depth=0` (3.12.2)
- `npm run format:src -- --quiet`
- `npx vitest run --config config/vitest.root.config.ts src/cli/kfc.test.ts src/lib/processors/watch-processor.test.ts` (39 passing)
- loaded legacy 3.12.2 release import paths from an isolated published tarball:
  - `kubernetes-fluent-client/dist`
  - `kubernetes-fluent-client/dist/fluent/index.js`
  - `kubernetes-fluent-client/dist/fluent/watch.js`
  - `kubernetes-fluent-client/dist/kinds.js`

`kubernetes-fluent-client/dist` emitted its expected deprecation warning and remained loadable.