### PR TITLE
chore(ci): update variable name for CGR login

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,6 +98,6 @@ registries:
   chainguard:
     type: "docker-registry"
     url: "cgr.dev"
-    username: "${{ secrets.CHAINGUARD_IDENTITY }}"
+    username: "${{ secrets.CHAINGUARD_IDENTITY_ID }}"
     password: "${{ secrets.CHAINGUARD_TOKEN }}"
     replaces-base: true


### PR DESCRIPTION
## Description

The old variable name shadowed a higher-level OIDC variable that was incompatible with dependabot. This one will work when checking for newer images.