### PR TITLE
chore: clarify Docker Dependabot commit titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,7 +85,7 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: "deps"
+      prefix: "deps(docker)"
     registries:
       - chainguard
     groups:


### PR DESCRIPTION
## Summary
- label Docker Dependabot updates with the `deps(docker)` conventional-commit scope
- retain Dependabot's standard update detail and directory suffix

## Validation
- Parsed `.github/dependabot.yml` with Ruby YAML
- Ran `git diff --check`

Dependabot does not support customizing its generated `bump <dependency> in <directory>` message body; this PR improves the configurable prefix.