### PR TITLE
fix(dependabot): use Chainguard pull-token credentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,6 +98,6 @@ registries:
   chainguard:
     type: "docker-registry"
     url: "cgr.dev"
-    username: "${{ secrets.CHAINGUARD_PEPR_USERNAME }}"
-    password: "${{ secrets.CHAINGUARD_PEPR_PASSWORD }}"
+    username: "${{ secrets.CHAINGUARD_IDENTITY }}"
+    password: "${{ secrets.CHAINGUARD_TOKEN }}"
     replaces-base: true


### PR DESCRIPTION
## Summary

- use `CHAINGUARD_IDENTITY` as the cgr.dev Docker registry username
- use `CHAINGUARD_TOKEN` as the corresponding Chainguard pull-token password
- remove Dependabot dependency on unavailable `CHAINGUARD_PEPR_*` secret names

## Validation

- parsed `.github/dependabot.yml` with the repository YAML parser
- `git diff --check`

## Follow-up

Create `CHAINGUARD_IDENTITY` and `CHAINGUARD_TOKEN` as Dependabot secrets. GitHub Actions secrets are not automatically exposed to Dependabot.